### PR TITLE
NCPInstanceBase: Allow FAULT and UPGRADING states to be reported, even when initializing.

### DIFF
--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -217,7 +217,9 @@ DummyNCPControlInterface::get_property(
     const std::string& in_key, CallbackWithStatusArg1 cb
     )
 {
-	syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+	if (!mNCPInstance->is_initializing_ncp()) {
+		syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+	}
 	mNCPInstance->get_property(in_key, cb);
 }
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -447,7 +447,9 @@ SpinelNCPControlInterface::get_property(
     const std::string& in_key, CallbackWithStatusArg1 cb
     )
 {
-	syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+	if (!mNCPInstance->is_initializing_ncp()) {
+		syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+	}
 	mNCPInstance->get_property(in_key, cb);
 }
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -241,8 +241,6 @@ SpinelNCPInstance::get_property(
 	const std::string& key,
 	CallbackWithStatusArg1 cb
 ) {
-	syslog(LOG_INFO, "get_property: key: \"%s\"", key.c_str());
-
 	if (strcaseequal(key.c_str(), kWPANTUNDProperty_ConfigNCPDriverName)) {
 		cb(0, boost::any(std::string("spinel")));
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPCCAThreshold)) {

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -405,7 +405,9 @@ NCPInstanceBase::get_property(
 		}
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPState)) {
-		if (is_initializing_ncp()) {
+		if ( is_initializing_ncp()
+		  && !ncp_state_is_detached_from_ncp(get_ncp_state())
+		) {
 			cb(0, boost::any(std::string(kWPANTUNDStateUninitialized)));
 		} else {
 			cb(0, boost::any(ncp_state_to_string(get_ncp_state())));


### PR DESCRIPTION
If this isn't allowed, we might never be able to query the NCP for status if it enters the FAULT state.

This pull request also include the following commit:

* ncp: Stop printing out `get_property` debug prints during initialization.

    During initialization, logs were being polluted with lines like:

        wpantund[12345] <info> get_property: key: "NCP:State"
        wpantund[12345] <info> get_property: key: "NCP:State"
        wpantund[12345] <info> get_property: key: "NCP:State"

    These lines are useless, and come from the the main wpantund run-loop
    attempting to determine if the NCP instance is ready to be announced
    via D-Bus. However, this log line is still generally useful, this
    commit adjusts the behavior to only print this message when we are not
    initializing.
