### PR TITLE
Add diagnostics(mfg) interface in wpantund

### DIFF
--- a/src/ipc-dbus/DBUSIPCServer.cpp
+++ b/src/ipc-dbus/DBUSIPCServer.cpp
@@ -37,7 +37,6 @@
 #endif
 #include <string.h>
 #include "NCPControlInterface.h"
-#include "NCPMfgInterface.h"
 #include "assert-macros.h"
 
 #include <boost/bind.hpp>

--- a/src/ipc-dbus/DBusIPCAPI_v0.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v0.cpp
@@ -36,7 +36,7 @@
 
 #include "NCPControlInterface.h"
 #include "NCPTypes.h"
-#include "NCPMfgInterface.h"
+#include "NCPMfgInterface_v0.h"
 #include "assert-macros.h"
 
 #include "DBUSHelpers.h"
@@ -993,7 +993,7 @@ DBusIPCAPI_v0::interface_mfg_finish_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1021,7 +1021,7 @@ DBusIPCAPI_v0::interface_mfg_begin_test_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1056,7 +1056,7 @@ DBusIPCAPI_v0::interface_mfg_end_test_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 	int16_t test_type = 0;
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1083,7 +1083,7 @@ DBusIPCAPI_v0::interface_mfg_tx_packet_handler(
 	const uint8_t *packet_data = NULL;
 	int packet_length = 0;
 	int16_t repeat = 1;
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1134,7 +1134,7 @@ DBusIPCAPI_v0::interface_mfg_clockmon_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1173,7 +1173,7 @@ DBusIPCAPI_v0::interface_mfg_gpio_set_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1214,7 +1214,7 @@ DBusIPCAPI_v0::interface_mfg_gpio_get_handler(
 	DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1252,7 +1252,7 @@ DBusIPCAPI_v0::interface_mfg_channelcal_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1291,7 +1291,7 @@ DBusIPCAPI_v0::interface_mfg_channelcal_get_handler(
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	if (mfg_interface) {
 		dbus_message_ref(message);
@@ -1420,7 +1420,7 @@ DBusIPCAPI_v0::add_interface(NCPControlInterface* interface)
 	std::pair<NCPControlInterface*, DBusIPCAPI_v0*> *cb_data =
 	    new std::pair<NCPControlInterface*, DBusIPCAPI_v0*>(interface, this);
 
-	NCPMfgInterface* mfg_interface(dynamic_cast<NCPMfgInterface*>(interface));
+	NCPMfgInterface_v0* mfg_interface(dynamic_cast<NCPMfgInterface_v0*>(interface));
 
 	require(dbus_connection_register_object_path(
 	            mConnection,

--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -172,6 +172,11 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_mfg_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 private:
 	typedef DBusHandlerResult (interface_handler_cb)(
 		NCPControlInterface*,

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -81,4 +81,6 @@
 #define WPANTUND_IF_CMD_PERMIT_JOIN           "PermitJoin"
 #define WPANTUND_IF_CMD_NETWORK_WAKE_BEGIN    "NetworkWakeBegin"
 
+#define WPANTUND_IF_CMD_MFG                   "Mfg"
+
 #endif

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -171,6 +171,14 @@ DummyNCPControlInterface::netscan_start(
 }
 
 void
+DummyNCPControlInterface::mfg(
+    const std::string& mfg_command,
+    CallbackWithStatusArg1 cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented, 0); // TODO: Start mfg run
+}
+
+void
 DummyNCPControlInterface::netscan_stop(CallbackWithStatus cb)
 {
 	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Start network scan

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -65,6 +65,8 @@ public:
 	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
 	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn());
 
+	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
+
 	virtual void begin_net_wake(uint8_t data, uint32_t flags, CallbackWithStatus cb = NilReturn());
 	virtual void reset(CallbackWithStatus cb = NilReturn());
 	virtual void permit_join(

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -438,6 +438,26 @@ SpinelNCPControlInterface::get_name() {
 	return mNCPInstance->get_name();
 }
 
+void
+SpinelNCPControlInterface::mfg(
+    const std::string& mfg_command,
+    CallbackWithStatusArg1 cb
+) {
+	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
+		new SpinelNCPTaskSendCommand(
+			mNCPInstance,
+			cb,
+			SpinelPackData(
+				SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UTF8_S),
+				SPINEL_PROP_NEST_STREAM_MFG,
+				mfg_command.c_str()
+			),
+			NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
+			SPINEL_DATATYPE_UTF8_S
+		)
+	));
+}
+
 const WPAN::NetworkInstance&
 SpinelNCPControlInterface::get_current_network_instance()const
 {

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -22,6 +22,7 @@
 
 #include "NCPInstance.h"
 #include "NCPControlInterface.h"
+#include "NCPMfgInterface_v1.h"
 #include "nlpt.h"
 #include "Callbacks.h"
 #include "EventHandler.h"
@@ -36,7 +37,7 @@ namespace wpantund {
 
 class SpinelNCPInstance;
 
-class SpinelNCPControlInterface : public NCPControlInterface {
+class SpinelNCPControlInterface : public NCPControlInterface, public NCPMfgInterface_v1 {
 public:
 	friend class SpinelNCPInstance;
 
@@ -92,6 +93,9 @@ public:
 	virtual std::string get_name();
 
 	virtual NCPInstance& get_ncp_instance(void);
+
+	/******************* NCPMfgInterface_v1 ********************/
+	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
 
 private:
 

--- a/src/wpantund/Makefile.am
+++ b/src/wpantund/Makefile.am
@@ -53,7 +53,8 @@ wpantund_SOURCES = \
 	NCPInstance.h \
 	NCPInstanceBase.cpp \
 	NCPInstanceBase.h \
-	NCPMfgInterface.h \
+	NCPMfgInterface_v0.h \
+	NCPMfgInterface_v1.h \
 	NetworkInstance.h \
 	NCPConstants.h \
 	FirmwareUpgrade.h \

--- a/src/wpantund/NCPMfgInterface_v0.h
+++ b/src/wpantund/NCPMfgInterface_v0.h
@@ -17,15 +17,15 @@
  *
  */
 
-#ifndef wpantund_NCPMfgInterface_h
-#define wpantund_NCPMfgInterface_h
+#ifndef wpantund_NCPMfgInterface_v0_h
+#define wpantund_NCPMfgInterface_v0_h
 
 #include "NCPControlInterface.h"
 
 namespace nl {
 namespace wpantund {
 
-class NCPMfgInterface {
+class NCPMfgInterface_v0 {
 public:
 	virtual void mfg_start(CallbackWithStatus cb) { }
 

--- a/src/wpantund/NCPMfgInterface_v1.h
+++ b/src/wpantund/NCPMfgInterface_v1.h
@@ -1,0 +1,37 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef wpantund_NCPMfgInterface_v1_h
+#define wpantund_NCPMfgInterface_v1_h
+
+#include "NCPControlInterface.h"
+
+namespace nl {
+namespace wpantund {
+
+class NCPMfgInterface_v1 {
+public:
+	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn()) = 0;
+
+};
+
+}; // namespace wpantund
+}; // namespace nl
+
+#endif

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1130,6 +1130,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_CONTEXT_REUSE_DELAY";
         break;
 
+    case SPINEL_PROP_NEST_STREAM_MFG:
+        ret = "SPINEL_PROP_NEST_STREAM_MFG";
+        break;
+
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -330,7 +330,7 @@ typedef enum
      * Structure Parameters:
      *
      * * `E`: EUI64 address of node
-     * * `c`: Optional fixed RSSI. -127 means not set.
+     * * `c`: Optional fixed RSSI. 127 means not set.
      */
     SPINEL_PROP_MAC_WHITELIST          = SPINEL_PROP_MAC_EXT__BEGIN + 0,
 
@@ -596,6 +596,7 @@ typedef enum
     SPINEL_PROP_CNTR__END       = 2048,
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
+    SPINEL_PROP_NEST_STREAM_MFG     = SPINEL_PROP_NEST__BEGIN + 0,
     SPINEL_PROP_NEST__END           = 15360,
 
     SPINEL_PROP_VENDOR__BEGIN       = 15360,


### PR DESCRIPTION
  - Spinel: add 'SPINEL_PROP_NEST_STREAM_MFG' property

  - D-Bus: add 'WPANTUND_IF_CMD_MFG' command

  - Move original 'NCPMfgInterface' to 'NCPMfgInterface_v0', add new 'NCPMfgInterface_v1'