### PR TITLE
ncp-spinel: Add support for Spinel counters.

### DIFF
--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -239,6 +239,8 @@ enum
     SPINEL_CAP_HBO                   = 3,
     SPINEL_CAP_POWER_SAVE            = 4,
 
+    SPINEL_CAP_COUNTERS              = 5,
+
     SPINEL_CAP_802_15_4__BEGIN        = 16,
     SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
     SPINEL_CAP_802_15_4_2006          = (SPINEL_CAP_802_15_4__BEGIN + 1),
@@ -329,9 +331,9 @@ typedef enum
     SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
     SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< [A(T(ES))]
     SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
-    SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [6]
+    SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
-                                       = SPINEL_PROP_THREAD__BEGIN + 5, ///< [6]
+                                       = SPINEL_PROP_THREAD__BEGIN + 5, ///< [C]
     SPINEL_PROP_THREAD_NETWORK_DATA    = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
     SPINEL_PROP_THREAD_NETWORK_DATA_VERSION
                                        = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
@@ -348,8 +350,8 @@ typedef enum
     SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
     SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
     SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
-    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,flags) [A(T(6CL))]
-    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCL))]
+    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(T(6CLLC))]
+    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCC))]
     SPINEL_PROP_IPV6__END            = 0x70,
 
     SPINEL_PROP_STREAM__BEGIN       = 0x70,
@@ -358,6 +360,43 @@ typedef enum
     SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
     SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
     SPINEL_PROP_STREAM__END         = 0x80,
+
+    /// UART Bitrate
+    /** Format: `L`
+     *
+     *  If the NCP is using a UART to communicate with the host,
+     *  this property allows the host to change the bitrate
+     *  of the serial connection. The value encoding is `L`,
+     *  which is a little-endian 32-bit unsigned integer.
+     *  The host should not assume that all possible numeric values
+     *  are supported.
+     *
+     *  If implemented by the NCP, this property should be persistent
+     *  across software resets and forgotten upon hardware resets.
+     *
+     *  This property is only implemented when a UART is being
+     *  used for Spinel. This property is optional.
+     *
+     *  When changing the bitrate, all frames will be received
+     *  at the previous bitrate until the response frame to this command
+     *  is received. Once a successful response frame is received by
+     *  the host, all further frames will be transmitted at the new
+     *  bitrate.
+     */
+    SPINEL_PROP_UART_BITRATE    = 0x100,
+
+    /// UART Software Flow Control
+    /** Format: `b`
+     *
+     *  If the NCP is using a UART to communicate with the host,
+     *  this property allows the host to determine if software flow
+     *  control (XON/XOFF style) should be used and (optionally) to
+     *  turn it on or off.
+     *
+     *  This property is only implemented when a UART is being
+     *  used for Spinel. This property is optional.
+     */
+    SPINEL_PROP_UART_XON_XOFF   = 0x101,
 
     SPINEL_PROP_15_4_PIB__BEGIN     = 1024,
     // For direct access to the 802.15.4 PID.
@@ -372,6 +411,117 @@ typedef enum
     SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
     SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED   = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
     SPINEL_PROP_15_4_PIB__END       = 1280,
+
+    SPINEL_PROP_CNTR__BEGIN        = 1280,
+
+    /// Counter reset behavior
+    /** Format: `C`
+     *  Writing a '1' to this property will reset
+     *  all of the counters to zero. */
+    SPINEL_PROP_CNTR_RESET             = SPINEL_PROP_CNTR__BEGIN + 0,
+
+    /// The total number of transmissions.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 1,
+
+    /// The number of transmissions with ack request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ    = SPINEL_PROP_CNTR__BEGIN + 2,
+
+    /// The number of transmissions that were acked.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_ACKED      = SPINEL_PROP_CNTR__BEGIN + 3,
+
+    /// The number of transmissions without ack request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ = SPINEL_PROP_CNTR__BEGIN + 4,
+
+    /// The number of transmitted data.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 5,
+
+    /// The number of transmitted data poll.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 6,
+
+    /// The number of transmitted beacon.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 7,
+
+    /// The number of transmitted beacon request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 8,
+
+    /// The number of transmitted other types of frames.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 9,
+
+    /// The number of retransmission times.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_PKT_RETRY      = SPINEL_PROP_CNTR__BEGIN + 10,
+
+    /// The number of CCA failure times.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_TX_ERR_CCA        = SPINEL_PROP_CNTR__BEGIN + 11,
+
+    /// The total number of received packets.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_TOTAL      = SPINEL_PROP_CNTR__BEGIN + 100,
+
+    /// The number of received data.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_DATA       = SPINEL_PROP_CNTR__BEGIN + 101,
+
+    /// The number of received data poll.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL  = SPINEL_PROP_CNTR__BEGIN + 102,
+
+    /// The number of received beacon.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_BEACON     = SPINEL_PROP_CNTR__BEGIN + 103,
+
+    /// The number of received beacon request.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 104,
+
+    /// The number of received other types of frames.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_OTHER      = SPINEL_PROP_CNTR__BEGIN + 105,
+
+    /// The number of received packets filtered by whitelist.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_FILT_WL    = SPINEL_PROP_CNTR__BEGIN + 106,
+
+    /// The number of received packets filtered by destination check.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_PKT_FILT_DA    = SPINEL_PROP_CNTR__BEGIN + 107,
+
+    /// The number of received packets that are empty.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_EMPTY      = SPINEL_PROP_CNTR__BEGIN + 108,
+
+    /// The number of received packets from an unknown neighbor.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR   = SPINEL_PROP_CNTR__BEGIN + 109,
+
+    /// The number of received packets whose source address is invalid.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR = SPINEL_PROP_CNTR__BEGIN + 110,
+
+    /// The number of received packets with a security error.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_SECURITY   = SPINEL_PROP_CNTR__BEGIN + 111,
+
+    /// The number of received packets with a checksum error.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS    = SPINEL_PROP_CNTR__BEGIN + 112,
+
+    /// The number of received packets with other errors.
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113,
+
+    SPINEL_PROP_CNTR__END       = 2048,
+
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
     SPINEL_PROP_NEST__END           = 15360,


### PR DESCRIPTION
This commit adds support for Spinel counters, which are being tracked on the OpenThread project by issue [openthread/openthread/199][1].

[1]: https://github.com/openthread/openthread/issues/199