### PR TITLE
SpinelNCPControlInterface: Fix config_gateway, add/remove external route

### DIFF
--- a/src/ncp-spinel/Makefile.am
+++ b/src/ncp-spinel/Makefile.am
@@ -55,6 +55,8 @@ NCP_SOURCES = \
 	SpinelNCPInstance-Protothreads.cpp \
 	SpinelNCPTask.cpp \
 	SpinelNCPTask.h \
+	SpinelNCPTaskChangeNetData.cpp \
+	SpinelNCPTaskChangeNetData.h \
 	SpinelNCPTaskDeepSleep.cpp \
 	SpinelNCPTaskDeepSleep.h \
 	SpinelNCPTaskForm.cpp \

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -50,6 +50,7 @@
 #include "SpinelNCPTaskForm.h"
 #include "SpinelNCPTaskLeave.h"
 #include "SpinelNCPTaskScan.h"
+#include "SpinelNCPTaskChangeNetData.h"
 #include "SpinelNCPTaskSendCommand.h"
 
 using namespace nl;
@@ -209,7 +210,7 @@ SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefi
 
 	if (validLifetime == 0) {
 		mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
-			new SpinelNCPTaskSendCommand(
+			new SpinelNCPTaskChangeNetData(
 				mNCPInstance,
 				boost::bind(cb,_1),
 				SpinelPackData(
@@ -229,7 +230,7 @@ SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefi
 		));
 	} else {
 		mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
-			new SpinelNCPTaskSendCommand(
+			new SpinelNCPTaskChangeNetData(
 				mNCPInstance,
 				boost::bind(cb,_1),
 				SpinelPackData(
@@ -275,7 +276,7 @@ SpinelNCPControlInterface::add_external_route(const uint8_t *route, int route_pr
 	memcpy(addr.s6_addr, route, route_prefix_len);
 
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
-		new SpinelNCPTaskSendCommand(
+		new SpinelNCPTaskChangeNetData(
 			mNCPInstance,
 			boost::bind(cb,_1),
 			SpinelPackData(
@@ -308,7 +309,7 @@ SpinelNCPControlInterface::remove_external_route(const uint8_t *route, int route
 	memcpy(addr.s6_addr, route, route_prefix_len);
 
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
-		new SpinelNCPTaskSendCommand(
+		new SpinelNCPTaskChangeNetData(
 			mNCPInstance,
 			boost::bind(cb,_1),
 			SpinelPackData(

--- a/src/ncp-spinel/SpinelNCPTaskChangeNetData.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskChangeNetData.cpp
@@ -1,0 +1,115 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+#include <syslog.h>
+#include <errno.h>
+#include "SpinelNCPTaskChangeNetData.h"
+#include "SpinelNCPInstance.h"
+#include "spinel-extra.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+nl::wpantund::SpinelNCPTaskChangeNetData::SpinelNCPTaskChangeNetData(
+	SpinelNCPInstance* instance,
+	CallbackWithStatusArg1 cb,
+	const Data& change_net_data_command,
+	int timeout
+):	SpinelNCPTask(instance, cb), mChangeNetDataCommand(change_net_data_command)
+{
+	mNextCommandTimeout = timeout;
+	mRetVal = kWPANTUNDStatus_Failure;
+}
+
+int
+nl::wpantund::SpinelNCPTaskChangeNetData::vprocess_event(int event, va_list args)
+{
+	EH_BEGIN();
+
+	mRetVal = kWPANTUNDStatus_Failure;
+
+	// The first event to a task is EVENT_STARTING_TASK. The following
+	// line makes sure that we don't start processing this task
+	// until it is properly scheduled. All tasks immediately receive
+	// the initial `EVENT_STARTING_TASK` event, but further events
+	// will only be received by that task once it is that task's turn
+	// to execute.
+	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,
+		true
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	mRetVal = mNextCommandRet;
+
+	// In case of BUSY error status (meaning the `ALLOW_LOCAL_NET_DATA_CHANGE`
+	// was already true), allow the operation to proceed.
+
+	require((mRetVal == SPINEL_STATUS_OK) || (mRetVal == SPINEL_STATUS_BUSY), on_error);
+
+	mNextCommand = mChangeNetDataCommand;
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	mRetVal = mNextCommandRet;
+
+	// Even in case of failure we proceed to set ALLOW_LOCAL_NET_DATA_CHANGE
+	// to `false`. The error status is checked after this. It is stored in
+	// a class instance variable `mRetVal` so that the value is preserved
+	// over the protothread EH_SPAWN() call.
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE,
+		false
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	require_noerr(mRetVal, on_error);
+
+	mRetVal = mNextCommandRet;
+
+	require_noerr(mRetVal, on_error);
+
+	finish(mRetVal);
+
+	EH_EXIT();
+
+on_error:
+
+	if (mRetVal == kWPANTUNDStatus_Ok) {
+		mRetVal = kWPANTUNDStatus_Failure;
+	}
+
+	syslog(LOG_ERR, "Change local network data failed: %d", mRetVal);
+
+	finish(mRetVal);
+
+	EH_END();
+}

--- a/src/ncp-spinel/SpinelNCPTaskChangeNetData.h
+++ b/src/ncp-spinel/SpinelNCPTaskChangeNetData.h
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __wpantund__SpinelNCPTaskChangeNetData__
+#define __wpantund__SpinelNCPTaskChangeNetData__
+
+#include "SpinelNCPTask.h"
+#include "SpinelNCPInstance.h"
+#include "ValueMap.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+namespace nl {
+namespace wpantund {
+
+class SpinelNCPTaskChangeNetData : public SpinelNCPTask
+{
+public:
+	SpinelNCPTaskChangeNetData(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		const Data& change_net_data_command,
+		int timeout = NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT
+	);
+
+	virtual int vprocess_event(int event, va_list args);
+
+private:
+	Data mChangeNetDataCommand;
+	int mRetVal;
+};
+
+}; // namespace wpantund
+}; // namespace nl
+
+
+#endif /* defined(__wpantund__SpinelNCPTaskChangeNetData__) */

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1088,6 +1088,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_ASSISTING_PORTS";
         break;
 
+    case SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE:
+        ret = "SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
+        break;
+
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -344,6 +344,8 @@ typedef enum
     SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
     SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
     SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
+    SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
+                                       = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
     SPINEL_PROP_THREAD__END            = 0x60,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
This commit changes how the `config_gateway`, `add/remove_external_route` are implemented in `SpinelNCPControlInterface` (spinel plugin). It ensures that after an update to any local network data (mesh prefixes or external routes), the new data is registered with the leader. This is done by adding a new Spinel property `THREAD_ALLOW_LOCAL_NET_DATA_CHANGE` with boolean type. This property is set to 'true' before modifying any properties related to local network data. When done, this property is set to 'false' causing the network data to be registered with leader. This commit also adds a new SpinelNCPTask, namely `SpinelNCPTaskChangeNetData` which implements the common logic for changing any net data property.

This commit is related to openthread issue #272.