### PR TITLE
wpantund: Refactor how the address list is handled.

### DIFF
--- a/src/util/IPv6Helpers.cpp
+++ b/src/util/IPv6Helpers.cpp
@@ -1,0 +1,64 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      This file contains helper glue code for manipulating IPv6 addresses.
+ *
+ */
+
+#include "IPv6Helpers.h"
+
+std::string
+in6_addr_to_string(const struct in6_addr &addr)
+{
+	char address_string[INET6_ADDRSTRLEN] = "::";
+	inet_ntop(AF_INET6, (const void *)&addr, address_string, sizeof(address_string));
+	return std::string(address_string);
+}
+
+struct in6_addr
+make_slaac_addr_from_eui64(const uint8_t prefix[8], const uint8_t eui64[8])
+{
+	struct in6_addr ret;
+
+	// Construct the IPv6 address from the prefix and EUI64.
+	memcpy(&ret.s6_addr[0], prefix, 8);
+	memcpy(&ret.s6_addr[8], eui64, 8);
+
+	// Flip the administratively assigned bit.
+	ret.s6_addr[8] ^= 0x02;
+
+	return ret;
+}
+
+void
+in6_addr_apply_mask(struct in6_addr &address, uint8_t mask)
+{
+	if (mask > 128) {
+		mask = 128;
+	}
+
+	memset(
+		(void*)(address.s6_addr + ((mask + 7) / 8)),
+		0,
+		16 - ((mask + 7) / 8)
+	);
+
+	if (mask % 8) {
+		address.s6_addr[mask / 8] &= ~(0xFF >> (mask % 8));
+	}
+}

--- a/src/util/IPv6Helpers.h
+++ b/src/util/IPv6Helpers.h
@@ -48,34 +48,16 @@ operator<(const struct in6_addr &lhs, const struct in6_addr &rhs)
 	return memcmp(lhs.s6_addr, rhs.s6_addr, sizeof(struct in6_addr)) < 0;
 }
 
-static inline std::string
-in6_addr_to_string(const struct in6_addr &addr) {
-	char address_string[INET6_ADDRSTRLEN] = "::";
-	inet_ntop(AF_INET6, (const void *)&addr, address_string, sizeof(address_string));
-	return std::string(address_string);
-}
-
-static inline void
-in6_addr_apply_mask(struct in6_addr &address, uint8_t mask)
-{
-	if (mask > 128) {
-		mask = 128;
-	}
-
-	memset(
-		(void*)(address.s6_addr + ((mask + 7) / 8)),
-		0,
-		16 - ((mask + 7) / 8)
-	);
-
-	if (mask % 8) {
-		address.s6_addr[mask / 8] &= ~(0xFF >> (mask % 8));
-	}
-}
-
 static inline bool
 is_valid_ipv6_packet(const uint8_t* packet, ssize_t len) {
 	return (len > MINIMUM_IPV6_PACKET_SIZE)
 		&& (packet[0] & 0xF0) == 0x60; // IPv6 Version
 }
+
+std::string in6_addr_to_string(const struct in6_addr &addr);
+
+struct in6_addr make_slaac_addr_from_eui64(const uint8_t prefix[8], const uint8_t eui64[8]);
+
+void in6_addr_apply_mask(struct in6_addr &address, uint8_t mask);
+
 #endif

--- a/src/util/Makefile.am
+++ b/src/util/Makefile.am
@@ -37,6 +37,7 @@ EXTRA_DIST = \
 	Data.h \
 	EventHandler.h \
 	IPv6Helpers.h \
+	IPv6Helpers.cpp \
 	IPv6PacketMatcher.h \
 	NilReturn.h \
 	SocketAdapter.h \

--- a/src/util/TunnelIPv6Interface.h
+++ b/src/util/TunnelIPv6Interface.h
@@ -50,11 +50,7 @@ public:
 	bool is_online(void);
 	int set_online(bool isOnline);
 
-	bool set_mac_address(const uint8_t addr[8]);
 
-	const uint8_t* get_mac_address(void)const;
-
-	bool set_realm_local_address(const struct in6_addr *addr, int prefixlen = 64);
 
 	const struct in6_addr& get_realm_local_address()const;
 
@@ -85,9 +81,6 @@ private:
 
 	int mNetlinkFD;
 
-	uint8_t mMACAddress[8];
-	struct in6_addr mRealmLocalAddress;
-	int mRealmLocalPrefixSize;
 	std::set<struct in6_addr> mAddresses;
 };
 #endif /* defined(__wpantund__TunnelInterface__) */

