### PR TITLE
socket-utils: Ensure child processes are terminated upon socket close

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,7 +159,7 @@ AC_HEADER_TIME
 
 AC_CHECK_HEADERS([unistd.h errno.h stdbool.h], [], [AC_MSG_ERROR(["Missing a required header."])])
 
-AC_CHECK_HEADERS([sys/un.h sys/wait.h pty.h pwd.h execinfo.h asm/sigcontext.h])
+AC_CHECK_HEADERS([sys/un.h sys/wait.h pty.h pwd.h execinfo.h asm/sigcontext.h sys/prctl.h])
 
 AC_C_CONST
 AC_TYPE_SIZE_T

--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -232,6 +232,8 @@ SpinelNCPInstance::ncp_to_driver_pump()
 				mInboundFrameHDLCCRC = hdlc_crc16(mInboundFrameHDLCCRC, mInboundFrame[mInboundFrameSize-2]);
 			}
 
+			require(mInboundFrameSize >= sizeof(mInboundFrame), on_error);
+
 			mInboundFrame[mInboundFrameSize++] = byte;
 
 		} while(true);

--- a/src/util/SuperSocket.h
+++ b/src/util/SuperSocket.h
@@ -33,6 +33,8 @@ protected:
 	SuperSocket(const std::string& path);
 
 public:
+	virtual ~SuperSocket();
+
 	static boost::shared_ptr<SocketWrapper> create(const std::string& path);
 
 	virtual void reset();

--- a/src/util/socket-utils.h
+++ b/src/util/socket-utils.h
@@ -41,6 +41,7 @@ bool socket_name_is_inet(const char* socket_name);
 bool socket_name_is_device(const char* socket_name);
 int lookup_sockaddr_from_host_and_port( struct sockaddr_in6* outaddr, const char* host, const char* port);
 int open_serial_socket(const char* socket_name);
+int close_serial_socket(int fd);
 int fd_has_error(int fd);
 
 int fork_unixdomain_socket(int* fd_pointer);


### PR DESCRIPTION
Addresses issue #7.

Added some rudimentary PID to FD tracking so that when we close a file
descriptor opened by `open_serial_socket()`, the process behind that socket
(if any) is explicitly terminated.

This unfortunately requires us to add a new function called
`close_serial_socket()`, but in this particular case the change was not
onerous.

We are only handling five such sockets for now. If there are ever more than
that many system sockets opened through this mechanism, then something is
likely seriously wrong.

The socket tracking code is super simple and possibly not thread safe,
which is fine in this case since these methods will only ever be called
from the same thread.

I really wish these sorts of antics were not necessary, but all other
methods of handling this sort of thing seem to come up short.