### PR TITLE
ncp-spinel: Add addresses for on-mesh SLAAC prefixes.

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -188,12 +188,6 @@ SpinelNCPControlInterface::data_poll(CallbackWithStatus cb)
 void
 SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefix[8], uint32_t preferredLifetime, uint32_t validLifetime, CallbackWithStatus cb)
 {
-    const static int kPreferredFlag = 1 << 5;
-    const static int kValidFlag = 1 << 4;
-    const static int kConfigureFlag = 1 << 2; (void)kConfigureFlag;
-    const static int kDefaultRouteFlag = 1 << 1;
-    const static int kDhcpFlag = 1 << 3; (void)kDhcpFlag;
-
 	struct in6_addr addr = {};
 	uint8_t flags = 0;
 
@@ -208,15 +202,13 @@ SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefi
 	}
 
 	if (defaultRoute) {
-		flags |= kDefaultRouteFlag;
+		flags |= SPINEL_NET_FLAG_DEFAULT_ROUTE;
 	}
 
-	flags |= kPreferredFlag | kValidFlag;
+	flags |= SPINEL_NET_FLAG_PREFERRED | SPINEL_NET_FLAG_SLAAC | SPINEL_NET_FLAG_ON_MESH;
 
 	memcpy(addr.s6_addr, prefix, 8);
 
-	memcpy(addr.s6_addr + 8, mNCPInstance->mMACAddress, 8);
-	addr.s6_addr[8] ^= 0x02; // flip the private-use bit on the hardware address.
 
 	if (validLifetime == 0) {
 		mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -455,7 +455,7 @@ SpinelNCPInstance::get_property(
 			new SpinelNCPTaskSendCommand(
 				this,
 				cb,
-				SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_IPV6_ML_ADDR),
+				SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_IPV6_LL_ADDR),
 				NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
 				SPINEL_DATATYPE_IPv6ADDR_S
 			)
@@ -727,6 +727,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 				case SPINEL_STATUS_RESET_CRASH:
 				case SPINEL_STATUS_RESET_FAULT:
 				case SPINEL_STATUS_RESET_ASSERT:
+				case SPINEL_STATUS_RESET_WATCHDOG:
 				case SPINEL_STATUS_RESET_OTHER:
 					wstatus = kWPANTUNDStatus_NCP_Crashed;
 					break;
@@ -754,7 +755,6 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		if (interface_type != SPINEL_PROTOCOL_TYPE_THREAD) {
 			syslog(LOG_CRIT, "[-NCP-]: NCP is using unsupported protocol type (%d)", interface_type);
 			change_ncp_state(FAULT);
-			// TODO: Possible firmware update
 		}
 
 
@@ -766,7 +766,6 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		if (protocol_version_major != SPINEL_PROTOCOL_VERSION_THREAD_MAJOR) {
 			syslog(LOG_CRIT, "[-NCP-]: NCP is using unsupported protocol version (NCP:%d, wpantund:%d)", protocol_version_major, SPINEL_PROTOCOL_VERSION_THREAD_MAJOR);
 			change_ncp_state(FAULT);
-			// TODO: Possible firmware update
 		}
 
 		if (protocol_version_minor != SPINEL_PROTOCOL_VERSION_THREAD_MINOR) {

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -137,6 +137,10 @@ protected:
 	virtual void address_was_added(const struct in6_addr& addr, int prefix_len);
 	virtual void address_was_removed(const struct in6_addr& addr, int prefix_len);
 
+private:
+
+	void refresh_on_mesh_prefix(struct in6_addr *addr, uint8_t prefix_len, bool stable, uint8_t flags);
+
 public:
 	static bool setup_property_supported_by_class(const std::string& prop_name);
 

--- a/src/wpantund/NCPTypes.cpp
+++ b/src/wpantund/NCPTypes.cpp
@@ -297,6 +297,28 @@ nl::wpantund::address_flags_to_string(uint8_t flags)
 	return ret;
 }
 
+std::string
+nl::wpantund::flags_to_string(uint8_t flags, const char flag_lookup[8])
+{
+	std::string ret;
+	int i;
+	if (flag_lookup == NULL) {
+		flag_lookup = "76543210";
+	}
+	for (i = 7; i >= 0 ; --i) {
+		uint8_t mask = (1<<i);
+		if (i == 3) {
+			ret += ' ';
+		}
+		if (!(mask & flags)) {
+			ret += '-';
+			continue;
+		}
+		ret += flag_lookup[7-i];
+	}
+	return ret;
+}
+
 NCPState
 nl::wpantund::string_to_ncp_state(const std::string& state_string)
 {

--- a/src/wpantund/NCPTypes.h
+++ b/src/wpantund/NCPTypes.h
@@ -80,8 +80,9 @@ struct EnergyScanResultEntry
 	int8_t 	mMaxRssi;
 };
 
-
 std::string address_flags_to_string(uint8_t flags);
+
+std::string flags_to_string(uint8_t flags, const char flag_lookup[8] = "76543210");
 
 bool ncp_state_is_sleeping(NCPState x);
 

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -149,10 +149,15 @@ typedef enum
 } spinel_power_state_t;
 
 enum {
-	SPINEL_NET_FLAG_CONFIGURE       = 0x04,
-	SPINEL_NET_FLAG_DHCP            = 0x08,
-	SPINEL_NET_FLAG_SLAAC_VALID     = 0x10,
-	SPINEL_NET_FLAG_SLAAC_PREFERRED = 0x20,
+    SPINEL_NET_FLAG_ON_MESH           = (1 << 0),
+    SPINEL_NET_FLAG_DEFAULT_ROUTE     = (1 << 1),
+    SPINEL_NET_FLAG_CONFIGURE         = (1 << 2),
+    SPINEL_NET_FLAG_DHCP              = (1 << 3),
+    SPINEL_NET_FLAG_SLAAC             = (1 << 4),
+    SPINEL_NET_FLAG_PREFERRED         = (1 << 5),
+
+    SPINEL_NET_FLAG_PREFERENCE_OFFSET = 6,
+    SPINEL_NET_FLAG_PREFERENCE_MASK   = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
 };
 
 enum


### PR DESCRIPTION
This commit makes sure that wpantund adds the appropriate addresses to the interface as on-mesh prefixes become available.