### PR TITLE
ncp_spinel: Miscellaneous minor bug fixes

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -121,6 +121,9 @@ SpinelNCPControlInterface::attach(CallbackWithStatus cb)
 void
 SpinelNCPControlInterface::reset(CallbackWithStatus cb)
 {
+	if (mNCPInstance->get_ncp_state() == FAULT) {
+		mNCPInstance->change_ncp_state(UNINITIALIZED);
+	}
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
 		new SpinelNCPTaskSendCommand(
 			mNCPInstance,

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -403,7 +403,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 				status = peek_ncp_callback_status(event, args);
 
 				if (status != 0) {
-					syslog(LOG_WARNING, "Error fetching property %d from NCP: %d", keys_to_fetch[mSubPTIndex], status);
+					syslog(LOG_WARNING, "Unsuccessful fetching property \"%s\" from NCP: \"%s\" (%d)", spinel_prop_key_to_cstr(keys_to_fetch[mSubPTIndex]), spinel_status_to_cstr(static_cast<spinel_status_t>(status)), status);
 				}
 			}
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -460,7 +460,7 @@ SpinelNCPInstance::get_property(
 					cb,
 					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, cntr_key),
 					NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-					SPINEL_DATATYPE_UINT8_S
+					SPINEL_DATATYPE_UINT32_S
 				)
 			));
 		} else {


### PR DESCRIPTION
### ncp_spinel: Fetch counters as 32-bit integers, not 8-bit integers.

This commit fixes a copy-paste bug that accidentally fetched
counter values as 8-bit values, when they are actually 32-bit values.
This caused only the least-significant portion of the counter
to be returned.

### ncp_spinel: Tone down the wording on a common error message.

At initialization, we have a list of properties we want to
try and fetch so that we can make sure that the state in
`wpantund` matches that of the NCP. However, not all of these
properties might be implemented, which is OK. In such a case
we log a warning and continue.

The wording of this error message has caused some concern, so
I've reworded the error message and also change the warning
to also lookup the textual representation of both the property
and the error, so that it is clear what exactly happened.

### ncp_spinel: Fault state should be recoverable by reset

It was noticed that when wpantund entered the `uninitialized:fault`
state that the `Reset` command didn't coax it back into the
`uninitialized` state. This change addresses this.
