### PR TITLE
NCPInstanceBase: Detect and report invalid state transitions

### DIFF
--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -103,6 +103,8 @@ public:
 
 	NCPState get_ncp_state()const;
 
+	bool is_state_change_valid(NCPState new_ncp_state)const;
+
 	//! Handles transitioning from state-to-state.
 	/*! This is the ONLY WAY to change mNCPState. */
 	void change_ncp_state(NCPState new_ncp_state);


### PR DESCRIPTION
This change was deemed necessary because we saw a case where a
device entered the `OFFLINE` state from the `UPGRADING` state, 
which caused all sorts of havoc.

This change adds some additional checks when a state transition
is triggered so that we detect and report invalid state transitions.
In some cases, invalid state transitions are actually outright
prevented, such as transitioning directly from a detached state
(like `FAULT` or `UPGRADING`) to any state other than `UNINITIALIZED`.

All invalid state transitions are clearly indicated to be bugs
in the logs.