### PR TITLE
NCPInstanceBase: Reset data pump NLPTs when entering a detached state

### DIFF
--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -715,6 +715,8 @@ NCPInstanceBase::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_nc
 		// from the NCP. For this we use the hibernate command.
 		mSerialAdapter->hibernate();
 		PT_INIT(&mControlPT);
+		NLPT_INIT(&mDriverToNCPPumpPT);
+		NLPT_INIT(&mNCPToDriverPumpPT);
 		mFailureCount = 0;
 
 		if (new_ncp_state == FAULT) {


### PR DESCRIPTION
This fixes a bug where `wpantund` terminates after a firmware update
with the error `select() errno="Bad file descriptor" (9)`.