### PR TITLE
ncp-spinel: Updates to Spinel API from OpenThread.

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -112,8 +112,15 @@ SpinelNCPControlInterface::attach(CallbackWithStatus cb)
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
 		new SpinelNCPTaskSendCommand(
 			mNCPInstance,
+			NilReturn(),
+			SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S), SPINEL_PROP_NET_IF_UP, true)
+		)
+	));
+	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
+		new SpinelNCPTaskSendCommand(
+			mNCPInstance,
 			boost::bind(cb,_1),
-			SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_NET_STATE, SPINEL_NET_STATE_ATTACHED)
+			SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S), SPINEL_PROP_NET_STACK_UP, true)
 		)
 	));
 }

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -363,7 +363,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 		if (get_ncp_state() == UNINITIALIZED) {
 			// Get the thread state
 			CONTROL_REQUIRE_PREP_TO_SEND_COMMAND_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
-			GetInstance(this)->mOutboundBufferLen = spinel_cmd_prop_value_get(GetInstance(this)->mOutboundBuffer, sizeof(GetInstance(this)->mOutboundBuffer), SPINEL_PROP_NET_STATE);
+			GetInstance(this)->mOutboundBufferLen = spinel_cmd_prop_value_get(GetInstance(this)->mOutboundBuffer, sizeof(GetInstance(this)->mOutboundBuffer), SPINEL_PROP_NET_STACK_UP);
 			CONTROL_REQUIRE_OUTBOUND_BUFFER_FLUSHED_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
 
 			CONTROL_REQUIRE_COMMAND_RESPONSE_WITHIN(NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT, on_error);
@@ -398,6 +398,9 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 				SPINEL_PROP_IPV6_LL_ADDR,
 				SPINEL_PROP_IPV6_ML_ADDR,
 				SPINEL_PROP_THREAD_ASSISTING_PORTS,
+				SPINEL_PROP_NET_IF_UP,
+				SPINEL_PROP_NET_STACK_UP,
+				SPINEL_PROP_NET_ROLE,
 			};
 
 			for (mSubPTIndex = 0; mSubPTIndex < sizeof(keys_to_fetch)/sizeof(keys_to_fetch[0]); mSubPTIndex++) {

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -306,11 +306,24 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 	}
 
-	// Now we can try associating
+	// Now bring up the network by bringing up the interface and the stack.
+
 	mNextCommand = SpinelPackData(
-		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
-		SPINEL_PROP_NET_STATE,
-		SPINEL_NET_STATE_ATTACHED
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_IF_UP,
+		true
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	ret = mNextCommandRet;
+
+	require_noerr(ret, on_error);
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_STACK_UP,
+		true
 	);
 
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -212,11 +212,24 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 	}
 
 
-	// Now we can try associating
+	// Now bring up the network by bringing up the interface and the stack.
+
 	mNextCommand = SpinelPackData(
-		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
-		SPINEL_PROP_NET_STATE,
-		SPINEL_NET_STATE_ATTACHED
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_IF_UP,
+		true
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	ret = mNextCommandRet;
+
+	require_noerr(ret, on_error);
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_STACK_UP,
+		true
 	);
 
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));

--- a/src/ncp-spinel/SpinelNCPTaskLeave.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskLeave.cpp
@@ -54,9 +54,18 @@ nl::wpantund::SpinelNCPTaskLeave::vprocess_event(int event, va_list args)
 	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
 
 	mNextCommand = SpinelPackData(
-		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
-		SPINEL_PROP_NET_STATE,
-		SPINEL_NET_STATE_OFFLINE
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_STACK_UP,
+		false
+	);
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	require_noerr(ret, on_error);
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
+		SPINEL_PROP_NET_IF_UP,
+		false
 	);
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
 	ret = mNextCommandRet;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -69,7 +69,7 @@
 // ----------------------------------------------------------------------------
 
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    0
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    1
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
 
@@ -92,13 +92,15 @@ typedef enum
     SPINEL_STATUS_PARSE_ERROR       = 9, ///< A error has occured while parsing the command.
     SPINEL_STATUS_IN_PROGRESS       = 10, ///< This operation is in progress.
     SPINEL_STATUS_NOMEM             = 11, ///< Operation prevented due to memory pressure.
-    SPINEL_STATUS_BUSY              = 12, ///< The device is currently performing an mutually exclusive operation
+    SPINEL_STATUS_BUSY              = 12, ///< The device is currently performing a mutually exclusive operation
+    SPINEL_STATUS_PROP_NOT_FOUND    = 13, ///< The given property is not recognized.
     SPINEL_STATUS_DROPPED           = 14, ///< A/The packet was dropped.
     SPINEL_STATUS_EMPTY             = 15, ///< The result of the operation is empty.
     SPINEL_STATUS_CMD_TOO_BIG       = 16, ///< The command was too large to fit in the internal buffer.
     SPINEL_STATUS_NO_ACK            = 17, ///< The packet was not acknowledged.
     SPINEL_STATUS_CCA_FAILURE       = 18, ///< The packet was not sent due to a CCA failure.
-    SPINEL_STATUS_PROP_NOT_FOUND    = 19, ///< The given property is not recognized.
+    SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
+    SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
 
     SPINEL_STATUS_RESET__BEGIN      = 112,
     SPINEL_STATUS_RESET_POWER_ON    = SPINEL_STATUS_RESET__BEGIN + 0,
