### PR TITLE
wpan-connman-plugin: Ensure that network info is retained in case of Connman untimely restart 

### DIFF
--- a/src/connman-plugin/wpan-connman-plugin.c
+++ b/src/connman-plugin/wpan-connman-plugin.c
@@ -1136,10 +1136,37 @@ lowpan_device_leave(struct connman_device *device)
 		dbus_message_unref(message);
 }
 
+static void
+lowpan_device_reset(struct connman_device *device)
+{
+	DBusMessage *message = NULL;
+	char dbus_path[DBUS_MAXIMUM_NAME_LENGTH];
+
+	snprintf(dbus_path,
+	         sizeof(dbus_path),
+	         "%s/%s",
+	         WPAN_TUNNEL_DBUS_PATH,
+	         connman_device_get_ident(device));
+
+	message = dbus_message_new_method_call(
+	    WPAN_TUNNEL_DBUS_NAME,
+	    dbus_path,
+	    WPAN_TUNNEL_DBUS_INTERFACE,
+	    WPAN_IFACE_CMD_RESET
+	    );
+
+	dbus_connection_send(connection, message, NULL);
+
+	if(message)
+		dbus_message_unref(message);
+}
+
+
 static int
 lowpan_network_disconnect(struct connman_network *network, bool user_initiated)
 {
 	int ret = -EINVAL;
+	bool should_reset = false;
 	struct connman_device* device = connman_network_get_device(network);
 	struct lowpan_device_s *device_info =
 	    (struct lowpan_device_s *)connman_device_get_data(device);
@@ -1166,6 +1193,9 @@ lowpan_network_disconnect(struct connman_network *network, bool user_initiated)
 	switch(device_info->ncp_state) {
 	case NCP_STATE_ASSOCIATING:
 	case NCP_STATE_CREDENTIALS_NEEDED:
+		should_reset = true;
+		break;
+
 	case NCP_STATE_OFFLINE:
 		user_initiated = TRUE;
 		break;
@@ -1175,6 +1205,8 @@ lowpan_network_disconnect(struct connman_network *network, bool user_initiated)
 
 	if (user_initiated) {
 		lowpan_device_leave(device);
+	} else if (should_reset) {
+		lowpan_device_reset(device);
 	}
 
 	ret = 0;


### PR DESCRIPTION
This commit changes how the disconnect is handled in the wpan-connman-plugin. If a disconnect command/call is received and if this is not user initiated, the current NCP state is checked:
If it is in `ASSOCIATING` or `NCP_STATE_CREDENTIALS_NEEDED` states, instead of issuing a `Leave` command to wpantund, we `Reset` the NCP. This ensures that ongoing association process is stopped, but will not remove/erase any retained NCP network info.

