### PR TITLE
NCPInstanceBase: Add return status to set_ncp_version_string()

### DIFF
--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -207,14 +207,17 @@ NCPInstanceBase::process_event_helper(int event)
 // ----------------------------------------------------------------------------
 // MARK: -
 
-void
+wpantund_status_t
 NCPInstanceBase::set_ncp_version_string(const std::string& version_string)
 {
+	wpantund_status_t status = kWPANTUNDStatus_Ok;
+
 	if (version_string != mNCPVersionString) {
 		if (!mNCPVersionString.empty()) {
 			// The previous version string isn't empty!
 			syslog(LOG_ERR, "Illegal NCP version change! (Previously \"%s\")", mNCPVersionString.c_str());
 			ncp_is_misbehaving();
+			status = kWPANTUNDStatus_InvalidArgument;
 		} else {
 			mNCPVersionString = version_string;
 
@@ -227,6 +230,7 @@ NCPInstanceBase::set_ncp_version_string(const std::string& version_string)
 			}
 		}
 	}
+	return status;
 }
 
 std::set<std::string>

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -212,7 +212,7 @@ public:
 	    const boost::any& value = boost::any()
 	);
 
-	void set_ncp_version_string(const std::string& version_string);
+	wpantund_status_t set_ncp_version_string(const std::string& version_string);
 
 protected:
 	// ========================================================================


### PR DESCRIPTION
This change adds a return value of type `wpantund_status_t` to `NCPInstanceBase::set_ncp_version_string()`. If the new version string does not match the previous value, the function will invoke `ncp_is_misbehaving()` to reinit the NCP and it will return `kWPANTUNDStatus_InvalidArgument`. Otherwise a success status of `kWPANTUNDStatus_Ok` is returned.