### PR TITLE
Fix xpanid set/get methods on big endian systems

### DIFF
--- a/src/wpantund/NetworkInstance.h
+++ b/src/wpantund/NetworkInstance.h
@@ -38,13 +38,15 @@ struct NetworkId {
 	get_xpanid_as_uint64() const
 	{
 		union {
-			uint64_t ret;
+			uint64_t val;
 			uint8_t data[8];
-		};
+		} x;
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-		memcpyrev(data, xpanid, 8);
+		memcpyrev(x.data, xpanid, 8);
+#else
+		memcpy(x.data, xpanid, 8);
 #endif
-		return ret;
+		return x.val;
 	}
 
 	void
@@ -57,6 +59,8 @@ struct NetworkId {
 		x.val = _xpanid;
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 		memcpyrev(xpanid, x.data, 8);
+#else
+		memcpy(xpanid, x.data, 8);
 #endif
 	}
 


### PR DESCRIPTION
Missing code for big endian systems.

As a side remark, it is sometimes unclear where should little/big/host values be used. I think it would be better (more compact and clearer to the reader) to use htole/htobe functions in the future, rather than the custom memcpy based on a define. Also we should check, maybe even add a test, to check spinel compatibility when different endianess architectures are communicating.