@@ -115,21 +117,16 @@ typedef enum
     SPINEL_STATUS_VENDOR__BEGIN     = 15360,
     SPINEL_STATUS_VENDOR__END       = 16384,
 
+    SPINEL_STATUS_STACK_NATIVE__BEGIN = 16384,
+    SPINEL_STATUS_STACK_NATIVE__END   = 81920,
+
     SPINEL_STATUS_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_STATUS_EXPERIMENTAL__END   = 2097152,
 } spinel_status_t;
 
 typedef enum
 {
-    SPINEL_NET_STATE_OFFLINE   = 0,
-    SPINEL_NET_STATE_DETACHED  = 1,
-    SPINEL_NET_STATE_ATTACHING = 2,
-    SPINEL_NET_STATE_ATTACHED  = 3,
-} spinel_net_state_t;
-
-typedef enum
-{
-    SPINEL_NET_ROLE_NONE       = 0,
+    SPINEL_NET_ROLE_DETACHED   = 0,
     SPINEL_NET_ROLE_CHILD      = 1,
     SPINEL_NET_ROLE_ROUTER     = 2,
     SPINEL_NET_ROLE_LEADER     = 3,
@@ -265,6 +262,10 @@ enum
     SPINEL_CAP_NET_THREAD_1_0        = (SPINEL_CAP_NET__BEGIN + 0),
     SPINEL_CAP_NET__END              = 64,
 
+    SPINEL_CAP_OPENTHREAD__BEGIN     = 512,
+    SPINEL_CAP_MAC_WHITELIST         = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
+    SPINEL_CAP_OPENTHREAD__END       = 640,
+
     SPINEL_CAP_NEST__BEGIN           = 15296,
     SPINEL_CAP_NEST_LEGACY_INTERFACE = (SPINEL_CAP_NEST__BEGIN + 0),
     SPINEL_CAP_NEST_LEGACY_NET_WAKE  = (SPINEL_CAP_NEST__BEGIN + 1),
@@ -315,10 +316,27 @@ typedef enum
     SPINEL_PROP_MAC_FILTER_MODE        = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
     SPINEL_PROP_MAC__END               = 0x40,
 
+    SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
+    /// MAC Whitelist
+    /** Format: `A(T(Ec))`
+     *
+     * Structure Parameters:
+     *
+     * * `E`: EUI64 address of node
+     * * `c`: Optional fixed RSSI. -127 means not set.
+     */
+    SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0,
+
+    /// MAC Whitelist Enabled Flag
+    /** Format: `b`
+     */
+    SPINEL_PROP_MAC_WHITELIST_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 1,
+    SPINEL_PROP_MAC_EXT__END           = 0x1400,
+
     SPINEL_PROP_NET__BEGIN           = 0x40,
     SPINEL_PROP_NET_SAVED            = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
-    SPINEL_PROP_NET_ENABLED          = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
-    SPINEL_PROP_NET_STATE            = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
+    SPINEL_PROP_NET_IF_UP            = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
+    SPINEL_PROP_NET_STACK_UP         = SPINEL_PROP_NET__BEGIN + 2, ///< [C]
     SPINEL_PROP_NET_ROLE             = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
     SPINEL_PROP_NET_NETWORK_NAME     = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
     SPINEL_PROP_NET_XPANID           = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
@@ -347,7 +365,44 @@ typedef enum
     SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
+
+    /// Thread Mode
+    /** Format: `C`
+     *
+     *  This property contains the value of the mode
+     *  TLV for this node. The meaning of the bits in this
+     *  bitfield are defined by section 4.5.2 of the Thread
+     *  specification.
+     */
+    SPINEL_PROP_THREAD_MODE            = SPINEL_PROP_THREAD__BEGIN + 14,
     SPINEL_PROP_THREAD__END            = 0x60,
+
+    SPINEL_PROP_THREAD_EXT__BEGIN      = 0x1500,
+
+    /// Thread Child Timeout
+    /** Format: `L`
+     *
+     *  Used when operating in the Child role.
+     */
+    SPINEL_PROP_THREAD_CHILD_TIMEOUT   = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
+
+    /// Thread RLOC16
+    /** Format: `S`
+     */
+    SPINEL_PROP_THREAD_RLOC16          = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
+
+    /// Thread Router Upgrade Threshold
+    /** Format: `C`
+     */
+    SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
+
+    /// Thread Context Reuse Delay
+    /** Format: `L`
+     */
+    SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
+    SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,
     SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
@@ -363,6 +418,7 @@ typedef enum
     SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
     SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
     SPINEL_PROP_STREAM__END         = 0x80,
+
 
     /// UART Bitrate
     /** Format: `L`
@@ -524,7 +580,6 @@ typedef enum
     SPINEL_PROP_CNTR_RX_ERR_OTHER      = SPINEL_PROP_CNTR__BEGIN + 113,
 
     SPINEL_PROP_CNTR__END       = 2048,
-
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
     SPINEL_PROP_NEST__END           = 15360,


### PR DESCRIPTION
This change is required to have `wpantund` successfully control
OpenThread NCPs after [OpenThread pull request #372][1] is merged
in.

Versions of `wpantund` that include this change *should* be able to
continue to control older NCPs, but no guarantees are made.

[1]: https://github.com/openthread/openthread/pull/372