### PR TITLE
Adding support for `energy scan` to core wpantund and wpanctl.

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -30,6 +30,7 @@
 #include <boost/function.hpp>
 
 #include "NetworkInstance.h"
+#include "NCPTypes.h"
 #include "Data.h"
 #include "time-utils.h"
 
@@ -69,12 +70,16 @@ private:
 	void CallbackWithStatusArg1_Helper(int ret, const boost::any& value, DBusMessage *original_message);
 
 	void status_response_helper(int ret, NCPControlInterface* interface, DBusMessage *original_message);
-	void scan_response_helper(int ret, DBusMessage *original_message);
+
+	// TODO: Remove these...
+	//void scan_response_helper(int ret, DBusMessage *original_message);
+	//void energy_scan_response_helper(int ret, DBusMessage *original_message);
 
 	// ------------------------------------------------------------------------
 
 	void property_changed(NCPControlInterface* interface,const std::string& key, const boost::any& value);
 	void received_beacon(NCPControlInterface* interface, const WPAN::NetworkInstance& network);
+	void received_energy_scan_result(NCPControlInterface* interface, const EnergyScanResultEntry& energy_scan_result);
 
 	// ------------------------------------------------------------------------
 
@@ -147,6 +152,16 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_energy_scan_start_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_energy_scan_stop_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 	DBusHandlerResult interface_data_poll_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message
@@ -165,7 +180,6 @@ private:
 
 	DBusConnection *mConnection;
 	std::map<std::string, boost::function<interface_handler_cb> > mInterfaceCallbackTable;
-
 }; // class DBusIPCAPI_v1
 
 }; // namespace nl

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -65,6 +65,10 @@
 #define WPANTUND_IF_CMD_NET_SCAN_STOP         "NetScanStop"
 #define WPANTUND_IF_SIGNAL_NET_SCAN_BEACON    "NetScanBeacon"
 
+#define WPANTUND_IF_CMD_ENERGY_SCAN_START     "EnergyScanStart"
+#define WPANTUND_IF_CMD_ENERGY_SCAN_STOP      "EnergyScanStop"
+#define WPANTUND_IF_SIGNAL_ENERGY_SCAN_RESULT "EnergyScanResult"
+
 #define WPANTUND_IF_CMD_PROP_GET              "PropGet"
 #define WPANTUND_IF_CMD_PROP_SET              "PropSet"
 #define WPANTUND_IF_SIGNAL_PROP_CHANGED       "PropChanged"

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -176,6 +176,20 @@ DummyNCPControlInterface::netscan_stop(CallbackWithStatus cb)
 	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Start network scan
 }
 
+void
+DummyNCPControlInterface::energyscan_start(
+    const ValueMap& options,
+    CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
+void
+DummyNCPControlInterface::energyscan_stop(CallbackWithStatus cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
 std::string
 DummyNCPControlInterface::get_name() {
 	return mNCPInstance->get_name();

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -62,6 +62,9 @@ public:
 	virtual void netscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
 	virtual void netscan_stop(CallbackWithStatus cb = NilReturn());
 
+	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
+	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn());
+
 	virtual void begin_net_wake(uint8_t data, uint32_t flags, CallbackWithStatus cb = NilReturn());
 	virtual void reset(CallbackWithStatus cb = NilReturn());
 	virtual void permit_join(

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -402,6 +402,20 @@ SpinelNCPControlInterface::netscan_stop(CallbackWithStatus cb)
 	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Start network scan
 }
 
+void
+SpinelNCPControlInterface::energyscan_start(
+    const ValueMap& options,
+    CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
+void
+SpinelNCPControlInterface::energyscan_stop(CallbackWithStatus cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
 std::string
 SpinelNCPControlInterface::get_name() {
 	return mNCPInstance->get_name();

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -62,6 +62,9 @@ public:
 	virtual void netscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
 	virtual void netscan_stop(CallbackWithStatus cb = NilReturn());
 
+	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
+	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn());
+
 	virtual void begin_net_wake(uint8_t data, uint32_t flags, CallbackWithStatus cb = NilReturn());
 	virtual void reset(CallbackWithStatus cb = NilReturn());
 	virtual void permit_join(

--- a/src/wpanctl/wpanctl-utils.h
+++ b/src/wpanctl/wpanctl-utils.h
@@ -71,6 +71,7 @@ struct wpan_network_info_s {
 const char* wpantund_status_to_cstr(int status);
 void print_error_diagnosis(int error);
 int parse_network_info_from_iter(struct wpan_network_info_s *network_info, DBusMessageIter *iter);
+int parse_energy_scan_result_from_iter(int16_t *channel, int8_t *maxRssi, DBusMessageIter *iter);
 int lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name);
 void dump_info_from_iter(FILE* file, DBusMessageIter *iter, int indent, bool bare, bool indentFirstLine);
 uint16_t node_type_str2int(const char *node_type);

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -38,6 +38,7 @@
 #include "time-utils.h"
 
 #include "NetworkInstance.h"
+#include "NCPTypes.h"
 #include <cstring>
 #include "IPv6PacketMatcher.h"
 #include "Data.h"
@@ -150,6 +151,15 @@ public:
 
 	boost::signals2::signal<void(const WPAN::NetworkInstance&)> mOnNetScanBeacon;
 
+public:
+	// ========================================================================
+	// EnergyScan-related Member Functions
+
+	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn()) = 0;
+
+	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn()) = 0;
+
+	boost::signals2::signal<void(const EnergyScanResultEntry&)> mOnEnergyScanResult;
 
 public:
 	// ========================================================================

--- a/src/wpantund/NCPTypes.h
+++ b/src/wpantund/NCPTypes.h
@@ -74,6 +74,13 @@ struct GlobalAddressEntry {
 	std::string get_description() const;
 };
 
+struct EnergyScanResultEntry
+{
+	uint8_t mChannel;
+	int8_t 	mMaxRssi;
+};
+
+
 std::string address_flags_to_string(uint8_t flags);
 
 bool ncp_state_is_sleeping(NCPState x);


### PR DESCRIPTION
This commit makes the following changes:

- New methods are introduced in `NCPControlInterface` class for
  starting or stopping energy scan.

- It adds new dbus APIs for requesting energy scan and signaling
  the scan results (DBus APIs v1).

- The wpanctl scan command is modified to enable both network
  scan and energy scan, and to be able to parse and output the
  energy scan results.

This commit does not add the implementation of energy scan for
Spinel plugin.