### PR TITLE
ncp_spinel: Fix for setting non-config properties in configuration file

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -236,7 +236,7 @@ SpinelNCPInstance::vprocess_offline(int event, va_list args)
 int
 SpinelNCPInstance::vprocess_init(int event, va_list args)
 {
-	int status;
+	int status = 0;
 
 	if (event == EVENT_NCP_RESET) {
 		if (mDriverState == INITIALIZING) {
@@ -309,7 +309,10 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 			EH_EXIT();
 		}
 
-		if (mAutoUpdateFirmware && (mFailureCount > (mFailureThreshold - 1)) && can_upgrade_firmware()) {
+		if ( mAutoUpdateFirmware
+		  && (mFailureCount > (mFailureThreshold - 1))
+		  && can_upgrade_firmware()
+		) {
 			syslog(LOG_ALERT, "The NCP is misbehaving: Attempting a firmware update");
 			upgrade_firmware();
 			EH_RESTART();
@@ -420,7 +423,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 
 on_error:
 		if (status) {
-			syslog(LOG_ERR, "Error from NCP: %d", status);
+			syslog(LOG_ERR, "Initialization error: %d", status);
 		}
 		EH_SLEEP_FOR(0.5);
 		mFailureCount++;

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -273,6 +273,8 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 
 	syslog(LOG_INFO, "Initializing NCP");
 
+	set_initializing_ncp(true);
+
 	change_ncp_state(UNINITIALIZED);
 
 	set_ncp_power(true);
@@ -431,6 +433,7 @@ on_error:
 
 	mFailureCount = 0;
 	mResetIsExpected = false;
+	set_initializing_ncp(false);
 	mDriverState = NORMAL_OPERATION;
 
 	syslog(LOG_NOTICE, "Finished initializing NCP");

--- a/src/util/sec-random.c
+++ b/src/util/sec-random.c
@@ -32,7 +32,13 @@ int
 sec_random_init(void)
 {
 	if (gSecRandomFile == NULL) {
-		gSecRandomFile = fopen("/dev/random", "r");
+		const char* random_source_filename = getenv("SEC_RANDOM_SOURCE_FILE");
+
+		if (!random_source_filename) {
+			random_source_filename = "/dev/urandom";
+		}
+
+		gSecRandomFile = fopen(random_source_filename, "r");
 
 		if (gSecRandomFile == NULL) {
 			return -1;

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -99,6 +99,9 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 
 			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareUpgradeCommand)) {
 				mFirmwareUpgrade.set_firmware_upgrade_command(iter->second);
+
+			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_DaemonAutoFirmwareUpdate)) {
+				mAutoUpdateFirmware = any_to_bool(boost::any(iter->second));
 			}
 		}
 	}
@@ -173,6 +176,7 @@ NCPInstanceBase::setup_property_supported_by_class(const std::string& prop_name)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigTUNInterfaceName)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPDriverName)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareCheckCommand)
+		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_DaemonAutoFirmwareUpdate)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareUpgradeCommand);
 }
 

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -113,6 +113,10 @@ public:
 
 	virtual void ncp_is_misbehaving();
 
+	virtual void set_initializing_ncp(bool x);
+
+	virtual bool is_initializing_ncp()const;
+
 public:
 	// ========================================================================
 	// MARK: Network Interface Methods
@@ -247,6 +251,7 @@ protected:
 
 private:
 	NCPState mNCPState;
+	bool mIsInitializingNCP;
 
 protected:
 	uint8_t mNCPHardwareAddress[8];


### PR DESCRIPTION
Forgot to set up some code for getting all of the non-config
settings working properly, like `Daemon:AutoFirmwareUpdate`.