### PR TITLE
wpan-connman-plugin: Remove scanned networks upon a successful connect

### DIFF
--- a/src/connman-plugin/wpan-connman-plugin.c
+++ b/src/connman-plugin/wpan-connman-plugin.c
@@ -664,6 +664,52 @@ lowpan_network_remove(struct connman_network *network)
 }
 
 static void
+lowpan_remove_all_disconnected_networks(struct connman_device *device)
+{
+	struct lowpan_device_s *device_info =
+	    (struct lowpan_device_s *)connman_device_get_data(device);
+
+	DBG("%p", device);
+
+	// This function removes all the disconnected networks from the lowpan device.
+	// This is achieved with a simple but effective trick using how scan operation
+	// is implemented in Connman.
+	//
+	// When `scanning` is set to `true` on a Connman device, Connman will mark all
+	// the current networks associated with the device as 'unavailable'. When the
+	// scan finishes and plugin goes through the scan result, it should add any new
+	// networks from scan results. For existing networks, it marks them as 'available'
+	// (using `connman_network_set_available(network)`). At the end, when `scanning`
+	// is set to 'false', Connman will remove all networks which are still marked as
+	// unavailable.
+	//
+	// To remove all disconnected networks, we simply set_scanning(TRUE) followed
+	// by set_scanning(FALSE).
+
+	if (connman_device_get_scanning(device) == TRUE) {
+		goto bail;
+	}
+
+	if (device_info->ncp_state == NCP_STATE_ASSOCIATING) {
+		goto bail;
+	}
+
+	if (device_info->ncp_state == NCP_STATE_COMMISSIONED) {
+		goto bail;
+	}
+
+	if (ncp_state_is_initializing(device_info->ncp_state)) {
+		goto bail;
+	}
+
+	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_LOWPAN, TRUE);
+	connman_device_set_scanning(device, CONNMAN_SERVICE_TYPE_LOWPAN, FALSE);
+
+bail:
+	return;
+}
+
+static void
 join_finished_callback(
     DBusPendingCall *pending, void* user_data
     )
@@ -1628,7 +1674,6 @@ lowpan_device_handle_state_change(
 						// This should happen in a few moments, initiated
 						// by the call to lowpan_network_update_key_from_ncp, above.
 					}
-					return 0;
 				} else {
 					DBG("Marking Network as connected.");
 					connman_network_set_connected(network, TRUE);
@@ -1636,6 +1681,8 @@ lowpan_device_handle_state_change(
 			} else {
 				DBG("Service/Network already connected.");
 			}
+
+			lowpan_remove_all_disconnected_networks(device);
 		}
 	}
 


### PR DESCRIPTION
This commit changes the wpan-connman plugin so that when NCP state changes to `associated` state, plugin removes all the other networks (services) from the lowpan device.