### PR TITLE
Adding NetworkRetain class and wpanretain script

### DIFF
--- a/src/scripts/wpanretain.sh
+++ b/src/scripts/wpanretain.sh
@@ -1,0 +1,346 @@
+#
+# Copyright (c) 2016 Nest Labs, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+function display_usage()
+{
+	echo "Thread Network Retain - Save/Recall thread network info"
+	echo ""
+	echo "Usage: $(basename $0) [primary-net-info-file] [secondary-net-info-file] [wpanctl path] [command]"
+	echo ""
+	echo "    Command:"
+	echo "        'S' or 'save'   : Save current network info."
+	echo "        'R' or 'recall' : Recall/Restore previously saved network info."
+	echo "        'E' or 'erase'  : Erase previously saved network info."
+	echo ""
+	echo "     [primary-net-info-file] and [secondary-net-info-file] give full path to files to store network info."
+	echo "     [wpanctl path] gives the full path to 'wpanctl'."
+	echo ""
+}
+
+# Check the input args
+
+if [ $# -ne 4 ]; then
+	display_usage
+	exit 1
+fi
+
+primary_file_name="$1"
+secondary_file_name="$2"
+wpanctl_command="$3"
+retain_command=$4
+
+# List of all wpantund properties saved
+WPANTUND_PROP_NAME="Network:Name"
+WPANTUND_PROP_KEY="Network:Key"
+WPANTUND_PROP_PANID="Network:PANID"
+WPANTUND_PROP_XPANID="Network:XPANID"
+WPANTUND_PROP_CHANNEL="NCP:Channel"
+WPANTUND_PROP_HWADDR="NCP:HardwareAddress"
+WPANTUND_PROP_NODE_TYPE="Network:NodeType"
+WPANTUND_PROP_KEY_INDEX="Network:KeyIndex"
+
+cur_name=
+cur_key=
+cur_panid=
+cur_xpanid=
+cur_channel=
+cur_hwaddr=SOMETHING
+cur_type=
+cur_keyindex=
+
+new_name=
+new_key=
+new_panid=
+new_xpanid=
+new_channel=
+new_hwaddr=
+new_type=
+new_keyindex=
+
+# Populate the new network info variables by reading the values from wpanctl
+function get_new_network_info_from_wpantund()
+{
+	val=$($wpanctl_command get $WPANTUND_PROP_NAME)
+	new_name=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+
+	val=$($wpanctl_command get $WPANTUND_PROP_KEY)
+	val=${val#*\[}
+	new_key=${val%\]*}
+
+	val=$($wpanctl_command get $WPANTUND_PROP_PANID)
+	new_panid=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+
+	val=$($wpanctl_command get $WPANTUND_PROP_XPANID)
+	new_xpanid=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+
+	val=$($wpanctl_command get $WPANTUND_PROP_CHANNEL)
+	new_channel=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+
+	val=$($wpanctl_command get $WPANTUND_PROP_HWADDR)
+	val=${val#*\[}
+	new_hwaddr=${val%\]*}
+
+	val=$($wpanctl_command get $WPANTUND_PROP_NODE_TYPE)
+	new_type=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+
+	val=$($wpanctl_command get $WPANTUND_PROP_KEY_INDEX)
+	new_keyindex=$(echo "$val" | sed -e 's/.*=[[:space:]]*//')
+}
+
+function restore_network_info_on_wpantund()
+{
+	$wpanctl_command set $WPANTUND_PROP_NAME $cur_name
+	$wpanctl_command set $WPANTUND_PROP_KEY -d $cur_key
+	$wpanctl_command set $WPANTUND_PROP_PANID $cur_panid
+	$wpanctl_command set $WPANTUND_PROP_XPANID -d $cur_xpanid
+	$wpanctl_command set $WPANTUND_PROP_CHANNEL $cur_channel
+	$wpanctl_command set $WPANTUND_PROP_HWADDR $cur_hwaddr
+	$wpanctl_command set $WPANTUND_PROP_NODE_TYPE $cur_type
+	$wpanctl_command set $WPANTUND_PROP_KEY_INDEX $cur_keyindex
+
+	$wpanctl_command attach
+}
+
+function verify_cur_info()
+{
+	if [ -z "$cur_name" ] ||		\
+	   [ -z "$cur_key" ] || 		\
+	   [ -z "$cur_panid" ] || 		\
+	   [ -z "$cur_xpanid" ] ||		\
+	   [ -z "$cur_channel" ] || 	\
+	   [ -z "$cur_hwaddr" ] || 		\
+	   [ -z "$cur_type" ] ||		\
+	   [ -z "$cur_keyindex" ]
+	then
+		return 1
+	fi
+
+	return 0
+}
+
+function verify_new_info()
+{
+
+	if [ -z "$new_name" ] ||		\
+	   [ -z "$new_key" ] || 		\
+	   [ -z "$new_panid" ] || 		\
+	   [ -z "$new_xpanid" ] ||		\
+	   [ -z "$new_channel" ] || 	\
+	   [ -z "$new_hwaddr" ] || 		\
+	   [ -z "$new_type" ] ||		\
+	   [ -z "$new_keyindex" ]
+	then
+		return 1
+	fi
+
+	return 0
+}
+
+function is_new_info_same_as_cur_info()
+{
+	if [ "$cur_name" != "$new_name" ] || \
+	   [ "$cur_key" != "$new_key" ] || \
+	   [ "$cur_panid" != "$new_panid" ] || \
+	   [ "$cur_xpanid" != "$new_xpanid" ] || \
+	   [ "$cur_channel" != "$new_channel" ] || \
+	   [ "$cur_hwaddr" != "$new_hwaddr" ] || \
+	   [ "$cur_type" != "$new_type" ] || \
+	   [ "$cur_keyindex" != "$new_keyindex" ]
+	then
+		return 1
+	fi
+
+	return 0
+}
+
+# Reads and parses the network info from a file and populate old network info variables
+#     First arg ($1) is the file name
+function read_cur_network_info_from_file()
+{
+	if [ -r $1 ]; then
+
+		while IFS="\= " read -r key value; do
+
+			case $key in
+			$WPANTUND_PROP_NAME)
+			  cur_name=$value
+			  ;;
+			$WPANTUND_PROP_KEY)
+			  cur_key=$value
+			  ;;
+			$WPANTUND_PROP_PANID)
+			  cur_panid=$value
+			  ;;
+			$WPANTUND_PROP_XPANID)
+			  cur_xpanid=$value
+			  ;;
+			$WPANTUND_PROP_CHANNEL)
+			  cur_channel=$value
+			  ;;
+			$WPANTUND_PROP_HWADDR)
+	          cur_hwaddr=$value
+	          ;;
+	        $WPANTUND_PROP_NODE_TYPE)
+	          cur_type=$value
+	          ;;
+	        $WPANTUND_PROP_KEY_INDEX)
+			  cur_keyindex=$value
+			  ;;
+			esac
+
+		done < $1
+	fi
+}
+
+# Writes the new info into a given file name (first arg should be filename)
+function write_new_info_to_file()
+{
+	fname=$1
+
+	if [ -e $fname ]; then
+		rm $fname > /dev/null 2>&1
+	fi
+
+	# Write all the contents to the file
+
+	echo "${WPANTUND_PROP_NAME} = $new_name" >> $fname
+	echo "${WPANTUND_PROP_KEY} = $new_key" >> $fname
+	echo "${WPANTUND_PROP_PANID} = $new_panid" >> $fname
+	echo "${WPANTUND_PROP_XPANID} = $new_xpanid" >> $fname
+	echo "${WPANTUND_PROP_CHANNEL} = $new_channel" >> $fname
+	echo "${WPANTUND_PROP_HWADDR} = $new_hwaddr" >> $fname
+	echo "${WPANTUND_PROP_NODE_TYPE} = $new_type" >> $fname
+	echo "${WPANTUND_PROP_KEY_INDEX} = $new_keyindex" >> $fname
+
+	# Add a time stamp
+	echo "# Saved on " $(date) >> $fname
+}
+
+# For test and debugging only
+function display_cur_network_info()
+{
+	echo "cur_name is"  $cur_name
+	echo "cur_key is"  $cur_key
+	echo "cur_panid is" $cur_panid
+	echo "cur_xpanid is" $cur_xpanid
+	echo "cur_channel is" $cur_channel
+	echo "cur_hwaddr is" $cur_hwaddr
+	echo "cur_type is" $cur_type
+	echo "cur_keyindex is"  $cur_keyindex
+}
+
+# For test and debugging only
+function display_new_network_info()
+{
+	echo "new_name is"  $new_name
+	echo "new_key is"  $new_key
+	echo "new_panid is" $new_panid
+	echo "new_xpanid is" $new_xpanid
+	echo "new_channel is" $new_channel
+	echo "new_hwaddr is" $new_hwaddr
+	echo "new_type is" $new_type
+	echo "new_keyindex is"  $new_keyindex
+}
+
+function save_network_info()
+{
+	get_new_network_info_from_wpantund
+
+	read_cur_network_info_from_file $primary_file_name
+
+	if verify_new_info; then
+
+		if is_new_info_same_as_cur_info; then
+			echo "Saved network info in \"$primary_file_name\" is up-to-date and valid."
+		else
+
+			write_new_info_to_file $secondary_file_name
+
+			# verify the file content match what was written
+
+			read_cur_network_info_from_file $secondary_file_name
+
+			if is_new_info_same_as_cur_info; then
+
+				cp $secondary_file_name $primary_file_name
+
+				echo  "Successfully saved network info in \"$primary_file_name\" and \"$secondary_file_name\""
+
+			else
+				echo "ERROR: Could not save the network data"
+			fi
+			# need to figure out if it fails what to do...
+		fi
+
+	else
+		echo "ERROR: Network info from wpantund is not valid"
+	fi
+}
+
+function erase_network_info()
+{
+	if [ -e $primary_file_name ]; then
+		rm $primary_file_name
+	fi
+
+	if [ -e $secondary_file_name ]; then
+		rm $secondary_file_name
+	fi
+
+	echo "Successfully erased network data in \"$primary_file_name\" and \"$secondary_file_name\"".
+}
+
+function recall_network_info()
+{
+	read_cur_network_info_from_file $primary_file_name
+
+	# if no valid data from the main file, try to read from the second (backup) file
+	verify_cur_info || read_cur_network_info_from_file $secondary_file_name
+
+	if verify_cur_info; then
+
+		restore_network_info_on_wpantund
+
+		echo "Successfully recalled network info from \"$primary_file_name\""
+	else
+		echo "No valid saved network info to recall."
+	fi
+}
+
+case $retain_command in
+
+R|recall)
+  recall_network_info
+  ;;
+
+S|save)
+  save_network_info
+  ;;
+
+E|erase)
+  erase_network_info
+  ;;
+
+*)
+  echo "Error: Unknown command \"$retain_command\""
+  echo " "
+  display_usage
+  ;;
+esac
+
+exit 0