--- a/src/util/tunnel.c
+++ b/src/util/tunnel.c
@@ -329,33 +329,6 @@ tunnel_set_mtu(
 #define SIOCSIFLLADDR SIOCSIFHWADDR
 #endif
 
-int
-tunnel_set_hw_address(
-    int fd, const uint8_t addr[8]
-    )
-{
-	int ret = -1;
-	bool was_online = tunnel_is_online(fd);
-
-	uint8_t ll_addr[16] = { 0xFE, 0x80 };
-
-	memcpy(ll_addr + 8, addr, 8);
-
-	ll_addr[8] = ll_addr[8] ^ 0x02;
-
-	tunnel_remove_address(fd, ll_addr);
-	ret = tunnel_add_address(fd, ll_addr, 10);
-
-	if (ret) {
-		if (errno == EALREADY)
-			ret = 0;
-	}
-
-	if (!was_online && tunnel_is_online(fd))
-		tunnel_bring_offline(fd);
-
-	return ret;
-}
 
 static inline void
 apply_mask(

--- a/src/util/tunnel.h
+++ b/src/util/tunnel.h
@@ -41,8 +41,6 @@ extern int tunnel_get_name(
     int fd, char* name, int maxlen);
 extern int tunnel_set_mtu(
     int fd, uint16_t mtu);
-extern int tunnel_set_hw_address(
-    int fd, const uint8_t addr[8]);
 extern int tunnel_add_address(
     int fd, const uint8_t addr[16], int prefixlen);
 extern int tunnel_remove_address(

--- a/src/wpantund/Makefile.am
+++ b/src/wpantund/Makefile.am
@@ -70,6 +70,7 @@ wpantund_SOURCES = \
 	NetworkRetain.h \
 	NetworkRetain.cpp \
 	../util/IPv6PacketMatcher.cpp \
+	../util/IPv6Helpers.cpp \
 	../util/tunnel.c \
 	../util/config-file.c \
 	../util/socket-utils.c \

--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -44,8 +44,20 @@ NCPInstanceBase::set_online(bool x)
 
 	restore_global_addresses();
 
+	if (IN6_IS_ADDR_LINKLOCAL(&mNCPLinkLocalAddress)) {
+		add_address(mNCPLinkLocalAddress);
+	}
+
 	if ((ret == 0) && static_cast<bool>(mLegacyInterface)) {
-		ret = mLegacyInterface->set_online(x && mNodeTypeSupportsLegacy);
+		if (x && mNodeTypeSupportsLegacy) {
+			ret = mLegacyInterface->set_online(true);
+
+			if (IN6_IS_ADDR_LINKLOCAL(&mNCPLinkLocalAddress)) {
+				mLegacyInterface->add_address(&mNCPLinkLocalAddress);
+			}
+		} else {
+			ret = mLegacyInterface->set_online(false);
+		}
 	}
 
 	return ret;

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -407,10 +407,10 @@ NCPInstanceBase::get_property(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress)) {
 		struct in6_addr legacy_addr;
 
-		if ((mLegacyInterfaceEnabled || mNodeTypeSupportsLegacy) && buffer_is_nonzero(mNCPV6LegacyPrefix, sizeof(mNCPV6LegacyPrefix))) {
-			memcpy(&legacy_addr, mNCPV6LegacyPrefix, sizeof(mNCPV6LegacyPrefix));
-			memcpy(&legacy_addr.s6_addr[8], mMACAddress, sizeof(mMACAddress));
-			legacy_addr.s6_addr[8] ^= 0x02; // Flip the private-use bit on the hardware address.
+		if ( (mLegacyInterfaceEnabled || mNodeTypeSupportsLegacy)
+		  && buffer_is_nonzero(mNCPV6LegacyPrefix, sizeof(mNCPV6LegacyPrefix))
+		) {
+			legacy_addr = make_slaac_addr_from_eui64(mNCPV6LegacyPrefix, mMACAddress);
 			cb(0, boost::any(in6_addr_to_string(legacy_addr)));
 		} else {
 			cb(kWPANTUNDStatus_FeatureNotSupported, std::string("Property is unavailable"));

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -124,7 +124,7 @@ public:
 
 	int set_online(bool x);
 
-	int set_mac_address(const uint8_t addr[8]);
+	void set_mac_address(const uint8_t addr[8]);
 
 	void set_mac_hardware_address(const uint8_t addr[8]);
 
@@ -136,7 +136,9 @@ public:
 	// ========================================================================
 	// MARK: Global Address Management
 
-	void update_global_address(const struct in6_addr &address, uint32_t valid_lifetime, uint32_t preferred_lifetime, uint8_t flags);
+
+	void add_address(const struct in6_addr &address, uint8_t prefix = 64, uint32_t valid_lifetime = UINT32_MAX, uint32_t preferred_lifetime = UINT32_MAX);
+	void remove_address(const struct in6_addr &address);
 
 	void refresh_global_addresses();
 


### PR DESCRIPTION
`wpantund` has traditionally treated the link local address and the
mesh-local/realm-local addresses as special and handled them independently
from other addresses. I now believe this was a mistake.

This change unifies how all addresses are handled into one single list
that addresses get added to and removed from. This approach simplifies
the internal API and also makes general address housekeeping much easier.

This is a fairly invasive change, so extra care should be taken
in its review.