### PR TITLE
wpantund: Show load average when main loop is thrashing.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ dnl This should only pick it up if necessary.
 AC_SEARCH_LIBS([clock_gettime], [rt])
 AC_CHECK_FUNCS([clock_gettime])
 
-AC_CHECK_FUNCS([alloca fgetln memcmp memset strtol strdup strndup strlcpy strlcat stpncpy vsnprintf vsprintf snprintf getdtablesize])
+AC_CHECK_FUNCS([alloca fgetln memcmp memset strtol strdup strndup strlcpy strlcat stpncpy vsnprintf vsprintf snprintf getdtablesize getloadavg])
 
 NL_DEBUG
 NL_CHECK_DBUS


### PR DESCRIPTION
The `wpantund` main loop detects cases of excessive thrashing
(which is almost always a bug) and prints out a log message
indicating that the thrashing is taking place. This change
also prints out the current load average on systems where it
is available.