--- a/src/wpantund/Makefile.am
+++ b/src/wpantund/Makefile.am
@@ -67,6 +67,8 @@ wpantund_SOURCES = \
 	NCPInstanceBase-AsyncIO.cpp \
 	NCPTypes.h \
 	NCPTypes.cpp \
+	NetworkRetain.h \
+	NetworkRetain.cpp \
 	../util/IPv6PacketMatcher.cpp \
 	../util/tunnel.c \
 	../util/config-file.c \

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -103,6 +103,9 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 
 			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_DaemonAutoFirmwareUpdate)) {
 				mAutoUpdateFirmware = any_to_bool(boost::any(iter->second));
+
+			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_ConfigDaemonNetworkRetainCommand)) {
+				mNetworkRetain.set_network_retain_command(iter->second);
 			}
 		}
 	}
@@ -178,7 +181,8 @@ NCPInstanceBase::setup_property_supported_by_class(const std::string& prop_name)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPDriverName)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareCheckCommand)
 		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_DaemonAutoFirmwareUpdate)
-		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareUpgradeCommand);
+		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigNCPFirmwareUpgradeCommand)
+		|| strcaseequal(prop_name.c_str(), kWPANTUNDProperty_ConfigDaemonNetworkRetainCommand);
 }
 
 NCPInstanceBase::~NCPInstanceBase()
