### PR TITLE
ncp-spinel: Miscellaneous bug fixes

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -781,7 +781,6 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 	} else if (key == SPINEL_PROP_IPV6_ADDRESS_TABLE) {
 		std::map<struct in6_addr, GlobalAddressEntry>::const_iterator iter;
 		std::map<struct in6_addr, GlobalAddressEntry> global_addresses(mGlobalAddresses);
-		clear_nonpermanent_global_addresses();
 
 		while(value_data_len > 0) {
 			const uint8_t *entry_ptr = NULL;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -134,6 +134,9 @@ protected:
 	void handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
+	virtual void address_was_added(const struct in6_addr& addr, int prefix_len);
+	virtual void address_was_removed(const struct in6_addr& addr, int prefix_len);
+
 public:
 	static bool setup_property_supported_by_class(const std::string& prop_name);
 

--- a/src/ncp-spinel/SpinelNCPTaskChangeNetData.h
+++ b/src/ncp-spinel/SpinelNCPTaskChangeNetData.h
@@ -20,6 +20,7 @@
 #ifndef __wpantund__SpinelNCPTaskChangeNetData__
 #define __wpantund__SpinelNCPTaskChangeNetData__
 
+#include <list>
 #include "SpinelNCPTask.h"
 #include "SpinelNCPInstance.h"
 #include "ValueMap.h"
@@ -40,10 +41,18 @@ public:
 		int timeout = NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT
 	);
 
+	SpinelNCPTaskChangeNetData(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		const std::list<Data>& change_net_data_commands,
+		int timeout = NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT
+	);
+
 	virtual int vprocess_event(int event, va_list args);
 
 private:
-	Data mChangeNetDataCommand;
+	std::list<Data> mChangeNetDataCommands;
+	std::list<Data>::const_iterator mCommandIter;
 	int mRetVal;
 };
 

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -94,6 +94,21 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 	mLastState = mInstance->get_ncp_state();
 	mInstance->change_ncp_state(ASSOCIATING);
 
+	if (mOptions.count(kWPANTUNDProperty_NCPChannel)) {
+		mNextCommand = SpinelPackData(
+			SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
+			SPINEL_PROP_PHY_CHAN,
+			any_to_int(mOptions[kWPANTUNDProperty_NCPChannel])
+		);
+
+		EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+		ret = mNextCommandRet;
+
+		require_noerr(ret, on_error);
+
+	}
+
 	if (mOptions.count(kWPANTUNDProperty_NetworkPANID)) {
 		mNextCommand = SpinelPackData(
 			SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT16_S),

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -148,6 +148,13 @@ typedef enum
     SPINEL_POWER_STATE_ONLINE     = 4,
 } spinel_power_state_t;
 
+enum {
+	SPINEL_NET_FLAG_CONFIGURE       = 0x04,
+	SPINEL_NET_FLAG_DHCP            = 0x08,
+	SPINEL_NET_FLAG_SLAAC_VALID     = 0x10,
+	SPINEL_NET_FLAG_SLAAC_PREFERRED = 0x20,
+};
+
 enum
 {
     SPINEL_PROTOCOL_TYPE_ZIGBEE    = 1,


### PR DESCRIPTION
* ncp-spinel: Handle adding and removing of unicast addresses.
* ncp-spinel: Don't clear addresses when we get a new IPv6 address table.
* ncp-spinel: Allow the channel to be set for join.
