### PR TITLE
ncp_spinel: Log data from PROP_STREAM_DEBUG to SysLog

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -820,6 +820,34 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			signal_property_changed(kWPANTUNDProperty_NCPTXPower, mTXPower);
 		}
 
+	} else if (key == SPINEL_PROP_STREAM_DEBUG) {
+		static char linebuffer[NCP_DEBUG_LINE_LENGTH_MAX + 1];
+		static int linepos = 0;
+		while (value_data_len--) {
+			char nextchar = *value_data_ptr++;
+
+			if (nextchar == 0) {
+				nextchar = '#';
+			}
+
+			if ((nextchar != '\n') && (nextchar != '\r')) {
+				linebuffer[linepos++] = nextchar;
+			}
+
+			if ( (linepos != 0)
+			  && ( (nextchar == '\n')
+			    || (nextchar == '\r')
+			    || (linepos >= (sizeof(linebuffer) - 1))
+			  )
+			)
+			{
+				// flush.
+				linebuffer[linepos] = 0;
+				syslog(LOG_INFO, "NCP => %s\n", linebuffer);
+				linepos = 0;
+			}
+		}
+
 	} else if (key == SPINEL_PROP_NET_ROLE) {
 		uint8_t value;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_UINT8_S, &value);

--- a/src/wpantund/NCPConstants.h
+++ b/src/wpantund/NCPConstants.h
@@ -30,4 +30,6 @@
 #define BUSY_DEBOUNCE_TIME_IN_MS         200
 #define MAX_INSOMNIA_TIME_IN_MS                 (MSEC_PER_SEC * 60 * 3)
 
+#define NCP_DEBUG_LINE_LENGTH_MAX		400
+
 #endif


### PR DESCRIPTION
Instead of writing log messages directly to the serial port, Spinel
has the capability to allow the NCP to write its log messages directly
to the host in-band via the Spinel stream property
`PROP_STREAM_DEBUG`.

This change makes sure that any log messages written to
`PROP_STREAM_DEBUG` get written to the `wpantund` logs.