@@ -774,11 +778,12 @@ NCPInstanceBase::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_nc
 		set_online(false);
 	}
 
-
 	// We don't announce transitions to the "UNITIALIZED" state.
 	if (UNINITIALIZED != new_ncp_state) {
 		signal_property_changed(kWPANTUNDProperty_NCPState, ncp_state_to_string(new_ncp_state));
 	}
+
+	mNetworkRetain.handle_ncp_state_change(new_ncp_state, old_ncp_state);
 }
 
 void

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -27,6 +27,7 @@
 #include "EventHandler.h"
 #include "NCPTypes.h"
 #include "StatCollector.h"
+#include "NetworkRetain.h"
 #include "RunawayResetBackoffManager.h"
 
 namespace nl {
@@ -299,6 +300,8 @@ private:
 	cms_t mLastChangedBusy;
 
 	FirmwareUpgrade mFirmwareUpgrade;
+
+	NetworkRetain mNetworkRetain;
 
 	StatCollector mStatCollector;  // Statistic collector
 }; // class NCPInstance

--- a/src/wpantund/NetworkRetain.cpp
+++ b/src/wpantund/NetworkRetain.cpp
@@ -1,0 +1,213 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      NetworkRetain class implementation.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+#include "wpan-properties.h"
+#include "NetworkRetain.h"
+#include "socket-utils.h"
+
+#include <syslog.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+
+#if HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+
+using namespace nl;
+using namespace wpantund;
+
+NetworkRetain::NetworkRetain(void) :
+	mNetworkRetainFD(-1)
+{
+}
+
+NetworkRetain::~NetworkRetain()
+{
+	close_network_retain_fd();
+}
+
+void
+NetworkRetain::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state)
+{
+	require_quiet(mNetworkRetainFD >= 0, bail);
+
+	// Not-joined --> joined
+	if (!ncp_state_has_joined(old_ncp_state) && ncp_state_has_joined(new_ncp_state)) {
+		save_network_info();
+	}
+
+	// Initializing --> Offline
+	else if (ncp_state_is_initializing(old_ncp_state) && (new_ncp_state == OFFLINE)) {
+		recall_network_info();
+	}
+
+	// Joined --> Offline
+	else if (ncp_state_has_joined(old_ncp_state) && (new_ncp_state == OFFLINE)) {
+		erase_network_info();
+	}
+
+bail:
+	return;
+}
+
+void
+NetworkRetain::close_network_retain_fd(void)
+{
+	if (mNetworkRetainFD >= 0)
+	{
+		IGNORE_RETURN_VALUE(write(mNetworkRetainFD, "X", 1));
+		close(mNetworkRetainFD);
+		mNetworkRetainFD = -1;
+	}
+}
+
+void
+NetworkRetain::set_network_retain_command(const std::string& command)
+{
+	int status = -1;
+	pid_t pid = -1;
+
+	if (mNetworkRetainFD >= 0) {
+		close_network_retain_fd();
+	}
+
+	pid = fork_unixdomain_socket(&mNetworkRetainFD);
+
+	if (pid < 0) {
+		return;
+	}
+
+	if (pid == 0) {
+		int stdout_copy = dup(STDOUT_FILENO);
+		int stdin_copy = dup(STDIN_FILENO);
+
+		dup2(STDERR_FILENO,STDOUT_FILENO);
+
+		if (stdin_copy >= 0) {
+			close(STDIN_FILENO);
+			stdin = fdopen(stdin_copy, "r");
+		}
+
+		if (stdout_copy >= 0) {
+			stdout = fdopen(stdout_copy, "w");
+		}
+
+		// Double fork to avoid leaking zombie processes.
+		pid = fork();
+		if (pid < 0) {
+			syslog(LOG_ERR, "Call to fork() failed: %s (%d)", strerror(errno), errno);
+
+			_exit(errno);
+		}
+
+		if (0 == pid)  // In child process.
+		{
+			// Set the shell environment variable if it isn't set already.
+			setenv("SHELL","/bin/sh",0);
+
+			while ((ferror(stdin) == 0) && (feof(stdin) == 0)) {
+				int c;
+				std::string args;
+
+				c = fgetc(stdin);
+
+				switch (c) {
+				case 'R':
+				case 'E':
+				case 'S':
+					args = " ";
+					args += c;
+
+					// Execute the requested command.
+					IGNORE_RETURN_VALUE(system((command + args).c_str()));
+					break;
+
+				case 'X':
+					_exit(EXIT_SUCCESS);
+					break;
+
+				default:
+					syslog(LOG_WARNING, "Got unrecognized char 0x%x in NetworkRetain child process.", (int)c);
+					break;
+				}
+			}
+
+			_exit(EXIT_FAILURE);
+		}
+
+		_exit(EXIT_SUCCESS);
+	}
+
+	// Wait for the first fork to return, and place the return value in errno
+	if (waitpid(pid, &status, 0) < 0) {
+		syslog(LOG_ERR, "Call to waitpid() failed: %s (%d)", strerror(errno), errno);
+	}
+
+	if (0 != WEXITSTATUS(status)) {
+		// If this has happened then the double fork failed. Clean up
+		// and pass this status along to the caller as errno.
+
+		syslog(LOG_ERR, "Child process failed: %s (%d)", strerror(WEXITSTATUS(status)), WEXITSTATUS(status));
+
+		close(mNetworkRetainFD);
+		mNetworkRetainFD = -1;
+
+		errno = WEXITSTATUS(status);
+	}
+}
+
+void
+NetworkRetain::save_network_info(void)
+{
+	syslog(LOG_NOTICE, "NetworkRetain - Saving network info...");
+	require_string(write(mNetworkRetainFD, "S", 1) == 1, bail, strerror(errno));
+bail:
+	return;
+}
+
+void
+NetworkRetain::recall_network_info(void)
+{
+	syslog(LOG_NOTICE, "NetworkRetain - Recalling/restoring network info...");
+	require_string(write(mNetworkRetainFD, "R", 1) == 1, bail, strerror(errno));
+bail:
+	return;
+}
+
+void
+NetworkRetain::erase_network_info(void)
+{
+	syslog(LOG_NOTICE, "NetworkRetaine - Erasing network info...");
+	require_string(write(mNetworkRetainFD, "E", 1) == 1, bail, strerror(errno));
+bail:
+	return;
+}
+

--- a/src/wpantund/NetworkRetain.h
+++ b/src/wpantund/NetworkRetain.h
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      Declaration of NetworkRetain class (Hooks for saving/restoring network info)
+ *
+ */
+
+#ifndef __wpantund__NetworkRetain__
+#define __wpantund__NetworkRetain__
+
+#include <string>
+#include "NCPTypes.h"
+
+namespace nl {
+namespace wpantund {
+
+class NetworkRetain
+{
+public:
+	NetworkRetain();
+	~NetworkRetain();
+	void set_network_retain_command(const std::string& command);
+	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
+
+private:
+	void save_network_info(void);
+	void recall_network_info(void);
+	void erase_network_info(void);
+	void close_network_retain_fd(void);
+
+private:
+	int mNetworkRetainFD;
+};
+
+}; // namespace wpantund
+}; // namespace nl
+
+#endif /* defined(__wpantund__NetworkRetain__) */

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -37,6 +37,7 @@
 #define kWPANTUNDProperty_ConfigDaemonPIDFile              "Config:Daemon:PIDFile"
 #define kWPANTUNDProperty_ConfigDaemonPrivDropToUser       "Config:Daemon:PrivDropToUser"
 #define kWPANTUNDProperty_ConfigDaemonChroot               "Config:Daemon:Chroot"
+#define kWPANTUNDProperty_ConfigDaemonNetworkRetainCommand "Config:Daemon:NetworkRetainCommand"
 
 #define kWPANTUNDProperty_DaemonVersion                   "Daemon:Version"
 #define kWPANTUNDProperty_DaemonEnabled                   "Daemon:Enabled"


### PR DESCRIPTION
This commit adds a new class `NetworkRetain` to wpantund. This class provides hooks to enable retaining (saving/recalling) network info. This is realized by adding a new configuration property to wpantund `Config:Daemon:NetworkRetainCommand`. This property provides the command to perform the network retain operations. The `NetworkRetain` class executes the retain command from a forked child process to request  a save operation (when NCP state transition to "associated" ) or an erase (upon a `leave`) or network info recall and restore (upon NCP reset or a wpantund restart). The `NetworkRetain` uses the same model as in `FirmwareUpgrade` module (i.e., the forked process
is started before wpatund possibly dropping privileges).

This commit also adds a script `wpanretain.sh` which can be used as the network retain command. This script implements the save, recall and erase operations. It uses `wpanctl get property` commands and
parses the responses to collect network parameters to save in a config file.