### PR TITLE
ncp-spinel: Add support for in-band assisted joining

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -416,6 +416,10 @@ SpinelNCPInstance::driver_to_ncp_pump()
 				continue;
 			}
 
+			if (get_ncp_state() == CREDENTIALS_NEEDED) {
+				mOutboundBufferType = FRAME_TYPE_INSECURE_DATA;
+			}
+
 			mOutboundBuffer[3] = (mOutboundBufferLen & 0xFF);
 			mOutboundBuffer[4] = ((mOutboundBufferLen >> 8) & 0xFF);
 
@@ -426,8 +430,10 @@ SpinelNCPInstance::driver_to_ncp_pump()
 
 			if (mOutboundBufferType == FRAME_TYPE_DATA) {
 				mOutboundBuffer[2] = SPINEL_PROP_STREAM_NET;
+
 			} else if (mOutboundBufferType == FRAME_TYPE_INSECURE_DATA) {
 				mOutboundBuffer[2] = SPINEL_PROP_STREAM_NET_INSECURE;
+
 			} else {
 				mOutboundBuffer[0] = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_1;
 				mOutboundBuffer[2] = SPINEL_PROP_STREAM_NET;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -241,6 +241,8 @@ bool ncp_event_matches_header_from_args(int event, va_list args, uint8_t last_he
 
 int peek_ncp_callback_status(int event, va_list args);
 
+int spinel_status_to_wpantund_status(int spinel_status);
+
 }; // namespace wpantund
 }; // namespace nl
 

--- a/src/ncp-spinel/SpinelNCPTask.cpp
+++ b/src/ncp-spinel/SpinelNCPTask.cpp
@@ -87,7 +87,7 @@ SpinelNCPTask::vprocess_send_command(int event, va_list args)
 	mNextCommandRet = peek_ncp_callback_status(event, args);
 
 	if (mNextCommandRet) {
-		mNextCommandRet = WPANTUND_NCPERROR_TO_STATUS(mNextCommandRet);
+		mNextCommandRet = spinel_status_to_wpantund_status(mNextCommandRet);
 	}
 
 	EH_EXIT();

--- a/src/ncp-spinel/SpinelNCPTaskSendCommand.h
+++ b/src/ncp-spinel/SpinelNCPTaskSendCommand.h
@@ -42,7 +42,6 @@ public:
 	virtual int vprocess_event(int event, va_list args);
 
 private:
-	int mTimeout;
 	std::string mPackedFormat;
 };
 

--- a/src/wpantund/StatCollector.cpp
+++ b/src/wpantund/StatCollector.cpp
@@ -1669,10 +1669,10 @@ StatCollector::record_rip_entry(const ValueMap& rip_entry)
 {
 	ValueMap::const_iterator it;
 	Data eui64;
-	int8_t rssi;
-	uint8_t in_lqi;
-	uint8_t out_lqi;
-	NodeType node_type;
+	int8_t rssi = 0;
+	uint8_t in_lqi = 0;
+	uint8_t out_lqi = 0;
+	NodeType node_type = UNKNOWN;
 
 
 	mLinkStat.update(eui64.data(), rssi, in_lqi, out_lqi, node_type);

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1082,6 +1082,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_IPV6_ROUTE_TABLE";
         break;
 
+    case SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD:
+        ret = "SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD";
+        break;
+
     case SPINEL_PROP_THREAD_PARENT:
         ret = "SPINEL_PROP_THREAD_PARENT";
         break;
@@ -1104,6 +1108,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 
     case SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE:
         ret = "SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
+        break;
+
+    case SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU:
+        ret = "SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
         break;
 
     case SPINEL_PROP_MAC_WHITELIST:
@@ -1129,6 +1137,11 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
     case SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY:
         ret = "PROP_THREAD_CONTEXT_REUSE_DELAY";
         break;
+
+    case SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING:
+        ret = "PROP_NET_REQUIRE_JOIN_EXISTING";
+        break;
+
 
     case SPINEL_PROP_NEST_STREAM_MFG:
         ret = "SPINEL_PROP_NEST_STREAM_MFG";
@@ -1229,6 +1242,22 @@ const char *spinel_status_to_cstr(spinel_status_t status)
 
     case SPINEL_STATUS_ITEM_NOT_FOUND:
         ret = "STATUS_ITEM_NOT_FOUND";
+        break;
+
+    case SPINEL_STATUS_JOIN_FAILURE:
+        ret = "STATUS_JOIN_FAILURE";
+        break;
+
+    case SPINEL_STATUS_JOIN_SECURITY:
+        ret = "STATUS_JOIN_SECURITY";
+        break;
+
+    case SPINEL_STATUS_JOIN_NO_PEERS:
+        ret = "STATUS_JOIN_NO_PEERS";
+        break;
+
+    case SPINEL_STATUS_JOIN_INCOMPATIBLE:
+        ret = "STATUS_JOIN_INCOMPATIBLE";
         break;
 
     case SPINEL_STATUS_RESET_POWER_ON:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -102,6 +102,41 @@ typedef enum
     SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
     SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
 
+    SPINEL_STATUS_JOIN__BEGIN       = 104,
+
+    /// Generic failure to associate with other peers.
+    /**
+     *  This status error should not be used by implementors if
+     *  enough information is available to determine that one of the
+     *  later join failure status codes would be more accurate.
+     *
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_FAILURE      = SPINEL_STATUS_JOIN__BEGIN + 0,
+
+    /// The node found other peers but was unable to decode their packets.
+    /**
+     *  Typically this error code indicates that the network
+     *  key has been set incorrectly.
+     *
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_SECURITY     = SPINEL_STATUS_JOIN__BEGIN + 1,
+
+    /// The node was unable to find any other peers on the network.
+    /**
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_NO_PEERS     = SPINEL_STATUS_JOIN__BEGIN + 2,
+
+    /// The only potential peer nodes found are incompatible.
+    /**
+     *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+     */
+    SPINEL_STATUS_JOIN_INCOMPATIBLE = SPINEL_STATUS_JOIN__BEGIN + 3,
+
+    SPINEL_STATUS_JOIN__END         = 112,
+
     SPINEL_STATUS_RESET__BEGIN      = 112,
     SPINEL_STATUS_RESET_POWER_ON    = SPINEL_STATUS_RESET__BEGIN + 0,
     SPINEL_STATUS_RESET_EXTERNAL    = SPINEL_STATUS_RESET__BEGIN + 1,
@@ -326,6 +361,7 @@ typedef enum
     SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
     SPINEL_PROP_MAC_RAW_STREAM_ENABLED = SPINEL_PROP_MAC__BEGIN + 7, ///< [C]
     SPINEL_PROP_MAC_FILTER_MODE        = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
+    SPINEL_PROP_MAC_ENERGY_SCAN_RESULT = SPINEL_PROP_MAC__BEGIN + 9, ///< chan,maxRssi [Cc]
     SPINEL_PROP_MAC__END               = 0x40,
 
     SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
@@ -362,6 +398,28 @@ typedef enum
     SPINEL_PROP_NET_MASTER_KEY       = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
     SPINEL_PROP_NET_KEY_SEQUENCE     = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
     SPINEL_PROP_NET_PARTITION_ID     = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
+
+    /// Require Join Existing
+    /** Format: `b`
+     *  Default Value: `false`
+     *
+     * This flag is typically used for nodes that are associating with an
+     * existing network for the first time. If this is set to `true` before
+     * `PROP_NET_STACK_UP` is set to `true`, the
+     * creation of a new partition at association is prevented. If the node
+     * cannot associate with an existing partition, `PROP_LAST_STATUS` will
+     * emit a status that indicates why the association failed and
+     * `PROP_NET_STACK_UP` will automatically revert to `false`.
+     *
+     * Once associated with an existing partition, this flag automatically
+     * reverts to `false`.
+     *
+     * The behavior of this property being set to `true` when
+     * `PROP_NET_STACK_UP` is already set to `true` is undefined.
+     */
+    SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
+                                     = SPINEL_PROP_NET__BEGIN + 9,
+
     SPINEL_PROP_NET__END             = 0x50,
 
     SPINEL_PROP_THREAD__BEGIN          = 0x50,
@@ -428,6 +486,22 @@ typedef enum
     SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
 
+    /// List of active thread router ids
+    /** Format: `A(C)`
+     *
+     * Note that some implementations may not support CMD_GET_VALUE
+     * routerids, but may support CMD_REMOVE_VALUE when the node is
+     * a leader.
+     */
+    SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
+
+    /// Forward IPv6 packets that use RLOC16 addresses to HOST.
+    /** Format: `b`
+     */
+    SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,
@@ -436,6 +510,18 @@ typedef enum
     SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
     SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(T(6CLLC))]
     SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCC))]
+
+
+    /// IPv6 ICMP Ping Offload
+    /** Format: `b`
+     *
+     * Allow the NCP to directly respond to ICMP ping requests. If this is
+     * turned on, ping request ICMP packets will not be passed to the host.
+     *
+     * Default value is `false`.
+     */
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
+
     SPINEL_PROP_IPV6__END            = 0x70,
 
     SPINEL_PROP_STREAM__BEGIN       = 0x70,

--- a/wpantund.xcodeproj/project.pbxproj
+++ b/wpantund.xcodeproj/project.pbxproj
@@ -1,0 +1,3737 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4C9B21B01B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4C9B21AD1B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.cpp */; };
+		A618B07C175BF2F30097500B /* config-file.c in Sources */ = {isa = PBXBuildFile; fileRef = A618B056175A8DBE0097500B /* config-file.c */; };
+		A618B07D175BF2F30097500B /* wpantund.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B062175A8DBE0097500B /* wpantund.cpp */; };
+		A66B37EB1762466000B0E219 /* EmberNCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B069175BD4640097500B /* EmberNCPControlInterface.cpp */; };
+		A6F82070175D45D2002A732F /* tunnel.c in Sources */ = {isa = PBXBuildFile; fileRef = A6F8206F175D45D2002A732F /* tunnel.c */; };
+		B6026B691BDAD356000D07DD /* FirmwareUpgrade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */; };
+		B61206531CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */; };
+		B61206541CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */; };
+		B61206551CADBF6C00A4E683 /* StatCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206511CADBF6C00A4E683 /* StatCollector.cpp */; };
+		B61206561CADBF6C00A4E683 /* StatCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206511CADBF6C00A4E683 /* StatCollector.cpp */; };
+		B612065B1CADC10E00A4E683 /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206581CADC10E00A4E683 /* Timer.cpp */; };
+		B612065C1CADC10E00A4E683 /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206581CADC10E00A4E683 /* Timer.cpp */; };
+		B61206691CADCD8200A4E683 /* NCPTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206671CADCD8200A4E683 /* NCPTypes.cpp */; };
+		B612066A1CADCD8200A4E683 /* NCPTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206671CADCD8200A4E683 /* NCPTypes.cpp */; };
+		B612066D1CADDDA700A4E683 /* RunawayResetBackoffManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */; };
+		B612066F1CADDDA700A4E683 /* config-file.c in Sources */ = {isa = PBXBuildFile; fileRef = A618B056175A8DBE0097500B /* config-file.c */; };
+		B61206711CADDDA700A4E683 /* any-to.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1F183ABE880081771A /* any-to.cpp */; };
+		B61206731CADDDA700A4E683 /* SocketWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E127376D18C5100C00789919 /* SocketWrapper.cpp */; };
+		B61206761CADDDA700A4E683 /* wpantund.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B062175A8DBE0097500B /* wpantund.cpp */; };
+		B61206781CADDDA700A4E683 /* UnixSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */; };
+		B61206791CADDDA700A4E683 /* SocketAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */; };
+		B612067A1CADDDA700A4E683 /* tunnel.c in Sources */ = {isa = PBXBuildFile; fileRef = A6F8206F175D45D2002A732F /* tunnel.c */; };
+		B612067B1CADDDA700A4E683 /* DBUSHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */; };
+		B612067C1CADDDA700A4E683 /* nlpt-select.c in Sources */ = {isa = PBXBuildFile; fileRef = B6CFE7331AC36CD2007D281D /* nlpt-select.c */; };
+		B612067F1CADDDA700A4E683 /* DBusIPCAPI_v1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */; };
+		B61206801CADDDA700A4E683 /* DBUSIPCServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */; };
+		B61206821CADDDA700A4E683 /* SuperSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */; };
+		B61206871CADDDA700A4E683 /* string-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1C183ABA530081771A /* string-utils.c */; };
+		B61206881CADDDA700A4E683 /* NCPInstanceBase-AsyncIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */; };
+		B61206891CADDDA700A4E683 /* IPv6PacketMatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */; };
+		B612068C1CADDDA700A4E683 /* StatCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206511CADBF6C00A4E683 /* StatCollector.cpp */; };
+		B61206901CADDDA700A4E683 /* TunnelIPv6Interface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */; };
+		B61206911CADDDA700A4E683 /* NCPInstanceBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */; };
+		B61206921CADDDA700A4E683 /* EventHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */; };
+		B61206931CADDDA700A4E683 /* Data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE881832792D00467C2F /* Data.cpp */; };
+		B61206941CADDDA700A4E683 /* time-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E17D837218D8FB1500755867 /* time-utils.c */; };
+		B61206951CADDDA700A4E683 /* socket-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C19183AB3990081771A /* socket-utils.c */; };
+		B61206971CADDDA700A4E683 /* ValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683F71C50457400D0FCAC /* ValueMap.cpp */; };
+		B61206991CADDDA700A4E683 /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206581CADC10E00A4E683 /* Timer.cpp */; };
+		B612069A1CADDDA700A4E683 /* FirmwareUpgrade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */; };
+		B612069B1CADDDA700A4E683 /* NCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B06B175BD69E0097500B /* NCPControlInterface.cpp */; };
+		B612069C1CADDDA700A4E683 /* NCPTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206671CADCD8200A4E683 /* NCPTypes.cpp */; };
+		B612069E1CADDDA700A4E683 /* NCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C09183A9AF60081771A /* NCPInstance.cpp */; };
+		B612069F1CADDDA700A4E683 /* NCPInstanceBase-Addresses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */; };
+		B61206A11CADDDA700A4E683 /* NCPInstanceBase-NetInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */; };
+		B61206A21CADDDA700A4E683 /* DBusIPCAPI_v0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */; };
+		B61206A41CADDDA700A4E683 /* soot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B68B78B91C58046000EC9FB8 /* soot.framework */; };
+		B61206A51CADDDA700A4E683 /* libdbus-1.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19C111B182D71E8002B958B /* libdbus-1.3.dylib */; };
+		B61206BA1CADDE0A00A4E683 /* DummyNCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A3BE6C1C88BAC500976BE9 /* DummyNCPControlInterface.cpp */; };
+		B61206BB1CADDE0E00A4E683 /* DummyNCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A3BE6E1C88BAC500976BE9 /* DummyNCPInstance.cpp */; };
+		B6174A221AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6174A201AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */; };
+		B618F7651CC82E79008B4AD4 /* spinel.c in Sources */ = {isa = PBXBuildFile; fileRef = B618F7641CC82E79008B4AD4 /* spinel.c */; };
+		B618F76D1CCAC260008B4AD4 /* SpinelNCPInstance-DataPump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F76C1CCAC260008B4AD4 /* SpinelNCPInstance-DataPump.cpp */; };
+		B618F7701CCACA6F008B4AD4 /* SpinelNCPInstance-Protothreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F76F1CCACA6F008B4AD4 /* SpinelNCPInstance-Protothreads.cpp */; };
+		B618F7801CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7711CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.cpp */; };
+		B618F7811CCAEC4B008B4AD4 /* SpinelNCPTaskScan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7721CCAEC4B008B4AD4 /* SpinelNCPTaskScan.cpp */; };
+		B618F7821CCAEC4B008B4AD4 /* SpinelNCPTaskForm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7731CCAEC4B008B4AD4 /* SpinelNCPTaskForm.cpp */; };
+		B618F7831CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7741CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.cpp */; };
+		B618F7841CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7751CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.cpp */; };
+		B618F7851CCAEC4B008B4AD4 /* SpinelNCPTaskWake.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7761CCAEC4B008B4AD4 /* SpinelNCPTaskWake.cpp */; };
+		B618F7861CCAEC4B008B4AD4 /* SpinelNCPTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7771CCAEC4B008B4AD4 /* SpinelNCPTask.cpp */; };
+		B618F7881CCAEC78008B4AD4 /* SpinelNCPTaskDeepSleep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B618F7871CCAEC78008B4AD4 /* SpinelNCPTaskDeepSleep.cpp */; };
+		B63BBCC01C77B18600083591 /* EmberNCPControlInterface-GetCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B63BBCBE1C77B18600083591 /* EmberNCPControlInterface-GetCounter.cpp */; };
+		B63BBCC11C77B1C500083591 /* EmberASHAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B7A1F1C694BEA00EC9FB8 /* EmberASHAdapter.cpp */; };
+		B63BBCC21C77B1E200083591 /* ash-v3.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755261C6BDDFD00C879D1 /* ash-v3.c */; };
+		B63BBCCD1C7BA5FD00083591 /* crc.c in Sources */ = {isa = PBXBuildFile; fileRef = B687552C1C6BDDFE00C879D1 /* crc.c */; };
+		B643F6881B754DC2004F1AB1 /* EmberPacked.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B643F6861B754DC2004F1AB1 /* EmberPacked.cpp */; };
+		B64B68121CE1542A00A113B4 /* spinel.c in Sources */ = {isa = PBXBuildFile; fileRef = B618F7641CC82E79008B4AD4 /* spinel.c */; };
+		B64F02CA1C6BE0D000F4FACA /* binary-management.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754471C6BDDFD00C879D1 /* binary-management.c */; };
+		B64F02CB1C6BE11900F4FACA /* tmsp-frame-utilities.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754791C6BDDFD00C879D1 /* tmsp-frame-utilities.c */; };
+		B64F02CC1C6BE11900F4FACA /* tmsp-host-utilities.c in Sources */ = {isa = PBXBuildFile; fileRef = B687547C1C6BDDFD00C879D1 /* tmsp-host-utilities.c */; };
+		B64F02CD1C6BE11900F4FACA /* tmsp-host.c in Sources */ = {isa = PBXBuildFile; fileRef = B687547F1C6BDDFD00C879D1 /* tmsp-host.c */; };
+		B64F02D11C6BE1BF00F4FACA /* counters.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754B91C6BDDFD00C879D1 /* counters.c */; };
+		B64F02D51C6BE23D00F4FACA /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755351C6BDDFE00C879D1 /* random.c */; };
+		B64F02D61C6BE23D00F4FACA /* system-timer.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755391C6BDDFE00C879D1 /* system-timer.c */; };
+		B64F02ED1C6BE2FA00F4FACA /* host-address-table.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755D51C6BDDFE00C879D1 /* host-address-table.c */; };
+		B64F02EE1C6BE2FA00F4FACA /* host-mfglib.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755DA1C6BDDFE00C879D1 /* host-mfglib.c */; };
+		B64F02EF1C6BE2FA00F4FACA /* unix-driver-utilities.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755E01C6BDDFE00C879D1 /* unix-driver-utilities.c */; };
+		B64F02F01C6BE30600F4FACA /* ip-address.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755E61C6BDDFE00C879D1 /* ip-address.c */; };
+		B64F02F21C6BE43B00F4FACA /* tmsp-host-nest-specific.c in Sources */ = {isa = PBXBuildFile; fileRef = B687547B1C6BDDFD00C879D1 /* tmsp-host-nest-specific.c */; };
+		B64F02F31C6BE89600F4FACA /* ember-ip-configuration.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755951C6BDDFE00C879D1 /* ember-ip-configuration.c */; };
+		B653017A1CB7070500B4F3DD /* log.c in Sources */ = {isa = PBXBuildFile; fileRef = B687559B1C6BDDFE00C879D1 /* log.c */; };
+		B65301831CC6E9F200B4F3DD /* RunawayResetBackoffManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */; };
+		B65301841CC6E9F200B4F3DD /* config-file.c in Sources */ = {isa = PBXBuildFile; fileRef = A618B056175A8DBE0097500B /* config-file.c */; };
+		B65301851CC6E9F200B4F3DD /* any-to.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1F183ABE880081771A /* any-to.cpp */; };
+		B65301861CC6E9F200B4F3DD /* SocketWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E127376D18C5100C00789919 /* SocketWrapper.cpp */; };
+		B65301871CC6E9F200B4F3DD /* wpantund.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B062175A8DBE0097500B /* wpantund.cpp */; };
+		B65301891CC6E9F200B4F3DD /* UnixSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */; };
+		B653018A1CC6E9F200B4F3DD /* SocketAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */; };
+		B653018B1CC6E9F200B4F3DD /* tunnel.c in Sources */ = {isa = PBXBuildFile; fileRef = A6F8206F175D45D2002A732F /* tunnel.c */; };
+		B653018C1CC6E9F200B4F3DD /* DBUSHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */; };
+		B653018D1CC6E9F200B4F3DD /* nlpt-select.c in Sources */ = {isa = PBXBuildFile; fileRef = B6CFE7331AC36CD2007D281D /* nlpt-select.c */; };
+		B653018E1CC6E9F200B4F3DD /* DBusIPCAPI_v1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */; };
+		B653018F1CC6E9F200B4F3DD /* DBUSIPCServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */; };
+		B65301901CC6E9F200B4F3DD /* SuperSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */; };
+		B65301911CC6E9F200B4F3DD /* string-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1C183ABA530081771A /* string-utils.c */; };
+		B65301921CC6E9F200B4F3DD /* NCPInstanceBase-AsyncIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */; };
+		B65301931CC6E9F200B4F3DD /* IPv6PacketMatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */; };
+		B65301941CC6E9F200B4F3DD /* StatCollector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206511CADBF6C00A4E683 /* StatCollector.cpp */; };
+		B65301951CC6E9F200B4F3DD /* TunnelIPv6Interface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */; };
+		B65301971CC6E9F200B4F3DD /* NCPInstanceBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */; };
+		B65301981CC6E9F200B4F3DD /* EventHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */; };
+		B65301991CC6E9F200B4F3DD /* Data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE881832792D00467C2F /* Data.cpp */; };
+		B653019A1CC6E9F200B4F3DD /* time-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E17D837218D8FB1500755867 /* time-utils.c */; };
+		B653019B1CC6E9F200B4F3DD /* socket-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C19183AB3990081771A /* socket-utils.c */; };
+		B653019C1CC6E9F200B4F3DD /* ValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683F71C50457400D0FCAC /* ValueMap.cpp */; };
+		B653019D1CC6E9F200B4F3DD /* Timer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206581CADC10E00A4E683 /* Timer.cpp */; };
+		B653019E1CC6E9F200B4F3DD /* FirmwareUpgrade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */; };
+		B653019F1CC6E9F200B4F3DD /* NCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B06B175BD69E0097500B /* NCPControlInterface.cpp */; };
+		B65301A01CC6E9F200B4F3DD /* NCPTypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B61206671CADCD8200A4E683 /* NCPTypes.cpp */; };
+		B65301A11CC6E9F200B4F3DD /* NCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C09183A9AF60081771A /* NCPInstance.cpp */; };
+		B65301A21CC6E9F200B4F3DD /* NCPInstanceBase-Addresses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */; };
+		B65301A31CC6E9F200B4F3DD /* NCPInstanceBase-NetInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */; };
+		B65301A41CC6E9F200B4F3DD /* DBusIPCAPI_v0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */; };
+		B65301A61CC6E9F200B4F3DD /* soot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B68B78B91C58046000EC9FB8 /* soot.framework */; };
+		B65301A71CC6E9F200B4F3DD /* libdbus-1.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19C111B182D71E8002B958B /* libdbus-1.3.dylib */; };
+		B65301B41CC6EA2500B4F3DD /* SpinelNCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B65301B01CC6EA2500B4F3DD /* SpinelNCPControlInterface.cpp */; };
+		B65301B51CC6EA2500B4F3DD /* SpinelNCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B65301B21CC6EA2500B4F3DD /* SpinelNCPInstance.cpp */; };
+		B67DE7621CF4DE1300E4AE53 /* spinel-extra.c in Sources */ = {isa = PBXBuildFile; fileRef = B67DE7601CF4DE1300E4AE53 /* spinel-extra.c */; };
+		B6820BBC1C7F894A0079130D /* host-stream.c in Sources */ = {isa = PBXBuildFile; fileRef = B687544D1C6BDDFD00C879D1 /* host-stream.c */; };
+		B68756951C6BDDFE00C879D1 /* command-interpreter2-binary.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754C61C6BDDFD00C879D1 /* command-interpreter2-binary.c */; };
+		B68756971C6BDDFE00C879D1 /* command-interpreter2-util.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754C81C6BDDFD00C879D1 /* command-interpreter2-util.c */; };
+		B68756981C6BDDFE00C879D1 /* command-interpreter2.c in Sources */ = {isa = PBXBuildFile; fileRef = B68754CA1C6BDDFD00C879D1 /* command-interpreter2.c */; };
+		B68756B31C6BDDFE00C879D1 /* micro.c in Sources */ = {isa = PBXBuildFile; fileRef = B687555C1C6BDDFE00C879D1 /* micro.c */; };
+		B68756C91C6BDDFE00C879D1 /* byte-utilities.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755A41C6BDDFE00C879D1 /* byte-utilities.c */; };
+		B68756CA1C6BDDFE00C879D1 /* event-control.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755A91C6BDDFE00C879D1 /* event-control.c */; };
+		B68756CB1C6BDDFE00C879D1 /* event-queue.c in Sources */ = {isa = PBXBuildFile; fileRef = B68755AA1C6BDDFE00C879D1 /* event-queue.c */; };
+		B68757051C6BDDFE00C879D1 /* Makefile in Sources */ = {isa = PBXBuildFile; fileRef = B687564C1C6BDDFE00C879D1 /* Makefile */; };
+		B688ACD61C8F63670072622D /* NCPInstanceBase-NetInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */; };
+		B688ACD71C8F63670072622D /* NCPInstanceBase-NetInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */; };
+		B688ACD81C8F63670072622D /* NCPInstanceBase-Addresses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */; };
+		B688ACD91C8F63670072622D /* NCPInstanceBase-Addresses.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */; };
+		B688ACDA1C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */; };
+		B688ACDB1C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */; };
+		B68B78BA1C5806F900EC9FB8 /* soot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B68B78B91C58046000EC9FB8 /* soot.framework */; };
+		B68B79BD1C65268500EC9FB8 /* config-file.c in Sources */ = {isa = PBXBuildFile; fileRef = A618B056175A8DBE0097500B /* config-file.c */; };
+		B68B79BF1C65268500EC9FB8 /* any-to.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1F183ABE880081771A /* any-to.cpp */; };
+		B68B79C11C65268500EC9FB8 /* SocketWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E127376D18C5100C00789919 /* SocketWrapper.cpp */; };
+		B68B79C41C65268500EC9FB8 /* wpantund.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B062175A8DBE0097500B /* wpantund.cpp */; };
+		B68B79C61C65268500EC9FB8 /* UnixSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */; };
+		B68B79C71C65268500EC9FB8 /* SocketAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */; };
+		B68B79C81C65268500EC9FB8 /* tunnel.c in Sources */ = {isa = PBXBuildFile; fileRef = A6F8206F175D45D2002A732F /* tunnel.c */; };
+		B68B79C91C65268500EC9FB8 /* DBUSHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */; };
+		B68B79CA1C65268500EC9FB8 /* nlpt-select.c in Sources */ = {isa = PBXBuildFile; fileRef = B6CFE7331AC36CD2007D281D /* nlpt-select.c */; };
+		B68B79CD1C65268500EC9FB8 /* DBusIPCAPI_v1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */; };
+		B68B79CE1C65268500EC9FB8 /* DBUSIPCServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */; };
+		B68B79D01C65268500EC9FB8 /* SuperSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */; };
+		B68B79D51C65268500EC9FB8 /* string-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1C183ABA530081771A /* string-utils.c */; };
+		B68B79D61C65268500EC9FB8 /* IPv6PacketMatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */; };
+		B68B79DC1C65268500EC9FB8 /* TunnelIPv6Interface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */; };
+		B68B79DD1C65268500EC9FB8 /* NCPInstanceBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */; };
+		B68B79DE1C65268500EC9FB8 /* EventHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */; };
+		B68B79DF1C65268500EC9FB8 /* Data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE881832792D00467C2F /* Data.cpp */; };
+		B68B79E01C65268500EC9FB8 /* time-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E17D837218D8FB1500755867 /* time-utils.c */; };
+		B68B79E11C65268500EC9FB8 /* socket-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C19183AB3990081771A /* socket-utils.c */; };
+		B68B79E31C65268500EC9FB8 /* ValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683F71C50457400D0FCAC /* ValueMap.cpp */; };
+		B68B79E51C65268500EC9FB8 /* FirmwareUpgrade.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */; };
+		B68B79E61C65268500EC9FB8 /* NCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B06B175BD69E0097500B /* NCPControlInterface.cpp */; };
+		B68B79E81C65268500EC9FB8 /* NCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C09183A9AF60081771A /* NCPInstance.cpp */; };
+		B68B79EA1C65268500EC9FB8 /* DBusIPCAPI_v0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */; };
+		B68B79EC1C65268500EC9FB8 /* soot.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B68B78B91C58046000EC9FB8 /* soot.framework */; };
+		B68B79ED1C65268500EC9FB8 /* libdbus-1.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19C111B182D71E8002B958B /* libdbus-1.3.dylib */; };
+		B68B79F31C6526F700EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78D21C65244500EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.cpp */; };
+		B68B79F41C6526F700EC9FB8 /* EmberNCPControlInterface-FormTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78D41C65244500EC9FB8 /* EmberNCPControlInterface-FormTask.cpp */; };
+		B68B79F51C6526F700EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78D61C65244500EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */; };
+		B68B79F61C6526F700EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78D81C65244500EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.cpp */; };
+		B68B79F71C6526F700EC9FB8 /* EmberNCPControlInterface-JoinTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78DA1C65244500EC9FB8 /* EmberNCPControlInterface-JoinTask.cpp */; };
+		B68B79F81C6526F700EC9FB8 /* EmberNCPControlInterface-LeaveTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78DC1C65244500EC9FB8 /* EmberNCPControlInterface-LeaveTask.cpp */; };
+		B68B79F91C6526F700EC9FB8 /* EmberNCPControlInterface-LurkTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78DE1C65244500EC9FB8 /* EmberNCPControlInterface-LurkTask.cpp */; };
+		B68B79FA1C6526F700EC9FB8 /* EmberNCPControlInterface-Mfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E01C65244500EC9FB8 /* EmberNCPControlInterface-Mfg.cpp */; };
+		B68B79FB1C6526F700EC9FB8 /* EmberNCPControlInterface-MfgFinish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E11C65244500EC9FB8 /* EmberNCPControlInterface-MfgFinish.cpp */; };
+		B68B79FC1C6526F700EC9FB8 /* EmberNCPControlInterface-ScanTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E31C65244500EC9FB8 /* EmberNCPControlInterface-ScanTask.cpp */; };
+		B68B79FD1C6526F700EC9FB8 /* EmberNCPControlInterface-SendCommandTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E51C65244500EC9FB8 /* EmberNCPControlInterface-SendCommandTask.cpp */; };
+		B68B79FE1C6526F700EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E71C65244500EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */; };
+		B68B79FF1C6526F700EC9FB8 /* EmberNCPControlInterface-WakeupTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78E91C65244500EC9FB8 /* EmberNCPControlInterface-WakeupTask.cpp */; };
+		B68B7A001C6526F700EC9FB8 /* EmberNCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78EB1C65244500EC9FB8 /* EmberNCPControlInterface.cpp */; };
+		B68B7A011C6526F700EC9FB8 /* EmberNCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78ED1C65244500EC9FB8 /* EmberNCPInstance.cpp */; };
+		B68B7A021C6526F700EC9FB8 /* EmberPacked.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78F01C65244500EC9FB8 /* EmberPacked.cpp */; };
+		B68B7A081C6526F700EC9FB8 /* SootAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B78FD1C65244500EC9FB8 /* SootAdapter.cpp */; };
+		B68B7A1C1C69429B00EC9FB8 /* EmberAPIGlue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B68B7A1A1C69429B00EC9FB8 /* EmberAPIGlue.cpp */; };
+		B693A50F1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B693A50D1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */; };
+		B69A46201AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B69A461E1AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.cpp */; };
+		B69A46241B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B69A46221B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.cpp */; };
+		B69A46271B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B69A46251B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.cpp */; };
+		B69D8A9A1D5110020060D2A8 /* sec-random.c in Sources */ = {isa = PBXBuildFile; fileRef = B69D8A981D5110020060D2A8 /* sec-random.c */; };
+		B69D8A9B1D5110020060D2A8 /* sec-random.c in Sources */ = {isa = PBXBuildFile; fileRef = B69D8A981D5110020060D2A8 /* sec-random.c */; };
+		B69D8A9C1D5110020060D2A8 /* sec-random.c in Sources */ = {isa = PBXBuildFile; fileRef = B69D8A981D5110020060D2A8 /* sec-random.c */; };
+		B69D8A9D1D5110020060D2A8 /* sec-random.c in Sources */ = {isa = PBXBuildFile; fileRef = B69D8A981D5110020060D2A8 /* sec-random.c */; };
+		B6A683F81C50457400D0FCAC /* ValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683F71C50457400D0FCAC /* ValueMap.cpp */; };
+		B6A683FC1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */; };
+		B6A683FF1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */; };
+		B6B0D40F1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6B0D40A1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.cpp */; };
+		B6B99A781BC324020043526B /* SootAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6B99A761BC324020043526B /* SootAdapter.cpp */; };
+		B6CFE7341AC36CD2007D281D /* nlpt-select.c in Sources */ = {isa = PBXBuildFile; fileRef = B6CFE7331AC36CD2007D281D /* nlpt-select.c */; };
+		B6D1F6121A8AABCA00F70266 /* FirmwareInterface-1.1.3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6D1F6101A8AABCA00F70266 /* FirmwareInterface-1.1.3.cpp */; };
+		B6D1F6151A8AABF400F70266 /* FirmwareInterface-2.0.0.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6D1F6131A8AABF400F70266 /* FirmwareInterface-2.0.0.cpp */; };
+		B6D1F6181A8AAF2E00F70266 /* FirmwareInterface-Base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6D1F6161A8AAF2E00F70266 /* FirmwareInterface-Base.cpp */; };
+		B6D23B0A1AB8ACCD00441CB5 /* EmberNCPControlInterface-Mfg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6D23B081AB8ACCD00441CB5 /* EmberNCPControlInterface-Mfg.cpp */; };
+		B6E13FC71D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */; };
+		B6E13FC81D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */; };
+		B6E13FC91D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */; };
+		B6E13FCA1D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */; };
+		B6F27E351AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E331AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.cpp */; };
+		B6F27E3E1AAF7E0B00A6B996 /* SocketAdapter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */; };
+		B6F27E411AAF7EB400A6B996 /* UnixSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */; };
+		B6F27E441AAF7F2800A6B996 /* SuperSocket.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */; };
+		B6F27E4E1AB21B8600A6B996 /* EventHandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */; };
+		B6F27E511AB3A23600A6B996 /* NCPInstanceBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */; };
+		E1102C0B183A9AF60081771A /* NCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C09183A9AF60081771A /* NCPInstance.cpp */; };
+		E1102C10183A9FE00081771A /* DBUSHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */; };
+		E1102C13183AAC030081771A /* EmberNCPInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C11183AAC030081771A /* EmberNCPInstance.cpp */; };
+		E1102C16183AAD6F0081771A /* FirmwareInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C14183AAD6F0081771A /* FirmwareInterface.cpp */; };
+		E1102C1A183AB3990081771A /* socket-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C19183AB3990081771A /* socket-utils.c */; };
+		E1102C1D183ABA530081771A /* string-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1C183ABA530081771A /* string-utils.c */; };
+		E1102C20183ABE880081771A /* any-to.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1102C1F183ABE880081771A /* any-to.cpp */; };
+		E123EE87183272D200467C2F /* IPv6PacketMatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */; };
+		E123EE8A1832792D00467C2F /* Data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E123EE881832792D00467C2F /* Data.cpp */; };
+		E127376F18C5100C00789919 /* SocketWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E127376D18C5100C00789919 /* SocketWrapper.cpp */; };
+		E1645420175FE4E90013F188 /* DBUSIPCServer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */; };
+		E17D837318D8FB1500755867 /* time-utils.c in Sources */ = {isa = PBXBuildFile; fileRef = E17D837218D8FB1500755867 /* time-utils.c */; };
+		E194620E17615FA10001279F /* NCPControlInterface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A618B06B175BD69E0097500B /* NCPControlInterface.cpp */; };
+		E19C111D182D71E8002B958B /* libdbus-1.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19C111B182D71E8002B958B /* libdbus-1.3.dylib */; };
+		E1EB488B196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB4889196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.cpp */; };
+		E1EB488E196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB488C196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.cpp */; };
+		E1EB4891196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB488F196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.cpp */; };
+		E1EB4894196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB4892196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.cpp */; };
+		E1EB489A196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB4898196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.cpp */; };
+		E1EB489D196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1EB489B196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.cpp */; };
+		E1FD94081A81777500CB3CC7 /* TunnelIPv6Interface.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B68B78B81C58046000EC9FB8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B649D1C01BEACA8200C2E83A /* soot.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = B649D16C1BEAA1B500C2E83A;
+			remoteInfo = soot;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A618B06F175BF2E10097500B /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		B61206A61CADDDA700A4E683 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		B64B68091CE153F000A113B4 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		B65301A81CC6E9F200B4F3DD /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		B68B79EE1C65268500EC9FB8 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		4C9B21AD1B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "FirmwareInterface-Thread-1.0.0.cpp"; sourceTree = "<group>"; };
+		4C9B21AE1B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FirmwareInterface-Thread-1.0.0.h"; sourceTree = "<group>"; };
+		A618B04A175A8DBE0097500B /* bootstrap.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = bootstrap.sh; sourceTree = "<group>"; };
+		A618B04B175A8DBE0097500B /* configure.ac */ = {isa = PBXFileReference; lastKnownFileType = text; path = configure.ac; sourceTree = "<group>"; };
+		A618B04D175A8DBE0097500B /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		A618B04E175A8DBE0097500B /* wpan-dbus-protocol.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = "wpan-dbus-protocol.md"; sourceTree = "<group>"; };
+		A618B04F175A8DBE0097500B /* wpantund.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = wpantund.1; sourceTree = "<group>"; };
+		A618B050175A8DBE0097500B /* wpanctl.1 */ = {isa = PBXFileReference; lastKnownFileType = text.man; path = wpanctl.1; sourceTree = "<group>"; };
+		A618B051175A8DBE0097500B /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		A618B052175A8DBE0097500B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		A618B054175A8DBE0097500B /* args.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = args.h; sourceTree = "<group>"; };
+		A618B055175A8DBE0097500B /* assert-macros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "assert-macros.h"; path = "../../third_party/assert-macros/assert-macros.h"; sourceTree = "<group>"; };
+		A618B056175A8DBE0097500B /* config-file.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "config-file.c"; sourceTree = "<group>"; };
+		A618B057175A8DBE0097500B /* config-file.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "config-file.h"; sourceTree = "<group>"; };
+		A618B058175A8DBE0097500B /* lc-addrlabels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "lc-addrlabels.h"; sourceTree = "<group>"; };
+		A618B059175A8DBE0097500B /* lc-switch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "lc-switch.h"; sourceTree = "<group>"; };
+		A618B05A175A8DBE0097500B /* lc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lc.h; sourceTree = "<group>"; };
+		A618B05B175A8DBE0097500B /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		A618B05D175A8DBE0097500B /* fgetln.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = fgetln.h; sourceTree = "<group>"; };
+		A618B060175A8DBE0097500B /* pt-sem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "pt-sem.h"; sourceTree = "<group>"; };
+		A618B061175A8DBE0097500B /* pt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = pt.h; sourceTree = "<group>"; };
+		A618B062175A8DBE0097500B /* wpantund.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = wpantund.cpp; sourceTree = "<group>"; };
+		A618B063175A8DBE0097500B /* wpanctl.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = wpanctl.c; sourceTree = "<group>"; };
+		A618B069175BD4640097500B /* EmberNCPControlInterface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EmberNCPControlInterface.cpp; sourceTree = "<group>"; };
+		A618B06A175BD4770097500B /* EmberNCPControlInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberNCPControlInterface.h; sourceTree = "<group>"; };
+		A618B06B175BD69E0097500B /* NCPControlInterface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NCPControlInterface.cpp; sourceTree = "<group>"; };
+		A618B071175BF2E10097500B /* wpantund */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wpantund; sourceTree = BUILT_PRODUCTS_DIR; };
+		A618B07E175BF4700097500B /* config.h.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = config.h.in; sourceTree = "<group>"; };
+		A66B37EC1763B1E200B0E219 /* wpantund.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wpantund.conf; sourceTree = "<group>"; tabWidth = 8; usesTabs = 0; };
+		A6F8206E175D45C8002A732F /* tunnel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = tunnel.h; sourceTree = "<group>"; };
+		A6F8206F175D45D2002A732F /* tunnel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tunnel.c; sourceTree = "<group>"; };
+		B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FirmwareUpgrade.cpp; sourceTree = "<group>"; };
+		B6026B681BDAD356000D07DD /* FirmwareUpgrade.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirmwareUpgrade.h; sourceTree = "<group>"; };
+		B602785F1C56BF510066DA9E /* wpan-error.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpan-error.h"; sourceTree = "<group>"; };
+		B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RunawayResetBackoffManager.cpp; sourceTree = "<group>"; };
+		B61206501CADBF6C00A4E683 /* RunawayResetBackoffManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RunawayResetBackoffManager.h; sourceTree = "<group>"; };
+		B61206511CADBF6C00A4E683 /* StatCollector.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StatCollector.cpp; sourceTree = "<group>"; };
+		B61206521CADBF6C00A4E683 /* StatCollector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatCollector.h; sourceTree = "<group>"; };
+		B61206581CADC10E00A4E683 /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
+		B61206591CADC10E00A4E683 /* ObjectPool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectPool.h; sourceTree = "<group>"; };
+		B612065A1CADC10E00A4E683 /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
+		B61206651CADC84400A4E683 /* wpantund.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = wpantund.h; sourceTree = "<group>"; };
+		B61206671CADCD8200A4E683 /* NCPTypes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NCPTypes.cpp; sourceTree = "<group>"; };
+		B61206681CADCD8200A4E683 /* NCPTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCPTypes.h; sourceTree = "<group>"; };
+		B61206AA1CADDDA700A4E683 /* wpantund copy */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "wpantund copy"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B612E2891AC9E47000E418E0 /* wpan-properties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpan-properties.h"; sourceTree = "<group>"; };
+		B612E28A1AC9E4A000E418E0 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B612E28B1AC9E4B000E418E0 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B6174A201AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-SetNetworkKeyTask.cpp"; sourceTree = "<group>"; };
+		B6174A211AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-SetNetworkKeyTask.h"; sourceTree = "<group>"; };
+		B618F7641CC82E79008B4AD4 /* spinel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = spinel.c; path = ../../third_party/openthread/src/ncp/spinel.c; sourceTree = "<group>"; };
+		B618F76C1CCAC260008B4AD4 /* SpinelNCPInstance-DataPump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "SpinelNCPInstance-DataPump.cpp"; sourceTree = "<group>"; };
+		B618F76F1CCACA6F008B4AD4 /* SpinelNCPInstance-Protothreads.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "SpinelNCPInstance-Protothreads.cpp"; sourceTree = "<group>"; };
+		B618F7711CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskSendCommand.cpp; sourceTree = "<group>"; };
+		B618F7721CCAEC4B008B4AD4 /* SpinelNCPTaskScan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskScan.cpp; sourceTree = "<group>"; };
+		B618F7731CCAEC4B008B4AD4 /* SpinelNCPTaskForm.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskForm.cpp; sourceTree = "<group>"; };
+		B618F7741CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskLeave.cpp; sourceTree = "<group>"; };
+		B618F7751CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskJoin.cpp; sourceTree = "<group>"; };
+		B618F7761CCAEC4B008B4AD4 /* SpinelNCPTaskWake.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskWake.cpp; sourceTree = "<group>"; };
+		B618F7771CCAEC4B008B4AD4 /* SpinelNCPTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTask.cpp; sourceTree = "<group>"; };
+		B618F7781CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskSendCommand.h; sourceTree = "<group>"; };
+		B618F7791CCAEC4B008B4AD4 /* SpinelNCPTaskScan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskScan.h; sourceTree = "<group>"; };
+		B618F77A1CCAEC4B008B4AD4 /* SpinelNCPTaskForm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskForm.h; sourceTree = "<group>"; };
+		B618F77B1CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskLeave.h; sourceTree = "<group>"; };
+		B618F77C1CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskJoin.h; sourceTree = "<group>"; };
+		B618F77D1CCAEC4B008B4AD4 /* SpinelNCPTaskWake.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskWake.h; sourceTree = "<group>"; };
+		B618F77E1CCAEC4B008B4AD4 /* SpinelNCPTaskDeepSleep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskDeepSleep.h; sourceTree = "<group>"; };
+		B618F77F1CCAEC4B008B4AD4 /* SpinelNCPTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTask.h; sourceTree = "<group>"; };
+		B618F7871CCAEC78008B4AD4 /* SpinelNCPTaskDeepSleep.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskDeepSleep.cpp; sourceTree = "<group>"; };
+		B63BBCBE1C77B18600083591 /* EmberNCPControlInterface-GetCounter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-GetCounter.cpp"; sourceTree = "<group>"; };
+		B63BBCBF1C77B18600083591 /* EmberNCPControlInterface-GetCounter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-GetCounter.h"; sourceTree = "<group>"; };
+		B643F6861B754DC2004F1AB1 /* EmberPacked.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmberPacked.cpp; sourceTree = "<group>"; };
+		B643F6871B754DC2004F1AB1 /* EmberPacked.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmberPacked.h; sourceTree = "<group>"; };
+		B649D15F1BE83BFD00C2E83A /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B649D1C01BEACA8200C2E83A /* soot.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = soot.xcodeproj; path = "src/ncp-silabs/libsoot/soot.xcodeproj"; sourceTree = "<group>"; };
+		B64B680B1CE153F000A113B4 /* spinel-unit-test */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "spinel-unit-test"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B65301AC1CC6E9F200B4F3DD /* wpantund-ncp-dummy copy */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "wpantund-ncp-dummy copy"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B65301AF1CC6EA2500B4F3DD /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B65301B01CC6EA2500B4F3DD /* SpinelNCPControlInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPControlInterface.cpp; sourceTree = "<group>"; };
+		B65301B11CC6EA2500B4F3DD /* SpinelNCPControlInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPControlInterface.h; sourceTree = "<group>"; };
+		B65301B21CC6EA2500B4F3DD /* SpinelNCPInstance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPInstance.cpp; sourceTree = "<group>"; };
+		B65301B31CC6EA2500B4F3DD /* SpinelNCPInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPInstance.h; sourceTree = "<group>"; };
+		B65301B71CC6EACE00B4F3DD /* spinel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = spinel.h; path = ../../third_party/openthread/src/ncp/spinel.h; sourceTree = "<group>"; };
+		B67DE7601CF4DE1300E4AE53 /* spinel-extra.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "spinel-extra.c"; sourceTree = "<group>"; };
+		B67DE7611CF4DE1300E4AE53 /* spinel-extra.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "spinel-extra.h"; sourceTree = "<group>"; };
+		B68754351C6BDDFD00C879D1 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		B68754361C6BDDFD00C879D1 /* README.google */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.google; sourceTree = "<group>"; };
+		B687543B1C6BDDFD00C879D1 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
+		B687543C1C6BDDFD00C879D1 /* list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = list.c; sourceTree = "<group>"; };
+		B687543D1C6BDDFD00C879D1 /* list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = list.h; sourceTree = "<group>"; };
+		B687543E1C6BDDFD00C879D1 /* scratchpad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = scratchpad.h; sourceTree = "<group>"; };
+		B687543F1C6BDDFD00C879D1 /* structs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = structs.h; sourceTree = "<group>"; };
+		B68754401C6BDDFD00C879D1 /* unix-host-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "unix-host-utilities.h"; sourceTree = "<group>"; };
+		B68754411C6BDDFD00C879D1 /* uri-handler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uri-handler.h"; sourceTree = "<group>"; };
+		B68754421C6BDDFD00C879D1 /* uri-parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uri-parser.h"; sourceTree = "<group>"; };
+		B68754441C6BDDFD00C879D1 /* ash-v3-test-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ash-v3-test-app-configuration.h"; sourceTree = "<group>"; };
+		B68754451C6BDDFD00C879D1 /* ash-v3-test-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ash-v3-test-app.c"; sourceTree = "<group>"; };
+		B68754461C6BDDFD00C879D1 /* ash-v3-test-app.mak */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = "ash-v3-test-app.mak"; sourceTree = "<group>"; };
+		B68754471C6BDDFD00C879D1 /* binary-management.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "binary-management.c"; sourceTree = "<group>"; };
+		B68754481C6BDDFD00C879D1 /* binary-management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "binary-management.h"; sourceTree = "<group>"; };
+		B68754491C6BDDFD00C879D1 /* data-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "data-client.c"; sourceTree = "<group>"; };
+		B687544A1C6BDDFD00C879D1 /* data-client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "data-client.h"; sourceTree = "<group>"; };
+		B687544B1C6BDDFD00C879D1 /* fetch-store-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "fetch-store-utilities.c"; sourceTree = "<group>"; };
+		B687544C1C6BDDFD00C879D1 /* fetch-store-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "fetch-store-utilities.h"; sourceTree = "<group>"; };
+		B687544D1C6BDDFD00C879D1 /* host-stream.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "host-stream.c"; sourceTree = "<group>"; };
+		B687544E1C6BDDFD00C879D1 /* host-stream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "host-stream.h"; sourceTree = "<group>"; };
+		B687544F1C6BDDFD00C879D1 /* ip-driver-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-driver-app-configuration.h"; sourceTree = "<group>"; };
+		B68754501C6BDDFD00C879D1 /* ip-driver-app-simulation.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-driver-app-simulation.c"; sourceTree = "<group>"; };
+		B68754511C6BDDFD00C879D1 /* ip-driver-app-unix-host.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-driver-app-unix-host.c"; sourceTree = "<group>"; };
+		B68754521C6BDDFD00C879D1 /* ip-driver-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-driver-app.c"; sourceTree = "<group>"; };
+		B68754531C6BDDFD00C879D1 /* ip-driver-app.mak */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = "ip-driver-app.mak"; sourceTree = "<group>"; };
+		B68754541C6BDDFD00C879D1 /* ip-driver-log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-driver-log.c"; sourceTree = "<group>"; };
+		B68754551C6BDDFD00C879D1 /* ip-driver-log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-driver-log.h"; sourceTree = "<group>"; };
+		B68754561C6BDDFD00C879D1 /* ip-driver.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-driver.c"; sourceTree = "<group>"; };
+		B68754571C6BDDFD00C879D1 /* ip-driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-driver.h"; sourceTree = "<group>"; };
+		B68754581C6BDDFD00C879D1 /* ip-management-enum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-management-enum.h"; sourceTree = "<group>"; };
+		B68754591C6BDDFD00C879D1 /* ip-modem-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-modem-app.c"; sourceTree = "<group>"; };
+		B687545B1C6BDDFD00C879D1 /* ip-modem-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-modem-configuration.h"; sourceTree = "<group>"; };
+		B687545C1C6BDDFD00C879D1 /* ip-modem-library.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-modem-library.h"; sourceTree = "<group>"; };
+		B687545D1C6BDDFD00C879D1 /* ip-modem-link.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-modem-link.c"; sourceTree = "<group>"; };
+		B687545E1C6BDDFD00C879D1 /* ip-modem-link.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-modem-link.h"; sourceTree = "<group>"; };
+		B687545F1C6BDDFD00C879D1 /* management-serial.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "management-serial.c"; sourceTree = "<group>"; };
+		B68754601C6BDDFD00C879D1 /* ncp-deep-sleep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ncp-deep-sleep.c"; sourceTree = "<group>"; };
+		B68754611C6BDDFD00C879D1 /* ncp-emapi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ncp-emapi.c"; sourceTree = "<group>"; };
+		B68754621C6BDDFD00C879D1 /* ncp-events.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ncp-events.c"; sourceTree = "<group>"; };
+		B68754631C6BDDFD00C879D1 /* ncp-events.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ncp-events.h"; sourceTree = "<group>"; };
+		B68754641C6BDDFD00C879D1 /* ncp-mfglib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ncp-mfglib.c"; sourceTree = "<group>"; };
+		B68754651C6BDDFD00C879D1 /* ncp-mfglib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ncp-mfglib.h"; sourceTree = "<group>"; };
+		B68754661C6BDDFD00C879D1 /* ncp-uart-interface.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ncp-uart-interface.c"; sourceTree = "<group>"; };
+		B68754671C6BDDFD00C879D1 /* ncp-uart-interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ncp-uart-interface.h"; sourceTree = "<group>"; };
+		B68754681C6BDDFD00C879D1 /* serial-link.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "serial-link.c"; sourceTree = "<group>"; };
+		B68754691C6BDDFD00C879D1 /* serial-link.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "serial-link.h"; sourceTree = "<group>"; };
+		B687546A1C6BDDFD00C879D1 /* spi-link-adapter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "spi-link-adapter.c"; sourceTree = "<group>"; };
+		B687546B1C6BDDFD00C879D1 /* thread-ip-modem-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "thread-ip-modem-configuration.h"; sourceTree = "<group>"; };
+		B687546C1C6BDDFD00C879D1 /* uart-link-protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uart-link-protocol.h"; sourceTree = "<group>"; };
+		B687546D1C6BDDFD00C879D1 /* uart-link-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "uart-link-stub.c"; sourceTree = "<group>"; };
+		B687546F1C6BDDFD00C879D1 /* common-test-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "common-test-commands.c"; sourceTree = "<group>"; };
+		B68754701C6BDDFD00C879D1 /* common-test-commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "common-test-commands.h"; sourceTree = "<group>"; };
+		B68754711C6BDDFD00C879D1 /* scan-test-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "scan-test-stub.c"; sourceTree = "<group>"; };
+		B68754721C6BDDFD00C879D1 /* scan-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "scan-test.c"; sourceTree = "<group>"; };
+		B68754731C6BDDFD00C879D1 /* thread-test-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-test-app.c"; sourceTree = "<group>"; };
+		B68754751C6BDDFD00C879D1 /* tmsp-custom-enum-decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-custom-enum-decode.c"; sourceTree = "<group>"; };
+		B68754761C6BDDFD00C879D1 /* tmsp-custom-enum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tmsp-custom-enum.h"; sourceTree = "<group>"; };
+		B68754771C6BDDFD00C879D1 /* tmsp-enum-decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-enum-decode.c"; sourceTree = "<group>"; };
+		B68754781C6BDDFD00C879D1 /* tmsp-enum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tmsp-enum.h"; sourceTree = "<group>"; };
+		B68754791C6BDDFD00C879D1 /* tmsp-frame-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-frame-utilities.c"; sourceTree = "<group>"; };
+		B687547A1C6BDDFD00C879D1 /* tmsp-frame-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tmsp-frame-utilities.h"; sourceTree = "<group>"; };
+		B687547B1C6BDDFD00C879D1 /* tmsp-host-nest-specific.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-host-nest-specific.c"; sourceTree = "<group>"; };
+		B687547C1C6BDDFD00C879D1 /* tmsp-host-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-host-utilities.c"; sourceTree = "<group>"; };
+		B687547E1C6BDDFD00C879D1 /* tmsp-host-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tmsp-host-utilities.h"; sourceTree = "<group>"; };
+		B687547F1C6BDDFD00C879D1 /* tmsp-host.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-host.c"; sourceTree = "<group>"; };
+		B68754801C6BDDFD00C879D1 /* tmsp-ncp-nest-specific.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-ncp-nest-specific.c"; sourceTree = "<group>"; };
+		B68754811C6BDDFD00C879D1 /* tmsp-ncp-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-ncp-utilities.c"; sourceTree = "<group>"; };
+		B68754821C6BDDFD00C879D1 /* tmsp-ncp-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tmsp-ncp-utilities.h"; sourceTree = "<group>"; };
+		B68754831C6BDDFD00C879D1 /* tmsp-ncp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tmsp-ncp.c"; sourceTree = "<group>"; };
+		B68754851C6BDDFD00C879D1 /* nest-host-stub-app.mak */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = "nest-host-stub-app.mak"; sourceTree = "<group>"; };
+		B68754861C6BDDFD00C879D1 /* nest-stub-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nest-stub-app.c"; sourceTree = "<group>"; };
+		B68754871C6BDDFD00C879D1 /* nest-thread-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nest-thread-app-configuration.h"; sourceTree = "<group>"; };
+		B68754881C6BDDFD00C879D1 /* nest-tokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "nest-tokens.h"; sourceTree = "<group>"; };
+		B68754891C6BDDFD00C879D1 /* qa-thread-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "qa-thread-app-configuration.h"; sourceTree = "<group>"; };
+		B687548A1C6BDDFD00C879D1 /* thread-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "thread-app-configuration.h"; sourceTree = "<group>"; };
+		B687548B1C6BDDFD00C879D1 /* thread-app-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-app-stubs.c"; sourceTree = "<group>"; };
+		B687548C1C6BDDFD00C879D1 /* thread-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-app.c"; sourceTree = "<group>"; };
+		B687548D1C6BDDFD00C879D1 /* thread-deep-sleep.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-deep-sleep.c"; sourceTree = "<group>"; };
+		B687548E1C6BDDFD00C879D1 /* thread-ecc-certificate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-ecc-certificate.c"; sourceTree = "<group>"; };
+		B687548F1C6BDDFD00C879D1 /* thread-ecc-certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "thread-ecc-certificate.h"; sourceTree = "<group>"; };
+		B68754901C6BDDFD00C879D1 /* thread-host-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "thread-host-app-configuration.h"; sourceTree = "<group>"; };
+		B68754911C6BDDFD00C879D1 /* thread-host-app.mak */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = "thread-host-app.mak"; sourceTree = "<group>"; };
+		B68754961C6BDDFD00C879D1 /* tftp-client-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-client-app-configuration.h"; sourceTree = "<group>"; };
+		B68754971C6BDDFD00C879D1 /* tftp-client-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-client-app.c"; sourceTree = "<group>"; };
+		B68754981C6BDDFD00C879D1 /* tftp-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-client.c"; sourceTree = "<group>"; };
+		B68754991C6BDDFD00C879D1 /* tftp-client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-client.h"; sourceTree = "<group>"; };
+		B687549A1C6BDDFD00C879D1 /* tftp-file-reader.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-file-reader.c"; sourceTree = "<group>"; };
+		B687549B1C6BDDFD00C879D1 /* tftp-file-reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-file-reader.h"; sourceTree = "<group>"; };
+		B687549D1C6BDDFD00C879D1 /* tftp-server-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-server-app-configuration.h"; sourceTree = "<group>"; };
+		B687549E1C6BDDFD00C879D1 /* tftp-server-app.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-server-app.c"; sourceTree = "<group>"; };
+		B687549F1C6BDDFD00C879D1 /* tftp-server-posix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-server-posix.c"; sourceTree = "<group>"; };
+		B68754A01C6BDDFD00C879D1 /* tftp-server-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-server-stub.c"; sourceTree = "<group>"; };
+		B68754A11C6BDDFD00C879D1 /* tftp-server.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-server.c"; sourceTree = "<group>"; };
+		B68754A21C6BDDFD00C879D1 /* tftp-server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-server.h"; sourceTree = "<group>"; };
+		B68754A31C6BDDFD00C879D1 /* tftp-15-4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-15-4.c"; sourceTree = "<group>"; };
+		B68754A41C6BDDFD00C879D1 /* tftp-posix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-posix.c"; sourceTree = "<group>"; };
+		B68754A51C6BDDFD00C879D1 /* tftp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tftp.c; sourceTree = "<group>"; };
+		B68754A61C6BDDFD00C879D1 /* tftp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tftp.h; sourceTree = "<group>"; };
+		B68754A91C6BDDFD00C879D1 /* tftp-bootloader-client-app-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-bootloader-client-app-configuration.h"; sourceTree = "<group>"; };
+		B68754AA1C6BDDFD00C879D1 /* tftp-bootloader-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader-client.c"; sourceTree = "<group>"; };
+		B68754AB1C6BDDFD00C879D1 /* tftp-bootloader-client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-bootloader-client.h"; sourceTree = "<group>"; };
+		B68754AD1C6BDDFD00C879D1 /* tftp-bootloader-server-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader-server-stub.c"; sourceTree = "<group>"; };
+		B68754AE1C6BDDFD00C879D1 /* tftp-bootloader-server.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader-server.c"; sourceTree = "<group>"; };
+		B68754AF1C6BDDFD00C879D1 /* tftp-bootloader-server.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-bootloader-server.h"; sourceTree = "<group>"; };
+		B68754B01C6BDDFD00C879D1 /* tftp-bootloader-15-4.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader-15-4.c"; sourceTree = "<group>"; };
+		B68754B11C6BDDFD00C879D1 /* tftp-bootloader-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader-stub.c"; sourceTree = "<group>"; };
+		B68754B21C6BDDFD00C879D1 /* tftp-bootloader.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tftp-bootloader.c"; sourceTree = "<group>"; };
+		B68754B31C6BDDFD00C879D1 /* tftp-bootloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tftp-bootloader.h"; sourceTree = "<group>"; };
+		B68754B51C6BDDFD00C879D1 /* counters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = counters.h; sourceTree = "<group>"; };
+		B68754B71C6BDDFD00C879D1 /* common-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "common-commands.c"; sourceTree = "<group>"; };
+		B68754B81C6BDDFD00C879D1 /* common-commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "common-commands.h"; sourceTree = "<group>"; };
+		B68754B91C6BDDFD00C879D1 /* counters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = counters.c; sourceTree = "<group>"; };
+		B68754BA1C6BDDFD00C879D1 /* internal-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "internal-commands.c"; sourceTree = "<group>"; };
+		B68754BB1C6BDDFD00C879D1 /* mfglib-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "mfglib-commands.c"; sourceTree = "<group>"; };
+		B68754BC1C6BDDFD00C879D1 /* mfglib-commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "mfglib-commands.h"; sourceTree = "<group>"; };
+		B68754BD1C6BDDFD00C879D1 /* network-management-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "network-management-commands.c"; sourceTree = "<group>"; };
+		B68754BE1C6BDDFD00C879D1 /* network-management-commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "network-management-commands.h"; sourceTree = "<group>"; };
+		B68754BF1C6BDDFD00C879D1 /* print-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "print-utilities.c"; sourceTree = "<group>"; };
+		B68754C01C6BDDFD00C879D1 /* print-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "print-utilities.h"; sourceTree = "<group>"; };
+		B68754C11C6BDDFD00C879D1 /* wakeup-commands.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "wakeup-commands.c"; sourceTree = "<group>"; };
+		B68754C21C6BDDFD00C879D1 /* wakeup-commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "wakeup-commands.h"; sourceTree = "<group>"; };
+		B68754C41C6BDDFD00C879D1 /* command-interpreter.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "command-interpreter.c"; sourceTree = "<group>"; };
+		B68754C51C6BDDFD00C879D1 /* command-interpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "command-interpreter.h"; sourceTree = "<group>"; };
+		B68754C61C6BDDFD00C879D1 /* command-interpreter2-binary.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "command-interpreter2-binary.c"; sourceTree = "<group>"; };
+		B68754C71C6BDDFD00C879D1 /* command-interpreter2-error.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "command-interpreter2-error.c"; sourceTree = "<group>"; };
+		B68754C81C6BDDFD00C879D1 /* command-interpreter2-util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "command-interpreter2-util.c"; sourceTree = "<group>"; };
+		B68754C91C6BDDFD00C879D1 /* command-interpreter2-util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "command-interpreter2-util.h"; sourceTree = "<group>"; };
+		B68754CA1C6BDDFD00C879D1 /* command-interpreter2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "command-interpreter2.c"; sourceTree = "<group>"; };
+		B68754CB1C6BDDFD00C879D1 /* command-interpreter2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "command-interpreter2.h"; sourceTree = "<group>"; };
+		B68754CD1C6BDDFD00C879D1 /* ember-printf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ember-printf.c"; sourceTree = "<group>"; };
+		B68754CE1C6BDDFD00C879D1 /* ember-printf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ember-printf.h"; sourceTree = "<group>"; };
+		B68754CF1C6BDDFD00C879D1 /* serial.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = serial.c; sourceTree = "<group>"; };
+		B68754D01C6BDDFD00C879D1 /* serial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serial.h; sourceTree = "<group>"; };
+		B68754D11C6BDDFD00C879D1 /* simple-linux-serial.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "simple-linux-serial.c"; sourceTree = "<group>"; };
+		B68754D51C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754D61C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754D71C6BDDFD00C879D1 /* boardHeaders.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = boardHeaders.properties; sourceTree = "<group>"; };
+		B68754D81C6BDDFD00C879D1 /* bootloader.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = bootloader.properties; sourceTree = "<group>"; };
+		B68754D91C6BDDFD00C879D1 /* button-callback.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "button-callback.info"; sourceTree = "<group>"; };
+		B68754DB1C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754DC1C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754DE1C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754E01C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754E11C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754E21C6BDDFD00C879D1 /* hal-callback.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "hal-callback.info"; sourceTree = "<group>"; };
+		B68754E31C6BDDFD00C879D1 /* halOptions.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = halOptions.properties; sourceTree = "<group>"; };
+		B68754E51C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754E71C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754E91C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754EA1C6BDDFD00C879D1 /* microphone-codec-msadpcm-callback.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "microphone-codec-msadpcm-callback.info"; sourceTree = "<group>"; };
+		B68754EB1C6BDDFD00C879D1 /* plugin.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.info; sourceTree = "<group>"; };
+		B68754ED1C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754EE1C6BDDFD00C879D1 /* cli.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = cli.xml; sourceTree = "<group>"; };
+		B68754EF1C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754F01C6BDDFD00C879D1 /* serial.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = serial.properties; sourceTree = "<group>"; };
+		B68754F11C6BDDFD00C879D1 /* sim-eeprom-callback.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "sim-eeprom-callback.info"; sourceTree = "<group>"; };
+		B68754F21C6BDDFD00C879D1 /* spi-protocol-callback.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "spi-protocol-callback.info"; sourceTree = "<group>"; };
+		B68754F41C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754F51C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754F71C6BDDFD00C879D1 /* callbacks.info */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = callbacks.info; sourceTree = "<group>"; };
+		B68754F81C6BDDFD00C879D1 /* plugin.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = plugin.properties; sourceTree = "<group>"; };
+		B68754F91C6BDDFD00C879D1 /* ember-base-configuration.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ember-base-configuration.c"; sourceTree = "<group>"; };
+		B68754FA1C6BDDFD00C879D1 /* ember-configuration.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ember-configuration.c"; sourceTree = "<group>"; };
+		B68754FB1C6BDDFD00C879D1 /* hal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = hal.h; sourceTree = "<group>"; };
+		B68754FD1C6BDDFD00C879D1 /* bootloader-eeprom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "bootloader-eeprom.h"; sourceTree = "<group>"; };
+		B68754FE1C6BDDFD00C879D1 /* button-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "button-common.h"; sourceTree = "<group>"; };
+		B68754FF1C6BDDFD00C879D1 /* crc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc.h; sourceTree = "<group>"; };
+		B68755021C6BDDFD00C879D1 /* platform-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "platform-common.h"; sourceTree = "<group>"; };
+		B68755031C6BDDFD00C879D1 /* crc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crc.c; sourceTree = "<group>"; };
+		B68755041C6BDDFD00C879D1 /* led-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "led-common.h"; sourceTree = "<group>"; };
+		B68755051C6BDDFD00C879D1 /* micro-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "micro-common.h"; sourceTree = "<group>"; };
+		B68755061C6BDDFD00C879D1 /* serial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serial.h; sourceTree = "<group>"; };
+		B68755071C6BDDFD00C879D1 /* spi-protocol-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "spi-protocol-common.h"; sourceTree = "<group>"; };
+		B68755081C6BDDFD00C879D1 /* system-timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "system-timer.h"; sourceTree = "<group>"; };
+		B687550A1C6BDDFD00C879D1 /* accelerometer-led.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "accelerometer-led.h"; sourceTree = "<group>"; };
+		B687550B1C6BDDFD00C879D1 /* adc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = adc.h; sourceTree = "<group>"; };
+		B687550C1C6BDDFD00C879D1 /* antenna.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = antenna.h; sourceTree = "<group>"; };
+		B687550D1C6BDDFD00C879D1 /* battery-monitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "battery-monitor.h"; sourceTree = "<group>"; };
+		B687550E1C6BDDFD00C879D1 /* bootloader-eeprom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "bootloader-eeprom.h"; sourceTree = "<group>"; };
+		B687550F1C6BDDFD00C879D1 /* bootloader-interface-app.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "bootloader-interface-app.h"; sourceTree = "<group>"; };
+		B68755101C6BDDFD00C879D1 /* bootloader-interface-standalone.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "bootloader-interface-standalone.h"; sourceTree = "<group>"; };
+		B68755111C6BDDFD00C879D1 /* bootloader-interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "bootloader-interface.h"; sourceTree = "<group>"; };
+		B68755121C6BDDFD00C879D1 /* button-interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "button-interface.h"; sourceTree = "<group>"; };
+		B68755131C6BDDFD00C879D1 /* button.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = button.h; sourceTree = "<group>"; };
+		B68755141C6BDDFD00C879D1 /* buzzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = buzzer.h; sourceTree = "<group>"; };
+		B68755151C6BDDFD00C879D1 /* caladc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = caladc.h; sourceTree = "<group>"; };
+		B68755161C6BDDFD00C879D1 /* crc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = crc.h; sourceTree = "<group>"; };
+		B68755171C6BDDFD00C879D1 /* diagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = diagnostic.h; sourceTree = "<group>"; };
+		B68755181C6BDDFD00C879D1 /* dog_glcd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dog_glcd.h; sourceTree = "<group>"; };
+		B68755191C6BDDFD00C879D1 /* endian.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endian.h; sourceTree = "<group>"; };
+		B687551A1C6BDDFD00C879D1 /* flash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = flash.h; sourceTree = "<group>"; };
+		B687551D1C6BDDFD00C879D1 /* rijndael-alg-fst.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "rijndael-alg-fst.c"; sourceTree = "<group>"; };
+		B687551E1C6BDDFD00C879D1 /* rijndael-alg-fst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "rijndael-alg-fst.h"; sourceTree = "<group>"; };
+		B687551F1C6BDDFD00C879D1 /* rijndael-api-fst.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "rijndael-api-fst.c"; sourceTree = "<group>"; };
+		B68755201C6BDDFD00C879D1 /* rijndael-api-fst.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "rijndael-api-fst.h"; sourceTree = "<group>"; };
+		B68755211C6BDDFD00C879D1 /* antenna-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "antenna-stub.c"; sourceTree = "<group>"; };
+		B68755221C6BDDFD00C879D1 /* ash-common.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ash-common.c"; sourceTree = "<group>"; };
+		B68755231C6BDDFD00C879D1 /* ash-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ash-common.h"; sourceTree = "<group>"; };
+		B68755241C6BDDFD00C879D1 /* ash-protocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ash-protocol.h"; sourceTree = "<group>"; };
+		B68755251C6BDDFD00C879D1 /* ash-v3-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ash-v3-stubs.c"; sourceTree = "<group>"; };
+		B68755261C6BDDFD00C879D1 /* ash-v3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ash-v3.c"; sourceTree = "<group>"; };
+		B68755271C6BDDFD00C879D1 /* ash-v3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ash-v3.h"; sourceTree = "<group>"; };
+		B68755281C6BDDFD00C879D1 /* button-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "button-stub.c"; sourceTree = "<group>"; };
+		B68755291C6BDDFD00C879D1 /* buzzer-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "buzzer-stub.c"; sourceTree = "<group>"; };
+		B687552B1C6BDDFE00C879D1 /* platform-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "platform-common.h"; sourceTree = "<group>"; };
+		B687552C1C6BDDFE00C879D1 /* crc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crc.c; sourceTree = "<group>"; };
+		B687552D1C6BDDFE00C879D1 /* diagnostic-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "diagnostic-stub.c"; sourceTree = "<group>"; };
+		B687552E1C6BDDFE00C879D1 /* em2xx-reset-defs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "em2xx-reset-defs.h"; sourceTree = "<group>"; };
+		B687552F1C6BDDFE00C879D1 /* endian.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = endian.c; sourceTree = "<group>"; };
+		B68755301C6BDDFE00C879D1 /* i2c-driver-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "i2c-driver-stub.c"; sourceTree = "<group>"; };
+		B68755311C6BDDFE00C879D1 /* led-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "led-stub.c"; sourceTree = "<group>"; };
+		B68755321C6BDDFE00C879D1 /* mem-util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "mem-util.c"; sourceTree = "<group>"; };
+		B68755331C6BDDFE00C879D1 /* micro-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "micro-stub.c"; sourceTree = "<group>"; };
+		B68755341C6BDDFE00C879D1 /* micro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = micro.h; sourceTree = "<group>"; };
+		B68755351C6BDDFE00C879D1 /* random.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = random.c; sourceTree = "<group>"; };
+		B68755361C6BDDFE00C879D1 /* sim-eeprom-internal.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "sim-eeprom-internal.c"; sourceTree = "<group>"; };
+		B68755371C6BDDFE00C879D1 /* sim-eeprom.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "sim-eeprom.c"; sourceTree = "<group>"; };
+		B68755381C6BDDFE00C879D1 /* sim-eeprom2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "sim-eeprom2.c"; sourceTree = "<group>"; };
+		B68755391C6BDDFE00C879D1 /* system-timer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "system-timer.c"; sourceTree = "<group>"; };
+		B687553A1C6BDDFE00C879D1 /* token-ram.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "token-ram.h"; sourceTree = "<group>"; };
+		B687553B1C6BDDFE00C879D1 /* generic-interrupt-control.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "generic-interrupt-control.h"; sourceTree = "<group>"; };
+		B687553C1C6BDDFE00C879D1 /* gpio-sensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "gpio-sensor.h"; sourceTree = "<group>"; };
+		B687553D1C6BDDFE00C879D1 /* i2c-driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "i2c-driver.h"; sourceTree = "<group>"; };
+		B687553E1C6BDDFE00C879D1 /* infrared-led-driver-emit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "infrared-led-driver-emit.h"; sourceTree = "<group>"; };
+		B687553F1C6BDDFE00C879D1 /* infrared-led-driver-sird.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "infrared-led-driver-sird.h"; sourceTree = "<group>"; };
+		B68755401C6BDDFE00C879D1 /* infrared-led-driver-uird.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "infrared-led-driver-uird.h"; sourceTree = "<group>"; };
+		B68755411C6BDDFE00C879D1 /* infrared-led-driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "infrared-led-driver.h"; sourceTree = "<group>"; };
+		B68755421C6BDDFE00C879D1 /* key-matrix-driver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "key-matrix-driver.h"; sourceTree = "<group>"; };
+		B68755431C6BDDFE00C879D1 /* led-blink.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "led-blink.h"; sourceTree = "<group>"; };
+		B68755441C6BDDFE00C879D1 /* led.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = led.h; sourceTree = "<group>"; };
+		B68755451C6BDDFE00C879D1 /* micro-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "micro-common.h"; sourceTree = "<group>"; };
+		B68755461C6BDDFE00C879D1 /* micro-types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "micro-types.h"; sourceTree = "<group>"; };
+		B68755471C6BDDFE00C879D1 /* micro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = micro.h; sourceTree = "<group>"; };
+		B68755481C6BDDFE00C879D1 /* microphone-codec-msadpcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "microphone-codec-msadpcm.h"; sourceTree = "<group>"; };
+		B68755491C6BDDFE00C879D1 /* msadpcm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = msadpcm.h; sourceTree = "<group>"; };
+		B687554A1C6BDDFE00C879D1 /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = random.h; sourceTree = "<group>"; };
+		B687554B1C6BDDFE00C879D1 /* sb1-gesture-sensor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "sb1-gesture-sensor.h"; sourceTree = "<group>"; };
+		B687554C1C6BDDFE00C879D1 /* serial-minimal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "serial-minimal.h"; sourceTree = "<group>"; };
+		B687554D1C6BDDFE00C879D1 /* serial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = serial.h; sourceTree = "<group>"; };
+		B687554E1C6BDDFE00C879D1 /* sim-eeprom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "sim-eeprom.h"; sourceTree = "<group>"; };
+		B687554F1C6BDDFE00C879D1 /* spi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = spi.h; sourceTree = "<group>"; };
+		B68755501C6BDDFE00C879D1 /* symbol-timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "symbol-timer.h"; sourceTree = "<group>"; };
+		B68755511C6BDDFE00C879D1 /* system-timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "system-timer.h"; sourceTree = "<group>"; };
+		B68755521C6BDDFE00C879D1 /* tamper-switch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tamper-switch.h"; sourceTree = "<group>"; };
+		B68755531C6BDDFE00C879D1 /* temperature.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = temperature.h; sourceTree = "<group>"; };
+		B68755541C6BDDFE00C879D1 /* token.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = token.h; sourceTree = "<group>"; };
+		B68755551C6BDDFE00C879D1 /* uart-link.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uart-link.h"; sourceTree = "<group>"; };
+		B68755581C6BDDFE00C879D1 /* gcc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = gcc.h; sourceTree = "<group>"; };
+		B687555B1C6BDDFE00C879D1 /* host.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = host.h; sourceTree = "<group>"; };
+		B687555C1C6BDDFE00C879D1 /* micro.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = micro.c; sourceTree = "<group>"; };
+		B687555D1C6BDDFE00C879D1 /* micro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = micro.h; sourceTree = "<group>"; };
+		B687555E1C6BDDFE00C879D1 /* spi-protocol-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "spi-protocol-common.h"; sourceTree = "<group>"; };
+		B687555F1C6BDDFE00C879D1 /* spi-protocol-linux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "spi-protocol-linux.c"; sourceTree = "<group>"; };
+		B68755611C6BDDFE00C879D1 /* bootloader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bootloader.h; sourceTree = "<group>"; };
+		B68755621C6BDDFE00C879D1 /* micro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = micro.h; sourceTree = "<group>"; };
+		B68755631C6BDDFE00C879D1 /* system-timer-sim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "system-timer-sim.h"; sourceTree = "<group>"; };
+		B68755651C6BDDFE00C879D1 /* misc-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "misc-test.c"; sourceTree = "<group>"; };
+		B68755661C6BDDFE00C879D1 /* nodetest-modules-em358_usb.ham */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "nodetest-modules-em358_usb.ham"; sourceTree = "<group>"; };
+		B68755671C6BDDFE00C879D1 /* nodetest-modules-em3xx.ham */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "nodetest-modules-em3xx.ham"; sourceTree = "<group>"; };
+		B68755681C6BDDFE00C879D1 /* platformtest-configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "platformtest-configuration.h"; sourceTree = "<group>"; };
+		B68755691C6BDDFE00C879D1 /* platformtest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = platformtest.c; sourceTree = "<group>"; };
+		B687556A1C6BDDFE00C879D1 /* platformtest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = platformtest.h; sourceTree = "<group>"; };
+		B687556B1C6BDDFE00C879D1 /* reset-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "reset-test.c"; sourceTree = "<group>"; };
+		B687556C1C6BDDFE00C879D1 /* response.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = response.c; sourceTree = "<group>"; };
+		B687556D1C6BDDFE00C879D1 /* response.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = response.h; sourceTree = "<group>"; };
+		B687556E1C6BDDFE00C879D1 /* token-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "token-test.c"; sourceTree = "<group>"; };
+		B68755721C6BDDFE00C879D1 /* ethernet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ethernet.h; sourceTree = "<group>"; };
+		B68755761C6BDDFE00C879D1 /* pl04-mgt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "pl04-mgt.h"; sourceTree = "<group>"; };
+		B68755781C6BDDFE00C879D1 /* pl04-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "pl04-test.c"; sourceTree = "<group>"; };
+		B68755791C6BDDFE00C879D1 /* green-phy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "green-phy.h"; sourceTree = "<group>"; };
+		B687557B1C6BDDFE00C879D1 /* bridge-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "bridge-test.c"; sourceTree = "<group>"; };
+		B687557C1C6BDDFE00C879D1 /* zigbee-bridge-internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "zigbee-bridge-internal.h"; sourceTree = "<group>"; };
+		B687557D1C6BDDFE00C879D1 /* zigbee-bridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "zigbee-bridge.h"; sourceTree = "<group>"; };
+		B687557E1C6BDDFE00C879D1 /* child-table.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "child-table.c"; sourceTree = "<group>"; };
+		B687557F1C6BDDFE00C879D1 /* mfglib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = mfglib.c; sourceTree = "<group>"; };
+		B68755801C6BDDFE00C879D1 /* phy-appended-info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "phy-appended-info.h"; sourceTree = "<group>"; };
+		B68755811C6BDDFE00C879D1 /* phy-library.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "phy-library.c"; sourceTree = "<group>"; };
+		B68755821C6BDDFE00C879D1 /* phy-util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "phy-util.c"; sourceTree = "<group>"; };
+		B68755831C6BDDFE00C879D1 /* phy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = phy.h; sourceTree = "<group>"; };
+		B68755841C6BDDFE00C879D1 /* security.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = security.h; sourceTree = "<group>"; };
+		B68755861C6BDDFE00C879D1 /* phy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = phy.h; sourceTree = "<group>"; };
+		B68755881C6BDDFE00C879D1 /* aes-software.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "aes-software.c"; sourceTree = "<group>"; };
+		B68755891C6BDDFE00C879D1 /* security.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = security.h; sourceTree = "<group>"; };
+		B687558B1C6BDDFE00C879D1 /* phy-common-rx-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "phy-common-rx-test.c"; sourceTree = "<group>"; };
+		B687558C1C6BDDFE00C879D1 /* phy-common-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "phy-common-test.c"; sourceTree = "<group>"; };
+		B687558D1C6BDDFE00C879D1 /* phy-common-test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "phy-common-test.h"; sourceTree = "<group>"; };
+		B687558E1C6BDDFE00C879D1 /* phy-common-tx-test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "phy-common-tx-test.c"; sourceTree = "<group>"; };
+		B687558F1C6BDDFE00C879D1 /* readme-main.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "readme-main.txt"; sourceTree = "<group>"; };
+		B68755921C6BDDFE00C879D1 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		B68755941C6BDDFE00C879D1 /* ember-configuration-defaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ember-configuration-defaults.h"; sourceTree = "<group>"; };
+		B68755951C6BDDFE00C879D1 /* ember-ip-configuration.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ember-ip-configuration.c"; sourceTree = "<group>"; };
+		B68755961C6BDDFE00C879D1 /* token-phy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "token-phy.h"; sourceTree = "<group>"; };
+		B68755971C6BDDFE00C879D1 /* token-stack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "token-stack.h"; sourceTree = "<group>"; };
+		B68755991C6BDDFE00C879D1 /* ember-stack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ember-stack.h"; sourceTree = "<group>"; };
+		B687559A1C6BDDFE00C879D1 /* log-gen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "log-gen.h"; sourceTree = "<group>"; };
+		B687559B1C6BDDFE00C879D1 /* log.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = log.c; sourceTree = "<group>"; };
+		B687559C1C6BDDFE00C879D1 /* log.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log.h; sourceTree = "<group>"; };
+		B687559E1C6BDDFE00C879D1 /* buffer-malloc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "buffer-malloc.c"; sourceTree = "<group>"; };
+		B687559F1C6BDDFE00C879D1 /* buffer-malloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "buffer-malloc.h"; sourceTree = "<group>"; };
+		B68755A01C6BDDFE00C879D1 /* buffer-management.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "buffer-management.c"; sourceTree = "<group>"; };
+		B68755A11C6BDDFE00C879D1 /* buffer-management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "buffer-management.h"; sourceTree = "<group>"; };
+		B68755A21C6BDDFE00C879D1 /* buffer-queue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "buffer-queue.c"; sourceTree = "<group>"; };
+		B68755A31C6BDDFE00C879D1 /* buffer-queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "buffer-queue.h"; sourceTree = "<group>"; };
+		B68755A41C6BDDFE00C879D1 /* byte-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "byte-utilities.c"; sourceTree = "<group>"; };
+		B68755A51C6BDDFE00C879D1 /* debug-gen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "debug-gen.h"; sourceTree = "<group>"; };
+		B68755A61C6BDDFE00C879D1 /* debug-message-type-gen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "debug-message-type-gen.h"; sourceTree = "<group>"; };
+		B68755A71C6BDDFE00C879D1 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
+		B68755A81C6BDDFE00C879D1 /* eui64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eui64.h; sourceTree = "<group>"; };
+		B68755A91C6BDDFE00C879D1 /* event-control.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "event-control.c"; sourceTree = "<group>"; };
+		B68755AA1C6BDDFE00C879D1 /* event-queue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "event-queue.c"; sourceTree = "<group>"; };
+		B68755AB1C6BDDFE00C879D1 /* event-queue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "event-queue.h"; sourceTree = "<group>"; };
+		B68755AC1C6BDDFE00C879D1 /* ip-packet-header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-packet-header.h"; sourceTree = "<group>"; };
+		B68755AE1C6BDDFE00C879D1 /* byte-utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "byte-utilities.h"; sourceTree = "<group>"; };
+		B68755AF1C6BDDFE00C879D1 /* cbke-crypto-engine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "cbke-crypto-engine.h"; sourceTree = "<group>"; };
+		B68755B01C6BDDFE00C879D1 /* child.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = child.h; sourceTree = "<group>"; };
+		B68755B11C6BDDFE00C879D1 /* coap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coap.h; sourceTree = "<group>"; };
+		B68755B21C6BDDFE00C879D1 /* counter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = counter.h; sourceTree = "<group>"; };
+		B68755B31C6BDDFE00C879D1 /* define-ember-api.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "define-ember-api.h"; sourceTree = "<group>"; };
+		B68755B41C6BDDFE00C879D1 /* ember-debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ember-debug.h"; sourceTree = "<group>"; };
+		B68755B51C6BDDFE00C879D1 /* ember-types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ember-types.h"; sourceTree = "<group>"; };
+		B68755B61C6BDDFE00C879D1 /* ember.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ember.h; sourceTree = "<group>"; };
+		B68755B71C6BDDFE00C879D1 /* error-def.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "error-def.h"; sourceTree = "<group>"; };
+		B68755B81C6BDDFE00C879D1 /* error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = error.h; sourceTree = "<group>"; };
+		B68755B91C6BDDFE00C879D1 /* event.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = event.h; sourceTree = "<group>"; };
+		B68755BA1C6BDDFE00C879D1 /* icmp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = icmp.h; sourceTree = "<group>"; };
+		B68755BB1C6BDDFE00C879D1 /* mfglib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mfglib.h; sourceTree = "<group>"; };
+		B68755BC1C6BDDFE00C879D1 /* network-management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "network-management.h"; sourceTree = "<group>"; };
+		B68755BD1C6BDDFE00C879D1 /* packet-buffer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "packet-buffer.h"; sourceTree = "<group>"; };
+		B68755BE1C6BDDFE00C879D1 /* stack-info.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "stack-info.h"; sourceTree = "<group>"; };
+		B68755BF1C6BDDFE00C879D1 /* tcp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tcp.h; sourceTree = "<group>"; };
+		B68755C11C6BDDFE00C879D1 /* thread-debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "thread-debug.h"; sourceTree = "<group>"; };
+		B68755C21C6BDDFE00C879D1 /* udp-peer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "udp-peer.h"; sourceTree = "<group>"; };
+		B68755C31C6BDDFE00C879D1 /* udp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = udp.h; sourceTree = "<group>"; };
+		B68755C41C6BDDFE00C879D1 /* undefine-ember-api.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "undefine-ember-api.h"; sourceTree = "<group>"; };
+		B68755C51C6BDDFE00C879D1 /* wakeup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wakeup.h; sourceTree = "<group>"; };
+		B68755C71C6BDDFE00C879D1 /* 6lowpan-header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "6lowpan-header.h"; sourceTree = "<group>"; };
+		B68755C81C6BDDFE00C879D1 /* address-cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "address-cache.c"; sourceTree = "<group>"; };
+		B68755C91C6BDDFE00C879D1 /* address-cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "address-cache.h"; sourceTree = "<group>"; };
+		B68755CA1C6BDDFE00C879D1 /* address-management.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "address-management.c"; sourceTree = "<group>"; };
+		B68755CB1C6BDDFE00C879D1 /* address-management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "address-management.h"; sourceTree = "<group>"; };
+		B68755CC1C6BDDFE00C879D1 /* coap-diagnostic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "coap-diagnostic.h"; sourceTree = "<group>"; };
+		B68755CD1C6BDDFE00C879D1 /* commission-dataset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "commission-dataset.h"; sourceTree = "<group>"; };
+		B68755CE1C6BDDFE00C879D1 /* commission.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = commission.h; sourceTree = "<group>"; };
+		B68755CF1C6BDDFE00C879D1 /* connection.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = connection.c; sourceTree = "<group>"; };
+		B68755D01C6BDDFE00C879D1 /* context-table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "context-table.h"; sourceTree = "<group>"; };
+		B68755D11C6BDDFE00C879D1 /* dhcp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dhcp.h; sourceTree = "<group>"; };
+		B68755D21C6BDDFE00C879D1 /* dispatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dispatch.h; sourceTree = "<group>"; };
+		B68755D31C6BDDFE00C879D1 /* global-prefix.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "global-prefix.c"; sourceTree = "<group>"; };
+		B68755D51C6BDDFE00C879D1 /* host-address-table.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "host-address-table.c"; sourceTree = "<group>"; };
+		B68755D61C6BDDFE00C879D1 /* host-address-table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "host-address-table.h"; sourceTree = "<group>"; };
+		B68755D71C6BDDFE00C879D1 /* host-app-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "host-app-utilities.c"; sourceTree = "<group>"; };
+		B68755D81C6BDDFE00C879D1 /* host-listener-table.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "host-listener-table.c"; sourceTree = "<group>"; };
+		B68755D91C6BDDFE00C879D1 /* host-listener-table.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "host-listener-table.h"; sourceTree = "<group>"; };
+		B68755DA1C6BDDFE00C879D1 /* host-mfglib.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "host-mfglib.c"; sourceTree = "<group>"; };
+		B68755DB1C6BDDFE00C879D1 /* host-mfglib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "host-mfglib.h"; sourceTree = "<group>"; };
+		B68755DC1C6BDDFE00C879D1 /* management-client.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "management-client.c"; sourceTree = "<group>"; };
+		B68755DD1C6BDDFE00C879D1 /* management-client.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "management-client.h"; sourceTree = "<group>"; };
+		B68755DE1C6BDDFE00C879D1 /* unix-address.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-address.c"; sourceTree = "<group>"; };
+		B68755DF1C6BDDFE00C879D1 /* unix-address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "unix-address.h"; sourceTree = "<group>"; };
+		B68755E01C6BDDFE00C879D1 /* unix-driver-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-driver-utilities.c"; sourceTree = "<group>"; };
+		B68755E11C6BDDFE00C879D1 /* unix-icmp-wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-icmp-wrapper.c"; sourceTree = "<group>"; };
+		B68755E21C6BDDFE00C879D1 /* unix-interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "unix-interface.h"; sourceTree = "<group>"; };
+		B68755E31C6BDDFE00C879D1 /* unix-ip-utilities.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-ip-utilities.c"; sourceTree = "<group>"; };
+		B68755E41C6BDDFE00C879D1 /* unix-listeners.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-listeners.c"; sourceTree = "<group>"; };
+		B68755E51C6BDDFE00C879D1 /* unix-udp-wrapper.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "unix-udp-wrapper.c"; sourceTree = "<group>"; };
+		B68755E61C6BDDFE00C879D1 /* ip-address.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ip-address.c"; sourceTree = "<group>"; };
+		B68755E71C6BDDFE00C879D1 /* ip-address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-address.h"; sourceTree = "<group>"; };
+		B68755E81C6BDDFE00C879D1 /* ip-header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ip-header.h"; sourceTree = "<group>"; };
+		B68755E91C6BDDFE00C879D1 /* jit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = jit.h; sourceTree = "<group>"; };
+		B68755EA1C6BDDFE00C879D1 /* local-server-data-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "local-server-data-stubs.c"; sourceTree = "<group>"; };
+		B68755EB1C6BDDFE00C879D1 /* local-server-data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "local-server-data.c"; sourceTree = "<group>"; };
+		B68755EC1C6BDDFE00C879D1 /* local-server-data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "local-server-data.h"; sourceTree = "<group>"; };
+		B68755ED1C6BDDFE00C879D1 /* mark-list.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "mark-list.c"; sourceTree = "<group>"; };
+		B68755EE1C6BDDFE00C879D1 /* mark-list.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "mark-list.h"; sourceTree = "<group>"; };
+		B68755EF1C6BDDFE00C879D1 /* mle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mle.h; sourceTree = "<group>"; };
+		B68755F01C6BDDFE00C879D1 /* multicast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = multicast.h; sourceTree = "<group>"; };
+		B68755F11C6BDDFE00C879D1 /* nd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = nd.h; sourceTree = "<group>"; };
+		B68755F21C6BDDFE00C879D1 /* network-data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "network-data.c"; sourceTree = "<group>"; };
+		B68755F31C6BDDFE00C879D1 /* network-data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "network-data.h"; sourceTree = "<group>"; };
+		B68755F41C6BDDFE00C879D1 /* rip-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "rip-stub.c"; sourceTree = "<group>"; };
+		B68755F51C6BDDFE00C879D1 /* rip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rip.h; sourceTree = "<group>"; };
+		B68755F61C6BDDFE00C879D1 /* router-selection-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "router-selection-stubs.c"; sourceTree = "<group>"; };
+		B68755F71C6BDDFE00C879D1 /* router-selection.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "router-selection.c"; sourceTree = "<group>"; };
+		B68755F81C6BDDFE00C879D1 /* router-selection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "router-selection.h"; sourceTree = "<group>"; };
+		B68755F91C6BDDFE00C879D1 /* stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = stubs.c; sourceTree = "<group>"; };
+		B68755FA1C6BDDFE00C879D1 /* tcp-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tcp-stub.c"; sourceTree = "<group>"; };
+		B68755FB1C6BDDFE00C879D1 /* tcp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tcp.h; sourceTree = "<group>"; };
+		B68755FC1C6BDDFE00C879D1 /* thread-key-stretch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "thread-key-stretch.c"; sourceTree = "<group>"; };
+		B68755FE1C6BDDFE00C879D1 /* asn1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = asn1.h; sourceTree = "<group>"; };
+		B68755FF1C6BDDFE00C879D1 /* big-int.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "big-int.h"; sourceTree = "<group>"; };
+		B68756001C6BDDFE00C879D1 /* certificate.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = certificate.c; sourceTree = "<group>"; };
+		B68756011C6BDDFE00C879D1 /* certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = certificate.h; sourceTree = "<group>"; };
+		B68756031C6BDDFE00C879D1 /* test-certificate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "test-certificate.h"; sourceTree = "<group>"; };
+		B68756041C6BDDFE00C879D1 /* debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = debug.h; sourceTree = "<group>"; };
+		B68756051C6BDDFE00C879D1 /* dtls-join-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "dtls-join-stubs.c"; sourceTree = "<group>"; };
+		B68756061C6BDDFE00C879D1 /* dtls-join.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "dtls-join.c"; sourceTree = "<group>"; };
+		B68756071C6BDDFE00C879D1 /* dtls-join.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "dtls-join.h"; sourceTree = "<group>"; };
+		B68756081C6BDDFE00C879D1 /* dtls-stub.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "dtls-stub.c"; sourceTree = "<group>"; };
+		B68756091C6BDDFE00C879D1 /* dtls.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dtls.c; sourceTree = "<group>"; };
+		B687560A1C6BDDFE00C879D1 /* dtls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dtls.h; sourceTree = "<group>"; };
+		B687560B1C6BDDFE00C879D1 /* eap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = eap.h; sourceTree = "<group>"; };
+		B687560C1C6BDDFE00C879D1 /* ecc-dummy.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ecc-dummy.c"; sourceTree = "<group>"; };
+		B687560D1C6BDDFE00C879D1 /* ecc-openssl.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "ecc-openssl.c"; sourceTree = "<group>"; };
+		B687560E1C6BDDFE00C879D1 /* ecc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ecc.c; sourceTree = "<group>"; };
+		B687560F1C6BDDFE00C879D1 /* ecc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ecc.h; sourceTree = "<group>"; };
+		B68756101C6BDDFE00C879D1 /* native-test-util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "native-test-util.c"; sourceTree = "<group>"; };
+		B68756111C6BDDFE00C879D1 /* native-test-util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "native-test-util.h"; sourceTree = "<group>"; };
+		B68756121C6BDDFE00C879D1 /* psk-only-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "psk-only-stubs.c"; sourceTree = "<group>"; };
+		B68756131C6BDDFE00C879D1 /* rsa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rsa.h; sourceTree = "<group>"; };
+		B68756141C6BDDFE00C879D1 /* sha256-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "sha256-stubs.c"; sourceTree = "<group>"; };
+		B68756151C6BDDFE00C879D1 /* sha256.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sha256.c; sourceTree = "<group>"; };
+		B68756161C6BDDFE00C879D1 /* sha256.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sha256.h; sourceTree = "<group>"; };
+		B68756171C6BDDFE00C879D1 /* tls-ccm-record.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-ccm-record.c"; sourceTree = "<group>"; };
+		B68756181C6BDDFE00C879D1 /* tls-debug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-debug.c"; sourceTree = "<group>"; };
+		B68756191C6BDDFE00C879D1 /* tls-ecc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-ecc.c"; sourceTree = "<group>"; };
+		B687561A1C6BDDFE00C879D1 /* tls-handshake-crypto.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-handshake-crypto.c"; sourceTree = "<group>"; };
+		B687561B1C6BDDFE00C879D1 /* tls-handshake-crypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tls-handshake-crypto.h"; sourceTree = "<group>"; };
+		B687561C1C6BDDFE00C879D1 /* tls-handshake.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-handshake.c"; sourceTree = "<group>"; };
+		B687561D1C6BDDFE00C879D1 /* tls-handshake.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tls-handshake.h"; sourceTree = "<group>"; };
+		B687561E1C6BDDFE00C879D1 /* tls-jpake.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-jpake.c"; sourceTree = "<group>"; };
+		B687561F1C6BDDFE00C879D1 /* tls-public-key.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-public-key.c"; sourceTree = "<group>"; };
+		B68756201C6BDDFE00C879D1 /* tls-public-key.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tls-public-key.h"; sourceTree = "<group>"; };
+		B68756211C6BDDFE00C879D1 /* tls-record-stubs.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-record-stubs.c"; sourceTree = "<group>"; };
+		B68756221C6BDDFE00C879D1 /* tls-record-util.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-record-util.c"; sourceTree = "<group>"; };
+		B68756231C6BDDFE00C879D1 /* tls-record.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tls-record.h"; sourceTree = "<group>"; };
+		B68756241C6BDDFE00C879D1 /* tls-session-state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-session-state.c"; sourceTree = "<group>"; };
+		B68756251C6BDDFE00C879D1 /* tls-session-state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tls-session-state.h"; sourceTree = "<group>"; };
+		B68756261C6BDDFE00C879D1 /* tls-tcp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-tcp.c"; sourceTree = "<group>"; };
+		B68756271C6BDDFE00C879D1 /* tls-test-credentials.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tls-test-credentials.c"; sourceTree = "<group>"; };
+		B68756281C6BDDFE00C879D1 /* tls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tls.h; sourceTree = "<group>"; };
+		B68756291C6BDDFE00C879D1 /* transport-header.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "transport-header.c"; sourceTree = "<group>"; };
+		B687562A1C6BDDFE00C879D1 /* udp-simple.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "udp-simple.c"; sourceTree = "<group>"; };
+		B687562B1C6BDDFE00C879D1 /* udp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = udp.c; sourceTree = "<group>"; };
+		B687562C1C6BDDFE00C879D1 /* udp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = udp.h; sourceTree = "<group>"; };
+		B687562D1C6BDDFE00C879D1 /* wakeup-specific.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "wakeup-specific.c"; sourceTree = "<group>"; };
+		B687562E1C6BDDFE00C879D1 /* wakeup-specific.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "wakeup-specific.h"; sourceTree = "<group>"; };
+		B68756301C6BDDFE00C879D1 /* child-data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "child-data.h"; sourceTree = "<group>"; };
+		B68756311C6BDDFE00C879D1 /* join.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = join.h; sourceTree = "<group>"; };
+		B68756321C6BDDFE00C879D1 /* key-management.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "key-management.h"; sourceTree = "<group>"; };
+		B68756351C6BDDFE00C879D1 /* 802-15-4-ccm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "802-15-4-ccm.c"; sourceTree = "<group>"; };
+		B68756361C6BDDFE00C879D1 /* 802-15-4-ccm.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "802-15-4-ccm.h"; sourceTree = "<group>"; };
+		B68756371C6BDDFE00C879D1 /* mac-arbiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "mac-arbiter.h"; sourceTree = "<group>"; };
+		B68756381C6BDDFE00C879D1 /* mac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mac.h; sourceTree = "<group>"; };
+		B68756391C6BDDFE00C879D1 /* wakeup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = wakeup.h; sourceTree = "<group>"; };
+		B687563A1C6BDDFE00C879D1 /* mac-header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "mac-header.h"; sourceTree = "<group>"; };
+		B687563D1C6BDDFE00C879D1 /* aes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = aes.h; sourceTree = "<group>"; };
+		B687563E1C6BDDFE00C879D1 /* debug-channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "debug-channel.h"; sourceTree = "<group>"; };
+		B68756401C6BDDFE00C879D1 /* aes.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = aes.c; sourceTree = "<group>"; };
+		B68756431C6BDDFE00C879D1 /* neighbor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neighbor.h; sourceTree = "<group>"; };
+		B68756451C6BDDFE00C879D1 /* retry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = retry.h; sourceTree = "<group>"; };
+		B68756491C6BDDFE00C879D1 /* posix-sim.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "posix-sim.c"; sourceTree = "<group>"; };
+		B687564A1C6BDDFE00C879D1 /* posix-sim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "posix-sim.h"; sourceTree = "<group>"; };
+		B687564C1C6BDDFE00C879D1 /* Makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		B687564D1C6BDDFE00C879D1 /* spi-server.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "spi-server.c"; sourceTree = "<group>"; };
+		B687564E1C6BDDFE00C879D1 /* spi-server.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "spi-server.sh"; sourceTree = "<group>"; };
+		B68756501C6BDDFE00C879D1 /* EM358-CDC.inf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "EM358-CDC.inf"; sourceTree = "<group>"; };
+		B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "NCPInstanceBase-NetInterface.cpp"; sourceTree = "<group>"; };
+		B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "NCPInstanceBase-Addresses.cpp"; sourceTree = "<group>"; };
+		B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "NCPInstanceBase-AsyncIO.cpp"; sourceTree = "<group>"; };
+		B68B78971C56EA7100EC9FB8 /* tool-cmd-add-route.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-add-route.c"; sourceTree = "<group>"; };
+		B68B78981C56EA7100EC9FB8 /* tool-cmd-add-route.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-add-route.h"; sourceTree = "<group>"; };
+		B68B78991C56EA7100EC9FB8 /* tool-cmd-begin-net-wake.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-begin-net-wake.c"; sourceTree = "<group>"; };
+		B68B789D1C56EC2400EC9FB8 /* tool-cmd-remove-route.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-remove-route.c"; sourceTree = "<group>"; };
+		B68B789E1C56EC2400EC9FB8 /* tool-cmd-remove-route.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-remove-route.h"; sourceTree = "<group>"; };
+		B68B78CB1C62A91B00EC9FB8 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B68B78D21C65244500EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-DeepSleepTask.cpp"; sourceTree = "<group>"; };
+		B68B78D31C65244500EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-DeepSleepTask.h"; sourceTree = "<group>"; };
+		B68B78D41C65244500EC9FB8 /* EmberNCPControlInterface-FormTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-FormTask.cpp"; sourceTree = "<group>"; };
+		B68B78D51C65244500EC9FB8 /* EmberNCPControlInterface-FormTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-FormTask.h"; sourceTree = "<group>"; };
+		B68B78D61C65244500EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-GetGlobalAddressesTask.cpp"; sourceTree = "<group>"; };
+		B68B78D71C65244500EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-GetGlobalAddressesTask.h"; sourceTree = "<group>"; };
+		B68B78D81C65244500EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-GetRIPEntryTask.cpp"; sourceTree = "<group>"; };
+		B68B78D91C65244500EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-GetRIPEntryTask.h"; sourceTree = "<group>"; };
+		B68B78DA1C65244500EC9FB8 /* EmberNCPControlInterface-JoinTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-JoinTask.cpp"; sourceTree = "<group>"; };
+		B68B78DB1C65244500EC9FB8 /* EmberNCPControlInterface-JoinTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-JoinTask.h"; sourceTree = "<group>"; };
+		B68B78DC1C65244500EC9FB8 /* EmberNCPControlInterface-LeaveTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-LeaveTask.cpp"; sourceTree = "<group>"; };
+		B68B78DD1C65244500EC9FB8 /* EmberNCPControlInterface-LeaveTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-LeaveTask.h"; sourceTree = "<group>"; };
+		B68B78DE1C65244500EC9FB8 /* EmberNCPControlInterface-LurkTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-LurkTask.cpp"; sourceTree = "<group>"; };
+		B68B78DF1C65244500EC9FB8 /* EmberNCPControlInterface-LurkTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-LurkTask.h"; sourceTree = "<group>"; };
+		B68B78E01C65244500EC9FB8 /* EmberNCPControlInterface-Mfg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-Mfg.cpp"; sourceTree = "<group>"; };
+		B68B78E11C65244500EC9FB8 /* EmberNCPControlInterface-MfgFinish.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-MfgFinish.cpp"; sourceTree = "<group>"; };
+		B68B78E21C65244500EC9FB8 /* EmberNCPControlInterface-MfgFinish.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-MfgFinish.h"; sourceTree = "<group>"; };
+		B68B78E31C65244500EC9FB8 /* EmberNCPControlInterface-ScanTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-ScanTask.cpp"; sourceTree = "<group>"; };
+		B68B78E41C65244500EC9FB8 /* EmberNCPControlInterface-ScanTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-ScanTask.h"; sourceTree = "<group>"; };
+		B68B78E51C65244500EC9FB8 /* EmberNCPControlInterface-SendCommandTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-SendCommandTask.cpp"; sourceTree = "<group>"; };
+		B68B78E61C65244500EC9FB8 /* EmberNCPControlInterface-SendCommandTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-SendCommandTask.h"; sourceTree = "<group>"; };
+		B68B78E71C65244500EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-SetNetworkKeyTask.cpp"; sourceTree = "<group>"; };
+		B68B78E81C65244500EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-SetNetworkKeyTask.h"; sourceTree = "<group>"; };
+		B68B78E91C65244500EC9FB8 /* EmberNCPControlInterface-WakeupTask.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-WakeupTask.cpp"; sourceTree = "<group>"; };
+		B68B78EA1C65244500EC9FB8 /* EmberNCPControlInterface-WakeupTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-WakeupTask.h"; sourceTree = "<group>"; };
+		B68B78EB1C65244500EC9FB8 /* EmberNCPControlInterface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EmberNCPControlInterface.cpp; sourceTree = "<group>"; };
+		B68B78EC1C65244500EC9FB8 /* EmberNCPControlInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberNCPControlInterface.h; sourceTree = "<group>"; };
+		B68B78ED1C65244500EC9FB8 /* EmberNCPInstance.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EmberNCPInstance.cpp; sourceTree = "<group>"; };
+		B68B78EE1C65244500EC9FB8 /* EmberNCPInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberNCPInstance.h; sourceTree = "<group>"; };
+		B68B78EF1C65244500EC9FB8 /* EmberNCPUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberNCPUtils.h; sourceTree = "<group>"; };
+		B68B78F01C65244500EC9FB8 /* EmberPacked.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EmberPacked.cpp; sourceTree = "<group>"; };
+		B68B78F11C65244500EC9FB8 /* EmberPacked.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberPacked.h; sourceTree = "<group>"; };
+		B68B78FC1C65244500EC9FB8 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B68B78FD1C65244500EC9FB8 /* SootAdapter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SootAdapter.cpp; sourceTree = "<group>"; };
+		B68B78FE1C65244500EC9FB8 /* SootAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SootAdapter.h; sourceTree = "<group>"; };
+		B68B79F21C65268500EC9FB8 /* wpantund-ncp-silabs-tmsp */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "wpantund-ncp-silabs-tmsp"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B68B7A1A1C69429B00EC9FB8 /* EmberAPIGlue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmberAPIGlue.cpp; sourceTree = "<group>"; };
+		B68B7A1B1C69429B00EC9FB8 /* EmberAPIGlue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmberAPIGlue.h; sourceTree = "<group>"; };
+		B68B7A1E1C69459200EC9FB8 /* wpantund-configuration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpantund-configuration.h"; sourceTree = "<group>"; };
+		B68B7A1F1C694BEA00EC9FB8 /* EmberASHAdapter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmberASHAdapter.cpp; sourceTree = "<group>"; };
+		B68B7A201C694BEA00EC9FB8 /* EmberASHAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmberASHAdapter.h; sourceTree = "<group>"; };
+		B693A50D1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-GetGlobalAddressesTask.cpp"; sourceTree = "<group>"; };
+		B693A50E1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-GetGlobalAddressesTask.h"; sourceTree = "<group>"; };
+		B69A45F51AF042A6001D8A8F /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B69A45F61AF157D9001D8A8F /* tool-cmd-leave.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-leave.h"; sourceTree = "<group>"; };
+		B69A45F71AF157D9001D8A8F /* tool-cmd-begin-net-wake.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-begin-net-wake.h"; sourceTree = "<group>"; };
+		B69A45F81AF157D9001D8A8F /* tool-cmd-cd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-cd.c"; sourceTree = "<group>"; };
+		B69A45F91AF157D9001D8A8F /* tool-cmd-cd.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-cd.h"; sourceTree = "<group>"; };
+		B69A45FA1AF157D9001D8A8F /* tool-cmd-config-gateway.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-config-gateway.c"; sourceTree = "<group>"; };
+		B69A45FB1AF157D9001D8A8F /* tool-cmd-config-gateway.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-config-gateway.h"; sourceTree = "<group>"; };
+		B69A45FC1AF157D9001D8A8F /* tool-cmd-form.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-form.c"; sourceTree = "<group>"; };
+		B69A45FD1AF157D9001D8A8F /* tool-cmd-form.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-form.h"; sourceTree = "<group>"; };
+		B69A45FE1AF157D9001D8A8F /* tool-cmd-getprop.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-getprop.c"; sourceTree = "<group>"; };
+		B69A45FF1AF157D9001D8A8F /* tool-cmd-getprop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-getprop.h"; sourceTree = "<group>"; };
+		B69A46001AF157D9001D8A8F /* tool-cmd-host-did-wake.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-host-did-wake.c"; sourceTree = "<group>"; };
+		B69A46011AF157D9001D8A8F /* tool-cmd-host-did-wake.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-host-did-wake.h"; sourceTree = "<group>"; };
+		B69A46021AF157D9001D8A8F /* tool-cmd-join.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-join.c"; sourceTree = "<group>"; };
+		B69A46031AF157D9001D8A8F /* tool-cmd-join.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-join.h"; sourceTree = "<group>"; };
+		B69A46041AF157D9001D8A8F /* tool-cmd-leave.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-leave.c"; sourceTree = "<group>"; };
+		B69A46051AF157D9001D8A8F /* tool-cmd-list.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-list.c"; sourceTree = "<group>"; };
+		B69A46061AF157D9001D8A8F /* tool-cmd-list.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-list.h"; sourceTree = "<group>"; };
+		B69A46071AF157D9001D8A8F /* tool-cmd-begin-low-power.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-begin-low-power.c"; sourceTree = "<group>"; };
+		B69A46081AF157D9001D8A8F /* tool-cmd-begin-low-power.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-begin-low-power.h"; sourceTree = "<group>"; };
+		B69A46091AF157D9001D8A8F /* tool-cmd-permit-join.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-permit-join.c"; sourceTree = "<group>"; };
+		B69A460A1AF157D9001D8A8F /* tool-cmd-permit-join.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-permit-join.h"; sourceTree = "<group>"; };
+		B69A460B1AF157D9001D8A8F /* tool-cmd-ping.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-ping.c"; sourceTree = "<group>"; };
+		B69A460C1AF157D9001D8A8F /* tool-cmd-ping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-ping.h"; sourceTree = "<group>"; };
+		B69A460D1AF157D9001D8A8F /* tool-cmd-poll.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-poll.c"; sourceTree = "<group>"; };
+		B69A460E1AF157D9001D8A8F /* tool-cmd-poll.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-poll.h"; sourceTree = "<group>"; };
+		B69A460F1AF157D9001D8A8F /* tool-cmd-reset.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-reset.c"; sourceTree = "<group>"; };
+		B69A46101AF157D9001D8A8F /* tool-cmd-reset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-reset.h"; sourceTree = "<group>"; };
+		B69A46111AF157D9001D8A8F /* tool-cmd-resume.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-resume.c"; sourceTree = "<group>"; };
+		B69A46121AF157D9001D8A8F /* tool-cmd-resume.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-resume.h"; sourceTree = "<group>"; };
+		B69A46131AF157D9001D8A8F /* tool-cmd-scan.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-scan.c"; sourceTree = "<group>"; };
+		B69A46141AF157D9001D8A8F /* tool-cmd-scan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-scan.h"; sourceTree = "<group>"; };
+		B69A46151AF157D9001D8A8F /* tool-cmd-setprop.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-setprop.c"; sourceTree = "<group>"; };
+		B69A46161AF157D9001D8A8F /* tool-cmd-setprop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-setprop.h"; sourceTree = "<group>"; };
+		B69A46171AF157D9001D8A8F /* tool-cmd-status.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "tool-cmd-status.c"; sourceTree = "<group>"; };
+		B69A46181AF157D9001D8A8F /* tool-cmd-status.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tool-cmd-status.h"; sourceTree = "<group>"; };
+		B69A46191AF157D9001D8A8F /* wpanctl-utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "wpanctl-utils.c"; sourceTree = "<group>"; };
+		B69A461A1AF157D9001D8A8F /* wpanctl-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpanctl-utils.h"; sourceTree = "<group>"; };
+		B69A461E1AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-LeaveTask.cpp"; sourceTree = "<group>"; };
+		B69A461F1AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-LeaveTask.h"; sourceTree = "<group>"; };
+		B69A46211AF7F654001D8A8F /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; usesTabs = 1; };
+		B69A46221B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-WakeupTask.cpp"; sourceTree = "<group>"; };
+		B69A46231B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-WakeupTask.h"; sourceTree = "<group>"; };
+		B69A46251B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-DeepSleepTask.cpp"; sourceTree = "<group>"; };
+		B69A46261B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-DeepSleepTask.h"; sourceTree = "<group>"; };
+		B69C84801BFE69D10087EF73 /* wpantund.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = wpantund.conf; sourceTree = "<group>"; };
+		B69D8A981D5110020060D2A8 /* sec-random.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "sec-random.c"; sourceTree = "<group>"; };
+		B69D8A991D5110020060D2A8 /* sec-random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "sec-random.h"; sourceTree = "<group>"; };
+		B6A3BE6C1C88BAC500976BE9 /* DummyNCPControlInterface.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DummyNCPControlInterface.cpp; sourceTree = "<group>"; };
+		B6A3BE6D1C88BAC500976BE9 /* DummyNCPControlInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DummyNCPControlInterface.h; sourceTree = "<group>"; };
+		B6A3BE6E1C88BAC500976BE9 /* DummyNCPInstance.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DummyNCPInstance.cpp; sourceTree = "<group>"; };
+		B6A3BE6F1C88BAC500976BE9 /* DummyNCPInstance.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DummyNCPInstance.h; sourceTree = "<group>"; };
+		B6A3BE711C88BAC500976BE9 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
+		B6A683F41C50212B00D0FCAC /* ValueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ValueMap.h; sourceTree = "<group>"; };
+		B6A683F71C50457400D0FCAC /* ValueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ValueMap.cpp; sourceTree = "<group>"; };
+		B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DBusIPCAPI_v0.cpp; sourceTree = "<group>"; };
+		B6A683FB1C518FC800D0FCAC /* DBusIPCAPI_v0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DBusIPCAPI_v0.h; sourceTree = "<group>"; };
+		B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DBusIPCAPI_v1.cpp; sourceTree = "<group>"; };
+		B6A683FE1C518FEE00D0FCAC /* DBusIPCAPI_v1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DBusIPCAPI_v1.h; sourceTree = "<group>"; };
+		B6A684001C51A0A500D0FCAC /* wpan-dbus-v1.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpan-dbus-v1.h"; sourceTree = "<group>"; };
+		B6B0D40A1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpinelNCPTaskChangeNetData.cpp; sourceTree = "<group>"; };
+		B6B0D40B1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpinelNCPTaskChangeNetData.h; sourceTree = "<group>"; };
+		B6B99A761BC324020043526B /* SootAdapter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SootAdapter.cpp; sourceTree = "<group>"; };
+		B6B99A771BC324020043526B /* SootAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SootAdapter.h; sourceTree = "<group>"; };
+		B6BF2C841C1F710D0083AD96 /* RingBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RingBuffer.h; sourceTree = "<group>"; };
+		B6BF2C8B1C20EAF20083AD96 /* INSTALL.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = INSTALL.md; sourceTree = SOURCE_ROOT; };
+		B6CFE7331AC36CD2007D281D /* nlpt-select.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "nlpt-select.c"; sourceTree = "<group>"; };
+		B6D1F6101A8AABCA00F70266 /* FirmwareInterface-1.1.3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "FirmwareInterface-1.1.3.cpp"; sourceTree = "<group>"; };
+		B6D1F6111A8AABCA00F70266 /* FirmwareInterface-1.1.3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FirmwareInterface-1.1.3.h"; sourceTree = "<group>"; };
+		B6D1F6131A8AABF400F70266 /* FirmwareInterface-2.0.0.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "FirmwareInterface-2.0.0.cpp"; sourceTree = "<group>"; };
+		B6D1F6141A8AABF400F70266 /* FirmwareInterface-2.0.0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FirmwareInterface-2.0.0.h"; sourceTree = "<group>"; };
+		B6D1F6161A8AAF2E00F70266 /* FirmwareInterface-Base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "FirmwareInterface-Base.cpp"; sourceTree = "<group>"; };
+		B6D1F6171A8AAF2E00F70266 /* FirmwareInterface-Base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FirmwareInterface-Base.h"; sourceTree = "<group>"; };
+		B6D23B071AB8A99500441CB5 /* NCPMfgInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCPMfgInterface.h; sourceTree = "<group>"; };
+		B6D23B081AB8ACCD00441CB5 /* EmberNCPControlInterface-Mfg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-Mfg.cpp"; sourceTree = "<group>"; };
+		B6D640931C3C62D000705A42 /* silabs-thread-1.0 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "silabs-thread-1.0"; path = "third_party/silabs-thread-1.0"; sourceTree = SOURCE_ROOT; };
+		B6D640941C3C62D000705A42 /* connectip-2.0 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "connectip-2.0"; path = "third_party/connectip-2.0"; sourceTree = SOURCE_ROOT; };
+		B6D640951C3C62D000705A42 /* connectip-1.1 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "connectip-1.1"; path = "third_party/connectip-1.1"; sourceTree = SOURCE_ROOT; };
+		B6D6409B1C3EF2EA00705A42 /* spi-server.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = "spi-server.md"; sourceTree = "<group>"; };
+		B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkRetain.cpp; sourceTree = "<group>"; };
+		B6E13FC61D5CF2A4001233C4 /* NetworkRetain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkRetain.h; sourceTree = "<group>"; };
+		B6F27E331AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-MfgFinish.cpp"; sourceTree = "<group>"; };
+		B6F27E341AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-MfgFinish.h"; sourceTree = "<group>"; };
+		B6F27E391AAE695700A6B996 /* TODO.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = TODO.md; path = ../TODO.md; sourceTree = "<group>"; };
+		B6F27E3A1AAE726C00A6B996 /* HACKING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = HACKING.md; path = ../HACKING.md; sourceTree = "<group>"; };
+		B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SocketAdapter.cpp; sourceTree = "<group>"; };
+		B6F27E3D1AAF7E0B00A6B996 /* SocketAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketAdapter.h; sourceTree = "<group>"; };
+		B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UnixSocket.cpp; sourceTree = "<group>"; };
+		B6F27E401AAF7EB400A6B996 /* UnixSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UnixSocket.h; sourceTree = "<group>"; };
+		B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SuperSocket.cpp; sourceTree = "<group>"; };
+		B6F27E431AAF7F2800A6B996 /* SuperSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperSocket.h; sourceTree = "<group>"; };
+		B6F27E451AAF837000A6B996 /* Callbacks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Callbacks.h; sourceTree = "<group>"; };
+		B6F27E461AAF86EC00A6B996 /* NCPConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCPConstants.h; sourceTree = "<group>"; };
+		B6F27E471AAF873900A6B996 /* EmberNCPUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EmberNCPUtils.h; sourceTree = "<group>"; };
+		B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EventHandler.cpp; sourceTree = "<group>"; };
+		B6F27E4D1AB21B8600A6B996 /* EventHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventHandler.h; sourceTree = "<group>"; };
+		B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NCPInstanceBase.cpp; sourceTree = "<group>"; };
+		B6F27E501AB3A23600A6B996 /* NCPInstanceBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCPInstanceBase.h; sourceTree = "<group>"; };
+		B6F27E531AB3A93C00A6B996 /* SocketAsyncOp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketAsyncOp.h; sourceTree = "<group>"; };
+		DC6F470818C93A2700DA3EDF /* time-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "time-utils.h"; sourceTree = "<group>"; };
+		E1102C09183A9AF60081771A /* NCPInstance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NCPInstance.cpp; sourceTree = "<group>"; };
+		E1102C0A183A9AF60081771A /* NCPInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NCPInstance.h; sourceTree = "<group>"; };
+		E1102C0C183A9B470081771A /* NilReturn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NilReturn.h; sourceTree = "<group>"; };
+		E1102C0D183A9ED90081771A /* DBUSIPCServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBUSIPCServer.h; sourceTree = "<group>"; };
+		E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DBUSHelpers.cpp; sourceTree = "<group>"; };
+		E1102C0F183A9FE00081771A /* DBUSHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DBUSHelpers.h; sourceTree = "<group>"; };
+		E1102C11183AAC030081771A /* EmberNCPInstance.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EmberNCPInstance.cpp; sourceTree = "<group>"; };
+		E1102C12183AAC030081771A /* EmberNCPInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmberNCPInstance.h; sourceTree = "<group>"; usesTabs = 1; };
+		E1102C14183AAD6F0081771A /* FirmwareInterface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FirmwareInterface.cpp; sourceTree = "<group>"; };
+		E1102C15183AAD6F0081771A /* FirmwareInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FirmwareInterface.h; sourceTree = "<group>"; };
+		E1102C18183AB3910081771A /* socket-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "socket-utils.h"; sourceTree = "<group>"; };
+		E1102C19183AB3990081771A /* socket-utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "socket-utils.c"; sourceTree = "<group>"; };
+		E1102C1B183AB9840081771A /* string-utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "string-utils.h"; sourceTree = "<group>"; };
+		E1102C1C183ABA530081771A /* string-utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "string-utils.c"; sourceTree = "<group>"; };
+		E1102C1E183ABE7A0081771A /* any-to.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "any-to.h"; sourceTree = "<group>"; };
+		E1102C1F183ABE880081771A /* any-to.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "any-to.cpp"; sourceTree = "<group>"; };
+		E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPv6PacketMatcher.cpp; sourceTree = "<group>"; };
+		E123EE86183272D200467C2F /* IPv6PacketMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPv6PacketMatcher.h; sourceTree = "<group>"; };
+		E123EE881832792D00467C2F /* Data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Data.cpp; sourceTree = "<group>"; };
+		E123EE891832792D00467C2F /* Data.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Data.h; sourceTree = "<group>"; };
+		E127376D18C5100C00789919 /* SocketWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SocketWrapper.cpp; sourceTree = "<group>"; };
+		E127376E18C5100C00789919 /* SocketWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SocketWrapper.h; sourceTree = "<group>"; };
+		E12737BA18C7C15400789919 /* nl.m4 */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = nl.m4; path = m4/nl.m4; sourceTree = "<group>"; };
+		E13DFA96184D289E008A3E07 /* wpan-dbus-v0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpan-dbus-v0.h"; sourceTree = "<group>"; };
+		E164541D175FD8F30013F188 /* IPCServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPCServer.h; sourceTree = "<group>"; };
+		E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DBUSIPCServer.cpp; sourceTree = "<group>"; };
+		E1645422175FFD540013F188 /* nlpt.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = nlpt.h; sourceTree = "<group>"; };
+		E1645423176121E30013F188 /* CallbackStore.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CallbackStore.hpp; sourceTree = "<group>"; };
+		E17D837218D8FB1500755867 /* time-utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "time-utils.c"; sourceTree = "<group>"; };
+		E194621217664A4E0001279F /* wpan-connman-plugin.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = "wpan-connman-plugin.c"; sourceTree = "<group>"; };
+		E19462141767F62D0001279F /* nlpt-select.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "nlpt-select.h"; sourceTree = "<group>"; };
+		E19462181768D8C20001279F /* wpanctl-cmds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wpanctl-cmds.h"; sourceTree = "<group>"; };
+		E19C111A182D71E8002B958B /* libboost_signals.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libboost_signals.dylib; path = ../../../usr/local/Cellar/boost/1.54.0/lib/libboost_signals.dylib; sourceTree = "<group>"; };
+		E19C111B182D71E8002B958B /* libdbus-1.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libdbus-1.3.dylib"; path = "../../../usr/local/Cellar/d-bus/1.6.12/lib/libdbus-1.3.dylib"; sourceTree = "<group>"; };
+		E19F483E1A71BDCE000502B4 /* version.c.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = version.c.in; sourceTree = "<group>"; };
+		E19F483F1A71BDCE000502B4 /* version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version.h; sourceTree = "<group>"; };
+		E1E20E3817FF2F5B000F39AA /* NetworkInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkInstance.h; sourceTree = "<group>"; };
+		E1E20E3A17FF2FC1000F39AA /* NCPControlInterface.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NCPControlInterface.h; sourceTree = "<group>"; };
+		E1EB4889196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-JoinTask.cpp"; sourceTree = "<group>"; };
+		E1EB488A196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-JoinTask.h"; sourceTree = "<group>"; };
+		E1EB488C196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-FormTask.cpp"; sourceTree = "<group>"; };
+		E1EB488D196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-FormTask.h"; sourceTree = "<group>"; };
+		E1EB488F196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-ScanTask.cpp"; sourceTree = "<group>"; };
+		E1EB4890196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-ScanTask.h"; sourceTree = "<group>"; };
+		E1EB4892196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-LurkTask.cpp"; sourceTree = "<group>"; };
+		E1EB4893196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-LurkTask.h"; sourceTree = "<group>"; };
+		E1EB4898196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-GetRIPEntryTask.cpp"; sourceTree = "<group>"; };
+		E1EB4899196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-GetRIPEntryTask.h"; sourceTree = "<group>"; };
+		E1EB489B196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "EmberNCPControlInterface-SendCommandTask.cpp"; sourceTree = "<group>"; };
+		E1EB489C196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EmberNCPControlInterface-SendCommandTask.h"; sourceTree = "<group>"; };
+		E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TunnelIPv6Interface.cpp; sourceTree = "<group>"; };
+		E1FD94071A81777500CB3CC7 /* TunnelIPv6Interface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TunnelIPv6Interface.h; sourceTree = "<group>"; };
+		E1FD94091A81821600CB3CC7 /* IPv6Helpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPv6Helpers.h; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A618B06E175BF2E10097500B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B68B78BA1C5806F900EC9FB8 /* soot.framework in Frameworks */,
+				E19C111D182D71E8002B958B /* libdbus-1.3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B61206A31CADDDA700A4E683 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B61206A41CADDDA700A4E683 /* soot.framework in Frameworks */,
+				B61206A51CADDDA700A4E683 /* libdbus-1.3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B64B68081CE153F000A113B4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B65301A51CC6E9F200B4F3DD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B65301A61CC6E9F200B4F3DD /* soot.framework in Frameworks */,
+				B65301A71CC6E9F200B4F3DD /* libdbus-1.3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B68B79EB1C65268500EC9FB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B68B79EC1C65268500EC9FB8 /* soot.framework in Frameworks */,
+				B68B79ED1C65268500EC9FB8 /* libdbus-1.3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A618B043175A8D740097500B = {
+			isa = PBXGroup;
+			children = (
+				B649D1C71BEACDA800C2E83A /* Autoconf Support */,
+				A618B04C175A8DBE0097500B /* Documentation */,
+				A618B053175A8DBE0097500B /* Sources */,
+				B649D1C81BEACDD300C2E83A /* Frameworks and Libraries */,
+				A618B072175BF2E10097500B /* Products */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 1;
+		};
+		A618B04C175A8DBE0097500B /* Documentation */ = {
+			isa = PBXGroup;
+			children = (
+				A618B052175A8DBE0097500B /* README.md */,
+				B6BF2C8B1C20EAF20083AD96 /* INSTALL.md */,
+				B6F27E391AAE695700A6B996 /* TODO.md */,
+				B6F27E3A1AAE726C00A6B996 /* HACKING.md */,
+				A618B04D175A8DBE0097500B /* Makefile.am */,
+				A618B04E175A8DBE0097500B /* wpan-dbus-protocol.md */,
+				A618B04F175A8DBE0097500B /* wpantund.1 */,
+				A618B050175A8DBE0097500B /* wpanctl.1 */,
+				B6D6409B1C3EF2EA00705A42 /* spi-server.md */,
+			);
+			name = Documentation;
+			path = doc;
+			sourceTree = "<group>";
+		};
+		A618B053175A8DBE0097500B /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				A618B05B175A8DBE0097500B /* Makefile.am */,
+				A618B07E175BF4700097500B /* config.h.in */,
+				E1946215176802EC0001279F /* util */,
+				E19462161768036B0001279F /* pt */,
+				A618B05C175A8DBE0097500B /* fgetln */,
+				E123EE8C18327B1A00467C2F /* wpanctl */,
+				E123EE8D18327B7200467C2F /* connman */,
+				E19F483E1A71BDCE000502B4 /* version.c.in */,
+				E19F483F1A71BDCE000502B4 /* version.h */,
+				B65301AE1CC6EA2500B4F3DD /* ncp-spinel */,
+				B6A3BE6B1C88BAC500976BE9 /* ncp-dummy */,
+				B68B78D11C65244500EC9FB8 /* ncp-silabs-tmsp */,
+				E123EE8B18327B0300467C2F /* ncp-silabs */,
+				E123EE8E18327BA200467C2F /* wpantund */,
+			);
+			name = Sources;
+			path = src;
+			sourceTree = "<group>";
+		};
+		A618B05C175A8DBE0097500B /* fgetln */ = {
+			isa = PBXGroup;
+			children = (
+				A618B05D175A8DBE0097500B /* fgetln.h */,
+			);
+			name = fgetln;
+			path = ../third_party/fgetln;
+			sourceTree = "<group>";
+		};
+		A618B072175BF2E10097500B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A618B071175BF2E10097500B /* wpantund */,
+				B68B79F21C65268500EC9FB8 /* wpantund-ncp-silabs-tmsp */,
+				B61206AA1CADDDA700A4E683 /* wpantund copy */,
+				B65301AC1CC6E9F200B4F3DD /* wpantund-ncp-dummy copy */,
+				B64B680B1CE153F000A113B4 /* spinel-unit-test */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B649D1C71BEACDA800C2E83A /* Autoconf Support */ = {
+			isa = PBXGroup;
+			children = (
+				A618B04A175A8DBE0097500B /* bootstrap.sh */,
+				A618B04B175A8DBE0097500B /* configure.ac */,
+				E12737BA18C7C15400789919 /* nl.m4 */,
+				A618B051175A8DBE0097500B /* Makefile.am */,
+			);
+			name = "Autoconf Support";
+			sourceTree = "<group>";
+		};
+		B649D1C81BEACDD300C2E83A /* Frameworks and Libraries */ = {
+			isa = PBXGroup;
+			children = (
+				B649D1C01BEACA8200C2E83A /* soot.xcodeproj */,
+				E19C111A182D71E8002B958B /* libboost_signals.dylib */,
+				E19C111B182D71E8002B958B /* libdbus-1.3.dylib */,
+			);
+			name = "Frameworks and Libraries";
+			sourceTree = "<group>";
+		};
+		B65301AE1CC6EA2500B4F3DD /* ncp-spinel */ = {
+			isa = PBXGroup;
+			children = (
+				B65301AF1CC6EA2500B4F3DD /* Makefile.am */,
+				B65301B01CC6EA2500B4F3DD /* SpinelNCPControlInterface.cpp */,
+				B65301B11CC6EA2500B4F3DD /* SpinelNCPControlInterface.h */,
+				B65301B31CC6EA2500B4F3DD /* SpinelNCPInstance.h */,
+				B65301B21CC6EA2500B4F3DD /* SpinelNCPInstance.cpp */,
+				B618F76C1CCAC260008B4AD4 /* SpinelNCPInstance-DataPump.cpp */,
+				B618F76F1CCACA6F008B4AD4 /* SpinelNCPInstance-Protothreads.cpp */,
+				B618F7771CCAEC4B008B4AD4 /* SpinelNCPTask.cpp */,
+				B618F77F1CCAEC4B008B4AD4 /* SpinelNCPTask.h */,
+				B618F7761CCAEC4B008B4AD4 /* SpinelNCPTaskWake.cpp */,
+				B618F77D1CCAEC4B008B4AD4 /* SpinelNCPTaskWake.h */,
+				B618F77E1CCAEC4B008B4AD4 /* SpinelNCPTaskDeepSleep.h */,
+				B618F7871CCAEC78008B4AD4 /* SpinelNCPTaskDeepSleep.cpp */,
+				B618F7711CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.cpp */,
+				B618F7781CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.h */,
+				B618F7721CCAEC4B008B4AD4 /* SpinelNCPTaskScan.cpp */,
+				B618F7791CCAEC4B008B4AD4 /* SpinelNCPTaskScan.h */,
+				B618F7731CCAEC4B008B4AD4 /* SpinelNCPTaskForm.cpp */,
+				B618F77A1CCAEC4B008B4AD4 /* SpinelNCPTaskForm.h */,
+				B618F7751CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.cpp */,
+				B618F77C1CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.h */,
+				B6B0D40A1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.cpp */,
+				B6B0D40B1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.h */,
+				B618F7741CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.cpp */,
+				B618F77B1CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.h */,
+				B65301B71CC6EACE00B4F3DD /* spinel.h */,
+				B618F7641CC82E79008B4AD4 /* spinel.c */,
+				B67DE7601CF4DE1300E4AE53 /* spinel-extra.c */,
+				B67DE7611CF4DE1300E4AE53 /* spinel-extra.h */,
+			);
+			path = "ncp-spinel";
+			sourceTree = "<group>";
+		};
+		B68754341C6BDDFD00C879D1 /* silabs-thread-1.0 */ = {
+			isa = PBXGroup;
+			children = (
+				B68754351C6BDDFD00C879D1 /* LICENSE */,
+				B68754361C6BDDFD00C879D1 /* README.google */,
+				B68754371C6BDDFD00C879D1 /* app */,
+				B68754D21C6BDDFD00C879D1 /* hal */,
+				B687556F1C6BDDFE00C879D1 /* phy */,
+				B687558F1C6BDDFE00C879D1 /* readme-main.txt */,
+				B68755901C6BDDFE00C879D1 /* stack */,
+				B68756461C6BDDFE00C879D1 /* tool */,
+			);
+			indentWidth = 2;
+			name = "silabs-thread-1.0";
+			path = "third_party/silabs-thread-1.0";
+			sourceTree = SOURCE_ROOT;
+			tabWidth = 4;
+			usesTabs = 0;
+		};
+		B68754371C6BDDFD00C879D1 /* app */ = {
+			isa = PBXGroup;
+			children = (
+				B68754381C6BDDFD00C879D1 /* afv6 */,
+				B68754431C6BDDFD00C879D1 /* ip-ncp */,
+				B687546E1C6BDDFD00C879D1 /* test */,
+				B68754741C6BDDFD00C879D1 /* tmsp */,
+				B68754841C6BDDFD00C879D1 /* udp */,
+				B68754921C6BDDFD00C879D1 /* util */,
+			);
+			path = app;
+			sourceTree = "<group>";
+		};
+		B68754381C6BDDFD00C879D1 /* afv6 */ = {
+			isa = PBXGroup;
+			children = (
+				B68754391C6BDDFD00C879D1 /* plugin */,
+			);
+			path = afv6;
+			sourceTree = "<group>";
+		};
+		B68754391C6BDDFD00C879D1 /* plugin */ = {
+			isa = PBXGroup;
+			children = (
+				B687543A1C6BDDFD00C879D1 /* common */,
+			);
+			path = plugin;
+			sourceTree = "<group>";
+		};
+		B687543A1C6BDDFD00C879D1 /* common */ = {
+			isa = PBXGroup;
+			children = (
+				B687543B1C6BDDFD00C879D1 /* common.h */,
+				B687543C1C6BDDFD00C879D1 /* list.c */,
+				B687543D1C6BDDFD00C879D1 /* list.h */,
+				B687543E1C6BDDFD00C879D1 /* scratchpad.h */,
+				B687543F1C6BDDFD00C879D1 /* structs.h */,
+				B68754401C6BDDFD00C879D1 /* unix-host-utilities.h */,
+				B68754411C6BDDFD00C879D1 /* uri-handler.h */,
+				B68754421C6BDDFD00C879D1 /* uri-parser.h */,
+			);
+			path = common;
+			sourceTree = "<group>";
+		};
+		B68754431C6BDDFD00C879D1 /* ip-ncp */ = {
+			isa = PBXGroup;
+			children = (
+				B68754441C6BDDFD00C879D1 /* ash-v3-test-app-configuration.h */,
+				B68754451C6BDDFD00C879D1 /* ash-v3-test-app.c */,
+				B68754461C6BDDFD00C879D1 /* ash-v3-test-app.mak */,
+				B68754471C6BDDFD00C879D1 /* binary-management.c */,
+				B68754481C6BDDFD00C879D1 /* binary-management.h */,
+				B68754491C6BDDFD00C879D1 /* data-client.c */,
+				B687544A1C6BDDFD00C879D1 /* data-client.h */,
+				B687544B1C6BDDFD00C879D1 /* fetch-store-utilities.c */,
+				B687544C1C6BDDFD00C879D1 /* fetch-store-utilities.h */,
+				B687544D1C6BDDFD00C879D1 /* host-stream.c */,
+				B687544E1C6BDDFD00C879D1 /* host-stream.h */,
+				B687544F1C6BDDFD00C879D1 /* ip-driver-app-configuration.h */,
+				B68754501C6BDDFD00C879D1 /* ip-driver-app-simulation.c */,
+				B68754511C6BDDFD00C879D1 /* ip-driver-app-unix-host.c */,
+				B68754521C6BDDFD00C879D1 /* ip-driver-app.c */,
+				B68754531C6BDDFD00C879D1 /* ip-driver-app.mak */,
+				B68754541C6BDDFD00C879D1 /* ip-driver-log.c */,
+				B68754551C6BDDFD00C879D1 /* ip-driver-log.h */,
+				B68754561C6BDDFD00C879D1 /* ip-driver.c */,
+				B68754571C6BDDFD00C879D1 /* ip-driver.h */,
+				B68754581C6BDDFD00C879D1 /* ip-management-enum.h */,
+				B68754591C6BDDFD00C879D1 /* ip-modem-app.c */,
+				B687545B1C6BDDFD00C879D1 /* ip-modem-configuration.h */,
+				B687545C1C6BDDFD00C879D1 /* ip-modem-library.h */,
+				B687545D1C6BDDFD00C879D1 /* ip-modem-link.c */,
+				B687545E1C6BDDFD00C879D1 /* ip-modem-link.h */,
+				B687545F1C6BDDFD00C879D1 /* management-serial.c */,
+				B68754601C6BDDFD00C879D1 /* ncp-deep-sleep.c */,
+				B68754611C6BDDFD00C879D1 /* ncp-emapi.c */,
+				B68754621C6BDDFD00C879D1 /* ncp-events.c */,
+				B68754631C6BDDFD00C879D1 /* ncp-events.h */,
+				B68754641C6BDDFD00C879D1 /* ncp-mfglib.c */,
+				B68754651C6BDDFD00C879D1 /* ncp-mfglib.h */,
+				B68754661C6BDDFD00C879D1 /* ncp-uart-interface.c */,
+				B68754671C6BDDFD00C879D1 /* ncp-uart-interface.h */,
+				B68754681C6BDDFD00C879D1 /* serial-link.c */,
+				B68754691C6BDDFD00C879D1 /* serial-link.h */,
+				B687546A1C6BDDFD00C879D1 /* spi-link-adapter.c */,
+				B687546B1C6BDDFD00C879D1 /* thread-ip-modem-configuration.h */,
+				B687546C1C6BDDFD00C879D1 /* uart-link-protocol.h */,
+				B687546D1C6BDDFD00C879D1 /* uart-link-stub.c */,
+			);
+			path = "ip-ncp";
+			sourceTree = "<group>";
+		};
+		B687546E1C6BDDFD00C879D1 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				B687546F1C6BDDFD00C879D1 /* common-test-commands.c */,
+				B68754701C6BDDFD00C879D1 /* common-test-commands.h */,
+				B68754711C6BDDFD00C879D1 /* scan-test-stub.c */,
+				B68754721C6BDDFD00C879D1 /* scan-test.c */,
+				B68754731C6BDDFD00C879D1 /* thread-test-app.c */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		B68754741C6BDDFD00C879D1 /* tmsp */ = {
+			isa = PBXGroup;
+			children = (
+				B68754751C6BDDFD00C879D1 /* tmsp-custom-enum-decode.c */,
+				B68754761C6BDDFD00C879D1 /* tmsp-custom-enum.h */,
+				B68754771C6BDDFD00C879D1 /* tmsp-enum-decode.c */,
+				B68754781C6BDDFD00C879D1 /* tmsp-enum.h */,
+				B68754791C6BDDFD00C879D1 /* tmsp-frame-utilities.c */,
+				B687547A1C6BDDFD00C879D1 /* tmsp-frame-utilities.h */,
+				B687547B1C6BDDFD00C879D1 /* tmsp-host-nest-specific.c */,
+				B687547C1C6BDDFD00C879D1 /* tmsp-host-utilities.c */,
+				B687547E1C6BDDFD00C879D1 /* tmsp-host-utilities.h */,
+				B687547F1C6BDDFD00C879D1 /* tmsp-host.c */,
+				B68754801C6BDDFD00C879D1 /* tmsp-ncp-nest-specific.c */,
+				B68754811C6BDDFD00C879D1 /* tmsp-ncp-utilities.c */,
+				B68754821C6BDDFD00C879D1 /* tmsp-ncp-utilities.h */,
+				B68754831C6BDDFD00C879D1 /* tmsp-ncp.c */,
+			);
+			path = tmsp;
+			sourceTree = "<group>";
+		};
+		B68754841C6BDDFD00C879D1 /* udp */ = {
+			isa = PBXGroup;
+			children = (
+				B68754851C6BDDFD00C879D1 /* nest-host-stub-app.mak */,
+				B68754861C6BDDFD00C879D1 /* nest-stub-app.c */,
+				B68754871C6BDDFD00C879D1 /* nest-thread-app-configuration.h */,
+				B68754881C6BDDFD00C879D1 /* nest-tokens.h */,
+				B68754891C6BDDFD00C879D1 /* qa-thread-app-configuration.h */,
+				B687548A1C6BDDFD00C879D1 /* thread-app-configuration.h */,
+				B687548B1C6BDDFD00C879D1 /* thread-app-stubs.c */,
+				B687548C1C6BDDFD00C879D1 /* thread-app.c */,
+				B687548D1C6BDDFD00C879D1 /* thread-deep-sleep.c */,
+				B687548E1C6BDDFD00C879D1 /* thread-ecc-certificate.c */,
+				B687548F1C6BDDFD00C879D1 /* thread-ecc-certificate.h */,
+				B68754901C6BDDFD00C879D1 /* thread-host-app-configuration.h */,
+				B68754911C6BDDFD00C879D1 /* thread-host-app.mak */,
+			);
+			path = udp;
+			sourceTree = "<group>";
+		};
+		B68754921C6BDDFD00C879D1 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				B68754931C6BDDFD00C879D1 /* bootload */,
+				B68754B41C6BDDFD00C879D1 /* counters */,
+				B68754B61C6BDDFD00C879D1 /* ip */,
+				B68754C31C6BDDFD00C879D1 /* serial */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		B68754931C6BDDFD00C879D1 /* bootload */ = {
+			isa = PBXGroup;
+			children = (
+				B68754941C6BDDFD00C879D1 /* tftp */,
+				B68754A71C6BDDFD00C879D1 /* tftp-bootloader */,
+			);
+			path = bootload;
+			sourceTree = "<group>";
+		};
+		B68754941C6BDDFD00C879D1 /* tftp */ = {
+			isa = PBXGroup;
+			children = (
+				B68754951C6BDDFD00C879D1 /* client */,
+				B687549C1C6BDDFD00C879D1 /* server */,
+				B68754A31C6BDDFD00C879D1 /* tftp-15-4.c */,
+				B68754A41C6BDDFD00C879D1 /* tftp-posix.c */,
+				B68754A51C6BDDFD00C879D1 /* tftp.c */,
+				B68754A61C6BDDFD00C879D1 /* tftp.h */,
+			);
+			path = tftp;
+			sourceTree = "<group>";
+		};
+		B68754951C6BDDFD00C879D1 /* client */ = {
+			isa = PBXGroup;
+			children = (
+				B68754961C6BDDFD00C879D1 /* tftp-client-app-configuration.h */,
+				B68754971C6BDDFD00C879D1 /* tftp-client-app.c */,
+				B68754981C6BDDFD00C879D1 /* tftp-client.c */,
+				B68754991C6BDDFD00C879D1 /* tftp-client.h */,
+				B687549A1C6BDDFD00C879D1 /* tftp-file-reader.c */,
+				B687549B1C6BDDFD00C879D1 /* tftp-file-reader.h */,
+			);
+			path = client;
+			sourceTree = "<group>";
+		};
+		B687549C1C6BDDFD00C879D1 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				B687549D1C6BDDFD00C879D1 /* tftp-server-app-configuration.h */,
+				B687549E1C6BDDFD00C879D1 /* tftp-server-app.c */,
+				B687549F1C6BDDFD00C879D1 /* tftp-server-posix.c */,
+				B68754A01C6BDDFD00C879D1 /* tftp-server-stub.c */,
+				B68754A11C6BDDFD00C879D1 /* tftp-server.c */,
+				B68754A21C6BDDFD00C879D1 /* tftp-server.h */,
+			);
+			path = server;
+			sourceTree = "<group>";
+		};
+		B68754A71C6BDDFD00C879D1 /* tftp-bootloader */ = {
+			isa = PBXGroup;
+			children = (
+				B68754A81C6BDDFD00C879D1 /* client */,
+				B68754AC1C6BDDFD00C879D1 /* server */,
+				B68754B01C6BDDFD00C879D1 /* tftp-bootloader-15-4.c */,
+				B68754B11C6BDDFD00C879D1 /* tftp-bootloader-stub.c */,
+				B68754B21C6BDDFD00C879D1 /* tftp-bootloader.c */,
+				B68754B31C6BDDFD00C879D1 /* tftp-bootloader.h */,
+			);
+			path = "tftp-bootloader";
+			sourceTree = "<group>";
+		};
+		B68754A81C6BDDFD00C879D1 /* client */ = {
+			isa = PBXGroup;
+			children = (
+				B68754A91C6BDDFD00C879D1 /* tftp-bootloader-client-app-configuration.h */,
+				B68754AA1C6BDDFD00C879D1 /* tftp-bootloader-client.c */,
+				B68754AB1C6BDDFD00C879D1 /* tftp-bootloader-client.h */,
+			);
+			path = client;
+			sourceTree = "<group>";
+		};
+		B68754AC1C6BDDFD00C879D1 /* server */ = {
+			isa = PBXGroup;
+			children = (
+				B68754AD1C6BDDFD00C879D1 /* tftp-bootloader-server-stub.c */,
+				B68754AE1C6BDDFD00C879D1 /* tftp-bootloader-server.c */,
+				B68754AF1C6BDDFD00C879D1 /* tftp-bootloader-server.h */,
+			);
+			path = server;
+			sourceTree = "<group>";
+		};
+		B68754B41C6BDDFD00C879D1 /* counters */ = {
+			isa = PBXGroup;
+			children = (
+				B68754B51C6BDDFD00C879D1 /* counters.h */,
+			);
+			path = counters;
+			sourceTree = "<group>";
+		};
+		B68754B61C6BDDFD00C879D1 /* ip */ = {
+			isa = PBXGroup;
+			children = (
+				B68754B71C6BDDFD00C879D1 /* common-commands.c */,
+				B68754B81C6BDDFD00C879D1 /* common-commands.h */,
+				B68754B91C6BDDFD00C879D1 /* counters.c */,
+				B68754BA1C6BDDFD00C879D1 /* internal-commands.c */,
+				B68754BB1C6BDDFD00C879D1 /* mfglib-commands.c */,
+				B68754BC1C6BDDFD00C879D1 /* mfglib-commands.h */,
+				B68754BD1C6BDDFD00C879D1 /* network-management-commands.c */,
+				B68754BE1C6BDDFD00C879D1 /* network-management-commands.h */,
+				B68754BF1C6BDDFD00C879D1 /* print-utilities.c */,
+				B68754C01C6BDDFD00C879D1 /* print-utilities.h */,
+				B68754C11C6BDDFD00C879D1 /* wakeup-commands.c */,
+				B68754C21C6BDDFD00C879D1 /* wakeup-commands.h */,
+			);
+			path = ip;
+			sourceTree = "<group>";
+		};
+		B68754C31C6BDDFD00C879D1 /* serial */ = {
+			isa = PBXGroup;
+			children = (
+				B68754C41C6BDDFD00C879D1 /* command-interpreter.c */,
+				B68754C51C6BDDFD00C879D1 /* command-interpreter.h */,
+				B68754C61C6BDDFD00C879D1 /* command-interpreter2-binary.c */,
+				B68754C71C6BDDFD00C879D1 /* command-interpreter2-error.c */,
+				B68754C81C6BDDFD00C879D1 /* command-interpreter2-util.c */,
+				B68754C91C6BDDFD00C879D1 /* command-interpreter2-util.h */,
+				B68754CA1C6BDDFD00C879D1 /* command-interpreter2.c */,
+				B68754CB1C6BDDFD00C879D1 /* command-interpreter2.h */,
+				B68754CD1C6BDDFD00C879D1 /* ember-printf.c */,
+				B68754CE1C6BDDFD00C879D1 /* ember-printf.h */,
+				B68754CF1C6BDDFD00C879D1 /* serial.c */,
+				B68754D01C6BDDFD00C879D1 /* serial.h */,
+				B68754D11C6BDDFD00C879D1 /* simple-linux-serial.c */,
+			);
+			path = serial;
+			sourceTree = "<group>";
+		};
+		B68754D21C6BDDFD00C879D1 /* hal */ = {
+			isa = PBXGroup;
+			children = (
+				B68754D31C6BDDFD00C879D1 /* config */,
+				B68754F91C6BDDFD00C879D1 /* ember-base-configuration.c */,
+				B68754FA1C6BDDFD00C879D1 /* ember-configuration.c */,
+				B68754FB1C6BDDFD00C879D1 /* hal.h */,
+				B68754FC1C6BDDFD00C879D1 /* host */,
+				B68755091C6BDDFD00C879D1 /* micro */,
+				B68755641C6BDDFE00C879D1 /* test */,
+			);
+			path = hal;
+			sourceTree = "<group>";
+		};
+		B68754D31C6BDDFD00C879D1 /* config */ = {
+			isa = PBXGroup;
+			children = (
+				B68754D41C6BDDFD00C879D1 /* battery-monitor */,
+				B68754D71C6BDDFD00C879D1 /* boardHeaders.properties */,
+				B68754D81C6BDDFD00C879D1 /* bootloader.properties */,
+				B68754D91C6BDDFD00C879D1 /* button-callback.info */,
+				B68754DA1C6BDDFD00C879D1 /* button-interface */,
+				B68754DD1C6BDDFD00C879D1 /* generic-interrupt-control */,
+				B68754DF1C6BDDFD00C879D1 /* gpio-sensor */,
+				B68754E21C6BDDFD00C879D1 /* hal-callback.info */,
+				B68754E31C6BDDFD00C879D1 /* halOptions.properties */,
+				B68754E41C6BDDFD00C879D1 /* i2c-driver */,
+				B68754E61C6BDDFD00C879D1 /* i2c-driver-stub */,
+				B68754E81C6BDDFD00C879D1 /* led-blink */,
+				B68754EA1C6BDDFD00C879D1 /* microphone-codec-msadpcm-callback.info */,
+				B68754EB1C6BDDFD00C879D1 /* plugin.info */,
+				B68754EC1C6BDDFD00C879D1 /* sb1-gesture-sensor */,
+				B68754F01C6BDDFD00C879D1 /* serial.properties */,
+				B68754F11C6BDDFD00C879D1 /* sim-eeprom-callback.info */,
+				B68754F21C6BDDFD00C879D1 /* spi-protocol-callback.info */,
+				B68754F31C6BDDFD00C879D1 /* tamper-switch */,
+				B68754F61C6BDDFD00C879D1 /* temperature-si7053 */,
+			);
+			path = config;
+			sourceTree = "<group>";
+		};
+		B68754D41C6BDDFD00C879D1 /* battery-monitor */ = {
+			isa = PBXGroup;
+			children = (
+				B68754D51C6BDDFD00C879D1 /* callbacks.info */,
+				B68754D61C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "battery-monitor";
+			sourceTree = "<group>";
+		};
+		B68754DA1C6BDDFD00C879D1 /* button-interface */ = {
+			isa = PBXGroup;
+			children = (
+				B68754DB1C6BDDFD00C879D1 /* callbacks.info */,
+				B68754DC1C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "button-interface";
+			sourceTree = "<group>";
+		};
+		B68754DD1C6BDDFD00C879D1 /* generic-interrupt-control */ = {
+			isa = PBXGroup;
+			children = (
+				B68754DE1C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "generic-interrupt-control";
+			sourceTree = "<group>";
+		};
+		B68754DF1C6BDDFD00C879D1 /* gpio-sensor */ = {
+			isa = PBXGroup;
+			children = (
+				B68754E01C6BDDFD00C879D1 /* callbacks.info */,
+				B68754E11C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "gpio-sensor";
+			sourceTree = "<group>";
+		};
+		B68754E41C6BDDFD00C879D1 /* i2c-driver */ = {
+			isa = PBXGroup;
+			children = (
+				B68754E51C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "i2c-driver";
+			sourceTree = "<group>";
+		};
+		B68754E61C6BDDFD00C879D1 /* i2c-driver-stub */ = {
+			isa = PBXGroup;
+			children = (
+				B68754E71C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "i2c-driver-stub";
+			sourceTree = "<group>";
+		};
+		B68754E81C6BDDFD00C879D1 /* led-blink */ = {
+			isa = PBXGroup;
+			children = (
+				B68754E91C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "led-blink";
+			sourceTree = "<group>";
+		};
+		B68754EC1C6BDDFD00C879D1 /* sb1-gesture-sensor */ = {
+			isa = PBXGroup;
+			children = (
+				B68754ED1C6BDDFD00C879D1 /* callbacks.info */,
+				B68754EE1C6BDDFD00C879D1 /* cli.xml */,
+				B68754EF1C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "sb1-gesture-sensor";
+			sourceTree = "<group>";
+		};
+		B68754F31C6BDDFD00C879D1 /* tamper-switch */ = {
+			isa = PBXGroup;
+			children = (
+				B68754F41C6BDDFD00C879D1 /* callbacks.info */,
+				B68754F51C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "tamper-switch";
+			sourceTree = "<group>";
+		};
+		B68754F61C6BDDFD00C879D1 /* temperature-si7053 */ = {
+			isa = PBXGroup;
+			children = (
+				B68754F71C6BDDFD00C879D1 /* callbacks.info */,
+				B68754F81C6BDDFD00C879D1 /* plugin.properties */,
+			);
+			path = "temperature-si7053";
+			sourceTree = "<group>";
+		};
+		B68754FC1C6BDDFD00C879D1 /* host */ = {
+			isa = PBXGroup;
+			children = (
+				B68754FD1C6BDDFD00C879D1 /* bootloader-eeprom.h */,
+				B68754FE1C6BDDFD00C879D1 /* button-common.h */,
+				B68754FF1C6BDDFD00C879D1 /* crc.h */,
+				B68755001C6BDDFD00C879D1 /* generic */,
+				B68755041C6BDDFD00C879D1 /* led-common.h */,
+				B68755051C6BDDFD00C879D1 /* micro-common.h */,
+				B68755061C6BDDFD00C879D1 /* serial.h */,
+				B68755071C6BDDFD00C879D1 /* spi-protocol-common.h */,
+				B68755081C6BDDFD00C879D1 /* system-timer.h */,
+			);
+			path = host;
+			sourceTree = "<group>";
+		};
+		B68755001C6BDDFD00C879D1 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				B68755011C6BDDFD00C879D1 /* compiler */,
+				B68755031C6BDDFD00C879D1 /* crc.c */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		B68755011C6BDDFD00C879D1 /* compiler */ = {
+			isa = PBXGroup;
+			children = (
+				B68755021C6BDDFD00C879D1 /* platform-common.h */,
+			);
+			path = compiler;
+			sourceTree = "<group>";
+		};
+		B68755091C6BDDFD00C879D1 /* micro */ = {
+			isa = PBXGroup;
+			children = (
+				B687550A1C6BDDFD00C879D1 /* accelerometer-led.h */,
+				B687550B1C6BDDFD00C879D1 /* adc.h */,
+				B687550C1C6BDDFD00C879D1 /* antenna.h */,
+				B687550D1C6BDDFD00C879D1 /* battery-monitor.h */,
+				B687550E1C6BDDFD00C879D1 /* bootloader-eeprom.h */,
+				B687550F1C6BDDFD00C879D1 /* bootloader-interface-app.h */,
+				B68755101C6BDDFD00C879D1 /* bootloader-interface-standalone.h */,
+				B68755111C6BDDFD00C879D1 /* bootloader-interface.h */,
+				B68755121C6BDDFD00C879D1 /* button-interface.h */,
+				B68755131C6BDDFD00C879D1 /* button.h */,
+				B68755141C6BDDFD00C879D1 /* buzzer.h */,
+				B68755151C6BDDFD00C879D1 /* caladc.h */,
+				B68755161C6BDDFD00C879D1 /* crc.h */,
+				B68755171C6BDDFD00C879D1 /* diagnostic.h */,
+				B68755181C6BDDFD00C879D1 /* dog_glcd.h */,
+				B68755191C6BDDFD00C879D1 /* endian.h */,
+				B687551A1C6BDDFD00C879D1 /* flash.h */,
+				B687551B1C6BDDFD00C879D1 /* generic */,
+				B687553B1C6BDDFE00C879D1 /* generic-interrupt-control.h */,
+				B687553C1C6BDDFE00C879D1 /* gpio-sensor.h */,
+				B687553D1C6BDDFE00C879D1 /* i2c-driver.h */,
+				B687553E1C6BDDFE00C879D1 /* infrared-led-driver-emit.h */,
+				B687553F1C6BDDFE00C879D1 /* infrared-led-driver-sird.h */,
+				B68755401C6BDDFE00C879D1 /* infrared-led-driver-uird.h */,
+				B68755411C6BDDFE00C879D1 /* infrared-led-driver.h */,
+				B68755421C6BDDFE00C879D1 /* key-matrix-driver.h */,
+				B68755431C6BDDFE00C879D1 /* led-blink.h */,
+				B68755441C6BDDFE00C879D1 /* led.h */,
+				B68755451C6BDDFE00C879D1 /* micro-common.h */,
+				B68755461C6BDDFE00C879D1 /* micro-types.h */,
+				B68755471C6BDDFE00C879D1 /* micro.h */,
+				B68755481C6BDDFE00C879D1 /* microphone-codec-msadpcm.h */,
+				B68755491C6BDDFE00C879D1 /* msadpcm.h */,
+				B687554A1C6BDDFE00C879D1 /* random.h */,
+				B687554B1C6BDDFE00C879D1 /* sb1-gesture-sensor.h */,
+				B687554C1C6BDDFE00C879D1 /* serial-minimal.h */,
+				B687554D1C6BDDFE00C879D1 /* serial.h */,
+				B687554E1C6BDDFE00C879D1 /* sim-eeprom.h */,
+				B687554F1C6BDDFE00C879D1 /* spi.h */,
+				B68755501C6BDDFE00C879D1 /* symbol-timer.h */,
+				B68755511C6BDDFE00C879D1 /* system-timer.h */,
+				B68755521C6BDDFE00C879D1 /* tamper-switch.h */,
+				B68755531C6BDDFE00C879D1 /* temperature.h */,
+				B68755541C6BDDFE00C879D1 /* token.h */,
+				B68755551C6BDDFE00C879D1 /* uart-link.h */,
+				B68755561C6BDDFE00C879D1 /* unix */,
+			);
+			path = micro;
+			sourceTree = "<group>";
+		};
+		B687551B1C6BDDFD00C879D1 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				B687551C1C6BDDFD00C879D1 /* aes */,
+				B68755211C6BDDFD00C879D1 /* antenna-stub.c */,
+				B68755221C6BDDFD00C879D1 /* ash-common.c */,
+				B68755231C6BDDFD00C879D1 /* ash-common.h */,
+				B68755241C6BDDFD00C879D1 /* ash-protocol.h */,
+				B68755251C6BDDFD00C879D1 /* ash-v3-stubs.c */,
+				B68755261C6BDDFD00C879D1 /* ash-v3.c */,
+				B68755271C6BDDFD00C879D1 /* ash-v3.h */,
+				B68755281C6BDDFD00C879D1 /* button-stub.c */,
+				B68755291C6BDDFD00C879D1 /* buzzer-stub.c */,
+				B687552A1C6BDDFD00C879D1 /* compiler */,
+				B687552C1C6BDDFE00C879D1 /* crc.c */,
+				B687552D1C6BDDFE00C879D1 /* diagnostic-stub.c */,
+				B687552E1C6BDDFE00C879D1 /* em2xx-reset-defs.h */,
+				B687552F1C6BDDFE00C879D1 /* endian.c */,
+				B68755301C6BDDFE00C879D1 /* i2c-driver-stub.c */,
+				B68755311C6BDDFE00C879D1 /* led-stub.c */,
+				B68755321C6BDDFE00C879D1 /* mem-util.c */,
+				B68755331C6BDDFE00C879D1 /* micro-stub.c */,
+				B68755341C6BDDFE00C879D1 /* micro.h */,
+				B68755351C6BDDFE00C879D1 /* random.c */,
+				B68755361C6BDDFE00C879D1 /* sim-eeprom-internal.c */,
+				B68755371C6BDDFE00C879D1 /* sim-eeprom.c */,
+				B68755381C6BDDFE00C879D1 /* sim-eeprom2.c */,
+				B68755391C6BDDFE00C879D1 /* system-timer.c */,
+				B687553A1C6BDDFE00C879D1 /* token-ram.h */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		B687551C1C6BDDFD00C879D1 /* aes */ = {
+			isa = PBXGroup;
+			children = (
+				B687551D1C6BDDFD00C879D1 /* rijndael-alg-fst.c */,
+				B687551E1C6BDDFD00C879D1 /* rijndael-alg-fst.h */,
+				B687551F1C6BDDFD00C879D1 /* rijndael-api-fst.c */,
+				B68755201C6BDDFD00C879D1 /* rijndael-api-fst.h */,
+			);
+			path = aes;
+			sourceTree = "<group>";
+		};
+		B687552A1C6BDDFD00C879D1 /* compiler */ = {
+			isa = PBXGroup;
+			children = (
+				B687552B1C6BDDFE00C879D1 /* platform-common.h */,
+			);
+			path = compiler;
+			sourceTree = "<group>";
+		};
+		B68755561C6BDDFE00C879D1 /* unix */ = {
+			isa = PBXGroup;
+			children = (
+				B68755571C6BDDFE00C879D1 /* compiler */,
+				B68755591C6BDDFE00C879D1 /* host */,
+				B68755601C6BDDFE00C879D1 /* simulation */,
+			);
+			path = unix;
+			sourceTree = "<group>";
+		};
+		B68755571C6BDDFE00C879D1 /* compiler */ = {
+			isa = PBXGroup;
+			children = (
+				B68755581C6BDDFE00C879D1 /* gcc.h */,
+			);
+			path = compiler;
+			sourceTree = "<group>";
+		};
+		B68755591C6BDDFE00C879D1 /* host */ = {
+			isa = PBXGroup;
+			children = (
+				B687555A1C6BDDFE00C879D1 /* board */,
+				B687555C1C6BDDFE00C879D1 /* micro.c */,
+				B687555D1C6BDDFE00C879D1 /* micro.h */,
+				B687555E1C6BDDFE00C879D1 /* spi-protocol-common.h */,
+				B687555F1C6BDDFE00C879D1 /* spi-protocol-linux.c */,
+			);
+			path = host;
+			sourceTree = "<group>";
+		};
+		B687555A1C6BDDFE00C879D1 /* board */ = {
+			isa = PBXGroup;
+			children = (
+				B687555B1C6BDDFE00C879D1 /* host.h */,
+			);
+			path = board;
+			sourceTree = "<group>";
+		};
+		B68755601C6BDDFE00C879D1 /* simulation */ = {
+			isa = PBXGroup;
+			children = (
+				B68755611C6BDDFE00C879D1 /* bootloader.h */,
+				B68755621C6BDDFE00C879D1 /* micro.h */,
+				B68755631C6BDDFE00C879D1 /* system-timer-sim.h */,
+			);
+			path = simulation;
+			sourceTree = "<group>";
+		};
+		B68755641C6BDDFE00C879D1 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				B68755651C6BDDFE00C879D1 /* misc-test.c */,
+				B68755661C6BDDFE00C879D1 /* nodetest-modules-em358_usb.ham */,
+				B68755671C6BDDFE00C879D1 /* nodetest-modules-em3xx.ham */,
+				B68755681C6BDDFE00C879D1 /* platformtest-configuration.h */,
+				B68755691C6BDDFE00C879D1 /* platformtest.c */,
+				B687556A1C6BDDFE00C879D1 /* platformtest.h */,
+				B687556B1C6BDDFE00C879D1 /* reset-test.c */,
+				B687556C1C6BDDFE00C879D1 /* response.c */,
+				B687556D1C6BDDFE00C879D1 /* response.h */,
+				B687556E1C6BDDFE00C879D1 /* token-test.c */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		B687556F1C6BDDFE00C879D1 /* phy */ = {
+			isa = PBXGroup;
+			children = (
+				B68755701C6BDDFE00C879D1 /* bridge */,
+				B687557E1C6BDDFE00C879D1 /* child-table.c */,
+				B687557F1C6BDDFE00C879D1 /* mfglib.c */,
+				B68755801C6BDDFE00C879D1 /* phy-appended-info.h */,
+				B68755811C6BDDFE00C879D1 /* phy-library.c */,
+				B68755821C6BDDFE00C879D1 /* phy-util.c */,
+				B68755831C6BDDFE00C879D1 /* phy.h */,
+				B68755841C6BDDFE00C879D1 /* security.h */,
+				B68755851C6BDDFE00C879D1 /* si446x */,
+				B68755871C6BDDFE00C879D1 /* simulation */,
+				B687558A1C6BDDFE00C879D1 /* test */,
+			);
+			path = phy;
+			sourceTree = "<group>";
+		};
+		B68755701C6BDDFE00C879D1 /* bridge */ = {
+			isa = PBXGroup;
+			children = (
+				B68755711C6BDDFE00C879D1 /* ethernet */,
+				B687557A1C6BDDFE00C879D1 /* test */,
+				B687557C1C6BDDFE00C879D1 /* zigbee-bridge-internal.h */,
+				B687557D1C6BDDFE00C879D1 /* zigbee-bridge.h */,
+			);
+			path = bridge;
+			sourceTree = "<group>";
+		};
+		B68755711C6BDDFE00C879D1 /* ethernet */ = {
+			isa = PBXGroup;
+			children = (
+				B68755721C6BDDFE00C879D1 /* ethernet.h */,
+				B68755731C6BDDFE00C879D1 /* homeplug */,
+			);
+			path = ethernet;
+			sourceTree = "<group>";
+		};
+		B68755731C6BDDFE00C879D1 /* homeplug */ = {
+			isa = PBXGroup;
+			children = (
+				B68755741C6BDDFE00C879D1 /* green-phy */,
+			);
+			path = homeplug;
+			sourceTree = "<group>";
+		};
+		B68755741C6BDDFE00C879D1 /* green-phy */ = {
+			isa = PBXGroup;
+			children = (
+				B68755751C6BDDFE00C879D1 /* atheros */,
+				B68755791C6BDDFE00C879D1 /* green-phy.h */,
+			);
+			path = "green-phy";
+			sourceTree = "<group>";
+		};
+		B68755751C6BDDFE00C879D1 /* atheros */ = {
+			isa = PBXGroup;
+			children = (
+				B68755761C6BDDFE00C879D1 /* pl04-mgt.h */,
+				B68755771C6BDDFE00C879D1 /* test */,
+			);
+			path = atheros;
+			sourceTree = "<group>";
+		};
+		B68755771C6BDDFE00C879D1 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				B68755781C6BDDFE00C879D1 /* pl04-test.c */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		B687557A1C6BDDFE00C879D1 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				B687557B1C6BDDFE00C879D1 /* bridge-test.c */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		B68755851C6BDDFE00C879D1 /* si446x */ = {
+			isa = PBXGroup;
+			children = (
+				B68755861C6BDDFE00C879D1 /* phy.h */,
+			);
+			path = si446x;
+			sourceTree = "<group>";
+		};
+		B68755871C6BDDFE00C879D1 /* simulation */ = {
+			isa = PBXGroup;
+			children = (
+				B68755881C6BDDFE00C879D1 /* aes-software.c */,
+				B68755891C6BDDFE00C879D1 /* security.h */,
+			);
+			path = simulation;
+			sourceTree = "<group>";
+		};
+		B687558A1C6BDDFE00C879D1 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				B687558B1C6BDDFE00C879D1 /* phy-common-rx-test.c */,
+				B687558C1C6BDDFE00C879D1 /* phy-common-test.c */,
+				B687558D1C6BDDFE00C879D1 /* phy-common-test.h */,
+				B687558E1C6BDDFE00C879D1 /* phy-common-tx-test.c */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		B68755901C6BDDFE00C879D1 /* stack */ = {
+			isa = PBXGroup;
+			children = (
+				B68755911C6BDDFE00C879D1 /* config */,
+				B68755981C6BDDFE00C879D1 /* core */,
+				B687559D1C6BDDFE00C879D1 /* framework */,
+				B68755AD1C6BDDFE00C879D1 /* include */,
+				B68755C61C6BDDFE00C879D1 /* ip */,
+				B68756331C6BDDFE00C879D1 /* mac */,
+				B687563B1C6BDDFE00C879D1 /* platform */,
+				B68756411C6BDDFE00C879D1 /* routing */,
+			);
+			path = stack;
+			sourceTree = "<group>";
+		};
+		B68755911C6BDDFE00C879D1 /* config */ = {
+			isa = PBXGroup;
+			children = (
+				B68755921C6BDDFE00C879D1 /* config.h */,
+				B68755941C6BDDFE00C879D1 /* ember-configuration-defaults.h */,
+				B68755951C6BDDFE00C879D1 /* ember-ip-configuration.c */,
+				B68755961C6BDDFE00C879D1 /* token-phy.h */,
+				B68755971C6BDDFE00C879D1 /* token-stack.h */,
+			);
+			path = config;
+			sourceTree = "<group>";
+		};
+		B68755981C6BDDFE00C879D1 /* core */ = {
+			isa = PBXGroup;
+			children = (
+				B68755991C6BDDFE00C879D1 /* ember-stack.h */,
+				B687559A1C6BDDFE00C879D1 /* log-gen.h */,
+				B687559B1C6BDDFE00C879D1 /* log.c */,
+				B687559C1C6BDDFE00C879D1 /* log.h */,
+			);
+			path = core;
+			sourceTree = "<group>";
+		};
+		B687559D1C6BDDFE00C879D1 /* framework */ = {
+			isa = PBXGroup;
+			children = (
+				B687559E1C6BDDFE00C879D1 /* buffer-malloc.c */,
+				B687559F1C6BDDFE00C879D1 /* buffer-malloc.h */,
+				B68755A01C6BDDFE00C879D1 /* buffer-management.c */,
+				B68755A11C6BDDFE00C879D1 /* buffer-management.h */,
+				B68755A21C6BDDFE00C879D1 /* buffer-queue.c */,
+				B68755A31C6BDDFE00C879D1 /* buffer-queue.h */,
+				B68755A41C6BDDFE00C879D1 /* byte-utilities.c */,
+				B68755A51C6BDDFE00C879D1 /* debug-gen.h */,
+				B68755A61C6BDDFE00C879D1 /* debug-message-type-gen.h */,
+				B68755A71C6BDDFE00C879D1 /* debug.h */,
+				B68755A81C6BDDFE00C879D1 /* eui64.h */,
+				B68755A91C6BDDFE00C879D1 /* event-control.c */,
+				B68755AA1C6BDDFE00C879D1 /* event-queue.c */,
+				B68755AB1C6BDDFE00C879D1 /* event-queue.h */,
+				B68755AC1C6BDDFE00C879D1 /* ip-packet-header.h */,
+			);
+			path = framework;
+			sourceTree = "<group>";
+		};
+		B68755AD1C6BDDFE00C879D1 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				B68755AE1C6BDDFE00C879D1 /* byte-utilities.h */,
+				B68755AF1C6BDDFE00C879D1 /* cbke-crypto-engine.h */,
+				B68755B01C6BDDFE00C879D1 /* child.h */,
+				B68755B11C6BDDFE00C879D1 /* coap.h */,
+				B68755B21C6BDDFE00C879D1 /* counter.h */,
+				B68755B31C6BDDFE00C879D1 /* define-ember-api.h */,
+				B68755B41C6BDDFE00C879D1 /* ember-debug.h */,
+				B68755B51C6BDDFE00C879D1 /* ember-types.h */,
+				B68755B61C6BDDFE00C879D1 /* ember.h */,
+				B68755B71C6BDDFE00C879D1 /* error-def.h */,
+				B68755B81C6BDDFE00C879D1 /* error.h */,
+				B68755B91C6BDDFE00C879D1 /* event.h */,
+				B68755BA1C6BDDFE00C879D1 /* icmp.h */,
+				B68755BB1C6BDDFE00C879D1 /* mfglib.h */,
+				B68755BC1C6BDDFE00C879D1 /* network-management.h */,
+				B68755BD1C6BDDFE00C879D1 /* packet-buffer.h */,
+				B68755BE1C6BDDFE00C879D1 /* stack-info.h */,
+				B68755BF1C6BDDFE00C879D1 /* tcp.h */,
+				B68755C11C6BDDFE00C879D1 /* thread-debug.h */,
+				B68755C21C6BDDFE00C879D1 /* udp-peer.h */,
+				B68755C31C6BDDFE00C879D1 /* udp.h */,
+				B68755C41C6BDDFE00C879D1 /* undefine-ember-api.h */,
+				B68755C51C6BDDFE00C879D1 /* wakeup.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		B68755C61C6BDDFE00C879D1 /* ip */ = {
+			isa = PBXGroup;
+			children = (
+				B68755C71C6BDDFE00C879D1 /* 6lowpan-header.h */,
+				B68755C81C6BDDFE00C879D1 /* address-cache.c */,
+				B68755C91C6BDDFE00C879D1 /* address-cache.h */,
+				B68755CA1C6BDDFE00C879D1 /* address-management.c */,
+				B68755CB1C6BDDFE00C879D1 /* address-management.h */,
+				B68755CC1C6BDDFE00C879D1 /* coap-diagnostic.h */,
+				B68755CD1C6BDDFE00C879D1 /* commission-dataset.h */,
+				B68755CE1C6BDDFE00C879D1 /* commission.h */,
+				B68755CF1C6BDDFE00C879D1 /* connection.c */,
+				B68755D01C6BDDFE00C879D1 /* context-table.h */,
+				B68755D11C6BDDFE00C879D1 /* dhcp.h */,
+				B68755D21C6BDDFE00C879D1 /* dispatch.h */,
+				B68755D31C6BDDFE00C879D1 /* global-prefix.c */,
+				B68755D41C6BDDFE00C879D1 /* host */,
+				B68755E61C6BDDFE00C879D1 /* ip-address.c */,
+				B68755E71C6BDDFE00C879D1 /* ip-address.h */,
+				B68755E81C6BDDFE00C879D1 /* ip-header.h */,
+				B68755E91C6BDDFE00C879D1 /* jit.h */,
+				B68755EA1C6BDDFE00C879D1 /* local-server-data-stubs.c */,
+				B68755EB1C6BDDFE00C879D1 /* local-server-data.c */,
+				B68755EC1C6BDDFE00C879D1 /* local-server-data.h */,
+				B68755ED1C6BDDFE00C879D1 /* mark-list.c */,
+				B68755EE1C6BDDFE00C879D1 /* mark-list.h */,
+				B68755EF1C6BDDFE00C879D1 /* mle.h */,
+				B68755F01C6BDDFE00C879D1 /* multicast.h */,
+				B68755F11C6BDDFE00C879D1 /* nd.h */,
+				B68755F21C6BDDFE00C879D1 /* network-data.c */,
+				B68755F31C6BDDFE00C879D1 /* network-data.h */,
+				B68755F41C6BDDFE00C879D1 /* rip-stub.c */,
+				B68755F51C6BDDFE00C879D1 /* rip.h */,
+				B68755F61C6BDDFE00C879D1 /* router-selection-stubs.c */,
+				B68755F71C6BDDFE00C879D1 /* router-selection.c */,
+				B68755F81C6BDDFE00C879D1 /* router-selection.h */,
+				B68755F91C6BDDFE00C879D1 /* stubs.c */,
+				B68755FA1C6BDDFE00C879D1 /* tcp-stub.c */,
+				B68755FB1C6BDDFE00C879D1 /* tcp.h */,
+				B68755FC1C6BDDFE00C879D1 /* thread-key-stretch.c */,
+				B68755FD1C6BDDFE00C879D1 /* tls */,
+				B68756291C6BDDFE00C879D1 /* transport-header.c */,
+				B687562A1C6BDDFE00C879D1 /* udp-simple.c */,
+				B687562B1C6BDDFE00C879D1 /* udp.c */,
+				B687562C1C6BDDFE00C879D1 /* udp.h */,
+				B687562D1C6BDDFE00C879D1 /* wakeup-specific.c */,
+				B687562E1C6BDDFE00C879D1 /* wakeup-specific.h */,
+				B687562F1C6BDDFE00C879D1 /* zigbee */,
+			);
+			path = ip;
+			sourceTree = "<group>";
+		};
+		B68755D41C6BDDFE00C879D1 /* host */ = {
+			isa = PBXGroup;
+			children = (
+				B68755D51C6BDDFE00C879D1 /* host-address-table.c */,
+				B68755D61C6BDDFE00C879D1 /* host-address-table.h */,
+				B68755D71C6BDDFE00C879D1 /* host-app-utilities.c */,
+				B68755D81C6BDDFE00C879D1 /* host-listener-table.c */,
+				B68755D91C6BDDFE00C879D1 /* host-listener-table.h */,
+				B68755DA1C6BDDFE00C879D1 /* host-mfglib.c */,
+				B68755DB1C6BDDFE00C879D1 /* host-mfglib.h */,
+				B68755DC1C6BDDFE00C879D1 /* management-client.c */,
+				B68755DD1C6BDDFE00C879D1 /* management-client.h */,
+				B68755DE1C6BDDFE00C879D1 /* unix-address.c */,
+				B68755DF1C6BDDFE00C879D1 /* unix-address.h */,
+				B68755E01C6BDDFE00C879D1 /* unix-driver-utilities.c */,
+				B68755E11C6BDDFE00C879D1 /* unix-icmp-wrapper.c */,
+				B68755E21C6BDDFE00C879D1 /* unix-interface.h */,
+				B68755E31C6BDDFE00C879D1 /* unix-ip-utilities.c */,
+				B68755E41C6BDDFE00C879D1 /* unix-listeners.c */,
+				B68755E51C6BDDFE00C879D1 /* unix-udp-wrapper.c */,
+			);
+			path = host;
+			sourceTree = "<group>";
+		};
+		B68755FD1C6BDDFE00C879D1 /* tls */ = {
+			isa = PBXGroup;
+			children = (
+				B68755FE1C6BDDFE00C879D1 /* asn1.h */,
+				B68755FF1C6BDDFE00C879D1 /* big-int.h */,
+				B68756001C6BDDFE00C879D1 /* certificate.c */,
+				B68756011C6BDDFE00C879D1 /* certificate.h */,
+				B68756021C6BDDFE00C879D1 /* credentials */,
+				B68756041C6BDDFE00C879D1 /* debug.h */,
+				B68756051C6BDDFE00C879D1 /* dtls-join-stubs.c */,
+				B68756061C6BDDFE00C879D1 /* dtls-join.c */,
+				B68756071C6BDDFE00C879D1 /* dtls-join.h */,
+				B68756081C6BDDFE00C879D1 /* dtls-stub.c */,
+				B68756091C6BDDFE00C879D1 /* dtls.c */,
+				B687560A1C6BDDFE00C879D1 /* dtls.h */,
+				B687560B1C6BDDFE00C879D1 /* eap.h */,
+				B687560C1C6BDDFE00C879D1 /* ecc-dummy.c */,
+				B687560D1C6BDDFE00C879D1 /* ecc-openssl.c */,
+				B687560E1C6BDDFE00C879D1 /* ecc.c */,
+				B687560F1C6BDDFE00C879D1 /* ecc.h */,
+				B68756101C6BDDFE00C879D1 /* native-test-util.c */,
+				B68756111C6BDDFE00C879D1 /* native-test-util.h */,
+				B68756121C6BDDFE00C879D1 /* psk-only-stubs.c */,
+				B68756131C6BDDFE00C879D1 /* rsa.h */,
+				B68756141C6BDDFE00C879D1 /* sha256-stubs.c */,
+				B68756151C6BDDFE00C879D1 /* sha256.c */,
+				B68756161C6BDDFE00C879D1 /* sha256.h */,
+				B68756171C6BDDFE00C879D1 /* tls-ccm-record.c */,
+				B68756181C6BDDFE00C879D1 /* tls-debug.c */,
+				B68756191C6BDDFE00C879D1 /* tls-ecc.c */,
+				B687561A1C6BDDFE00C879D1 /* tls-handshake-crypto.c */,
+				B687561B1C6BDDFE00C879D1 /* tls-handshake-crypto.h */,
+				B687561C1C6BDDFE00C879D1 /* tls-handshake.c */,
+				B687561D1C6BDDFE00C879D1 /* tls-handshake.h */,
+				B687561E1C6BDDFE00C879D1 /* tls-jpake.c */,
+				B687561F1C6BDDFE00C879D1 /* tls-public-key.c */,
+				B68756201C6BDDFE00C879D1 /* tls-public-key.h */,
+				B68756211C6BDDFE00C879D1 /* tls-record-stubs.c */,
+				B68756221C6BDDFE00C879D1 /* tls-record-util.c */,
+				B68756231C6BDDFE00C879D1 /* tls-record.h */,
+				B68756241C6BDDFE00C879D1 /* tls-session-state.c */,
+				B68756251C6BDDFE00C879D1 /* tls-session-state.h */,
+				B68756261C6BDDFE00C879D1 /* tls-tcp.c */,
+				B68756271C6BDDFE00C879D1 /* tls-test-credentials.c */,
+				B68756281C6BDDFE00C879D1 /* tls.h */,
+			);
+			path = tls;
+			sourceTree = "<group>";
+		};
+		B68756021C6BDDFE00C879D1 /* credentials */ = {
+			isa = PBXGroup;
+			children = (
+				B68756031C6BDDFE00C879D1 /* test-certificate.h */,
+			);
+			path = credentials;
+			sourceTree = "<group>";
+		};
+		B687562F1C6BDDFE00C879D1 /* zigbee */ = {
+			isa = PBXGroup;
+			children = (
+				B68756301C6BDDFE00C879D1 /* child-data.h */,
+				B68756311C6BDDFE00C879D1 /* join.h */,
+				B68756321C6BDDFE00C879D1 /* key-management.h */,
+			);
+			path = zigbee;
+			sourceTree = "<group>";
+		};
+		B68756331C6BDDFE00C879D1 /* mac */ = {
+			isa = PBXGroup;
+			children = (
+				B68756341C6BDDFE00C879D1 /* 802.15.4 */,
+				B687563A1C6BDDFE00C879D1 /* mac-header.h */,
+			);
+			path = mac;
+			sourceTree = "<group>";
+		};
+		B68756341C6BDDFE00C879D1 /* 802.15.4 */ = {
+			isa = PBXGroup;
+			children = (
+				B68756351C6BDDFE00C879D1 /* 802-15-4-ccm.c */,
+				B68756361C6BDDFE00C879D1 /* 802-15-4-ccm.h */,
+				B68756371C6BDDFE00C879D1 /* mac-arbiter.h */,
+				B68756381C6BDDFE00C879D1 /* mac.h */,
+				B68756391C6BDDFE00C879D1 /* wakeup.h */,
+			);
+			path = 802.15.4;
+			sourceTree = "<group>";
+		};
+		B687563B1C6BDDFE00C879D1 /* platform */ = {
+			isa = PBXGroup;
+			children = (
+				B687563C1C6BDDFE00C879D1 /* micro */,
+			);
+			path = platform;
+			sourceTree = "<group>";
+		};
+		B687563C1C6BDDFE00C879D1 /* micro */ = {
+			isa = PBXGroup;
+			children = (
+				B687563D1C6BDDFE00C879D1 /* aes.h */,
+				B687563E1C6BDDFE00C879D1 /* debug-channel.h */,
+				B687563F1C6BDDFE00C879D1 /* generic */,
+			);
+			path = micro;
+			sourceTree = "<group>";
+		};
+		B687563F1C6BDDFE00C879D1 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				B68756401C6BDDFE00C879D1 /* aes.c */,
+			);
+			path = generic;
+			sourceTree = "<group>";
+		};
+		B68756411C6BDDFE00C879D1 /* routing */ = {
+			isa = PBXGroup;
+			children = (
+				B68756421C6BDDFE00C879D1 /* neighbor */,
+				B68756441C6BDDFE00C879D1 /* util */,
+			);
+			path = routing;
+			sourceTree = "<group>";
+		};
+		B68756421C6BDDFE00C879D1 /* neighbor */ = {
+			isa = PBXGroup;
+			children = (
+				B68756431C6BDDFE00C879D1 /* neighbor.h */,
+			);
+			path = neighbor;
+			sourceTree = "<group>";
+		};
+		B68756441C6BDDFE00C879D1 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				B68756451C6BDDFE00C879D1 /* retry.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		B68756461C6BDDFE00C879D1 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				B68756471C6BDDFE00C879D1 /* simulator */,
+				B687564B1C6BDDFE00C879D1 /* spi-server */,
+				B687564F1C6BDDFE00C879D1 /* usb-host-drivers */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
+		B68756471C6BDDFE00C879D1 /* simulator */ = {
+			isa = PBXGroup;
+			children = (
+				B68756481C6BDDFE00C879D1 /* child */,
+			);
+			path = simulator;
+			sourceTree = "<group>";
+		};
+		B68756481C6BDDFE00C879D1 /* child */ = {
+			isa = PBXGroup;
+			children = (
+				B68756491C6BDDFE00C879D1 /* posix-sim.c */,
+				B687564A1C6BDDFE00C879D1 /* posix-sim.h */,
+			);
+			path = child;
+			sourceTree = "<group>";
+		};
+		B687564B1C6BDDFE00C879D1 /* spi-server */ = {
+			isa = PBXGroup;
+			children = (
+				B687564C1C6BDDFE00C879D1 /* Makefile */,
+				B687564D1C6BDDFE00C879D1 /* spi-server.c */,
+				B687564E1C6BDDFE00C879D1 /* spi-server.sh */,
+			);
+			path = "spi-server";
+			sourceTree = "<group>";
+		};
+		B687564F1C6BDDFE00C879D1 /* usb-host-drivers */ = {
+			isa = PBXGroup;
+			children = (
+				B68756501C6BDDFE00C879D1 /* EM358-CDC.inf */,
+			);
+			path = "usb-host-drivers";
+			sourceTree = "<group>";
+		};
+		B68B78B51C58046000EC9FB8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B68B78B91C58046000EC9FB8 /* soot.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B68B78D11C65244500EC9FB8 /* ncp-silabs-tmsp */ = {
+			isa = PBXGroup;
+			children = (
+				B68754341C6BDDFD00C879D1 /* silabs-thread-1.0 */,
+				B68B78FC1C65244500EC9FB8 /* Makefile.am */,
+				B63BBCBE1C77B18600083591 /* EmberNCPControlInterface-GetCounter.cpp */,
+				B63BBCBF1C77B18600083591 /* EmberNCPControlInterface-GetCounter.h */,
+				B68B78D21C65244500EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.cpp */,
+				B68B78D31C65244500EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.h */,
+				B68B78D41C65244500EC9FB8 /* EmberNCPControlInterface-FormTask.cpp */,
+				B68B78D51C65244500EC9FB8 /* EmberNCPControlInterface-FormTask.h */,
+				B68B78D61C65244500EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */,
+				B68B78D71C65244500EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.h */,
+				B68B78D81C65244500EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.cpp */,
+				B68B78D91C65244500EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.h */,
+				B68B78DA1C65244500EC9FB8 /* EmberNCPControlInterface-JoinTask.cpp */,
+				B68B78DB1C65244500EC9FB8 /* EmberNCPControlInterface-JoinTask.h */,
+				B68B78DC1C65244500EC9FB8 /* EmberNCPControlInterface-LeaveTask.cpp */,
+				B68B78DD1C65244500EC9FB8 /* EmberNCPControlInterface-LeaveTask.h */,
+				B68B78DE1C65244500EC9FB8 /* EmberNCPControlInterface-LurkTask.cpp */,
+				B68B78DF1C65244500EC9FB8 /* EmberNCPControlInterface-LurkTask.h */,
+				B68B78E01C65244500EC9FB8 /* EmberNCPControlInterface-Mfg.cpp */,
+				B68B78E11C65244500EC9FB8 /* EmberNCPControlInterface-MfgFinish.cpp */,
+				B68B78E21C65244500EC9FB8 /* EmberNCPControlInterface-MfgFinish.h */,
+				B68B78E31C65244500EC9FB8 /* EmberNCPControlInterface-ScanTask.cpp */,
+				B68B78E41C65244500EC9FB8 /* EmberNCPControlInterface-ScanTask.h */,
+				B68B78E51C65244500EC9FB8 /* EmberNCPControlInterface-SendCommandTask.cpp */,
+				B68B78E61C65244500EC9FB8 /* EmberNCPControlInterface-SendCommandTask.h */,
+				B68B78E71C65244500EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */,
+				B68B78E81C65244500EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.h */,
+				B68B78E91C65244500EC9FB8 /* EmberNCPControlInterface-WakeupTask.cpp */,
+				B68B78EA1C65244500EC9FB8 /* EmberNCPControlInterface-WakeupTask.h */,
+				B68B78EB1C65244500EC9FB8 /* EmberNCPControlInterface.cpp */,
+				B68B78EC1C65244500EC9FB8 /* EmberNCPControlInterface.h */,
+				B68B78ED1C65244500EC9FB8 /* EmberNCPInstance.cpp */,
+				B68B78EE1C65244500EC9FB8 /* EmberNCPInstance.h */,
+				B68B78EF1C65244500EC9FB8 /* EmberNCPUtils.h */,
+				B68B78F01C65244500EC9FB8 /* EmberPacked.cpp */,
+				B68B78F11C65244500EC9FB8 /* EmberPacked.h */,
+				B68B7A1A1C69429B00EC9FB8 /* EmberAPIGlue.cpp */,
+				B68B7A1B1C69429B00EC9FB8 /* EmberAPIGlue.h */,
+				B68B7A1E1C69459200EC9FB8 /* wpantund-configuration.h */,
+				B68B78FD1C65244500EC9FB8 /* SootAdapter.cpp */,
+				B68B78FE1C65244500EC9FB8 /* SootAdapter.h */,
+				B68B7A1F1C694BEA00EC9FB8 /* EmberASHAdapter.cpp */,
+				B68B7A201C694BEA00EC9FB8 /* EmberASHAdapter.h */,
+			);
+			name = "ncp-silabs-tmsp";
+			path = "src/ncp-silabs_tmsp";
+			sourceTree = SOURCE_ROOT;
+		};
+		B6A3BE6B1C88BAC500976BE9 /* ncp-dummy */ = {
+			isa = PBXGroup;
+			children = (
+				B6A3BE6C1C88BAC500976BE9 /* DummyNCPControlInterface.cpp */,
+				B6A3BE6D1C88BAC500976BE9 /* DummyNCPControlInterface.h */,
+				B6A3BE6E1C88BAC500976BE9 /* DummyNCPInstance.cpp */,
+				B6A3BE6F1C88BAC500976BE9 /* DummyNCPInstance.h */,
+				B6A3BE711C88BAC500976BE9 /* Makefile.am */,
+			);
+			path = "ncp-dummy";
+			sourceTree = "<group>";
+		};
+		E1102C17183AB2540081771A /* DBus */ = {
+			isa = PBXGroup;
+			children = (
+				B612E28A1AC9E4A000E418E0 /* Makefile.am */,
+				E164541F175FE4E90013F188 /* DBUSIPCServer.cpp */,
+				E1102C0D183A9ED90081771A /* DBUSIPCServer.h */,
+				B6A683FD1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp */,
+				B6A683FE1C518FEE00D0FCAC /* DBusIPCAPI_v1.h */,
+				B6A684001C51A0A500D0FCAC /* wpan-dbus-v1.h */,
+				B6A683FA1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp */,
+				B6A683FB1C518FC800D0FCAC /* DBusIPCAPI_v0.h */,
+				E13DFA96184D289E008A3E07 /* wpan-dbus-v0.h */,
+				A66B37EC1763B1E200B0E219 /* wpantund.conf */,
+			);
+			name = DBus;
+			path = "../ipc-dbus";
+			sourceTree = "<group>";
+		};
+		E123EE8B18327B0300467C2F /* ncp-silabs */ = {
+			isa = PBXGroup;
+			children = (
+				B6D640931C3C62D000705A42 /* silabs-thread-1.0 */,
+				B6D640941C3C62D000705A42 /* connectip-2.0 */,
+				B6D640951C3C62D000705A42 /* connectip-1.1 */,
+				B69A46211AF7F654001D8A8F /* Makefile.am */,
+				B6B99A761BC324020043526B /* SootAdapter.cpp */,
+				B6B99A771BC324020043526B /* SootAdapter.h */,
+				E1102C14183AAD6F0081771A /* FirmwareInterface.cpp */,
+				E1102C15183AAD6F0081771A /* FirmwareInterface.h */,
+				B6D1F6161A8AAF2E00F70266 /* FirmwareInterface-Base.cpp */,
+				B6D1F6171A8AAF2E00F70266 /* FirmwareInterface-Base.h */,
+				B6D1F6101A8AABCA00F70266 /* FirmwareInterface-1.1.3.cpp */,
+				B6D1F6111A8AABCA00F70266 /* FirmwareInterface-1.1.3.h */,
+				B6D1F6131A8AABF400F70266 /* FirmwareInterface-2.0.0.cpp */,
+				B6D1F6141A8AABF400F70266 /* FirmwareInterface-2.0.0.h */,
+				4C9B21AD1B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.cpp */,
+				4C9B21AE1B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.h */,
+				B643F6861B754DC2004F1AB1 /* EmberPacked.cpp */,
+				B643F6871B754DC2004F1AB1 /* EmberPacked.h */,
+				B6F27E471AAF873900A6B996 /* EmberNCPUtils.h */,
+				E1102C11183AAC030081771A /* EmberNCPInstance.cpp */,
+				E1102C12183AAC030081771A /* EmberNCPInstance.h */,
+				A618B069175BD4640097500B /* EmberNCPControlInterface.cpp */,
+				A618B06A175BD4770097500B /* EmberNCPControlInterface.h */,
+				B6D23B081AB8ACCD00441CB5 /* EmberNCPControlInterface-Mfg.cpp */,
+				E1EB4892196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.cpp */,
+				E1EB4893196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.h */,
+				B6F27E331AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.cpp */,
+				B6F27E341AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.h */,
+				E1EB489B196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.cpp */,
+				E1EB489C196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.h */,
+				E1EB4898196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.cpp */,
+				E1EB4899196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.h */,
+				E1EB488F196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.cpp */,
+				E1EB4890196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.h */,
+				B69A461E1AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.cpp */,
+				B69A461F1AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.h */,
+				E1EB4889196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.cpp */,
+				E1EB488A196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.h */,
+				E1EB488C196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.cpp */,
+				E1EB488D196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.h */,
+				B69A46221B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.cpp */,
+				B69A46231B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.h */,
+				B69A46251B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.cpp */,
+				B69A46261B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.h */,
+				B6174A201AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.cpp */,
+				B6174A211AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.h */,
+				B693A50D1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp */,
+				B693A50E1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.h */,
+			);
+			path = "ncp-silabs";
+			sourceTree = "<group>";
+		};
+		E123EE8C18327B1A00467C2F /* wpanctl */ = {
+			isa = PBXGroup;
+			children = (
+				B68B78CB1C62A91B00EC9FB8 /* Makefile.am */,
+				B69A45F81AF157D9001D8A8F /* tool-cmd-cd.c */,
+				B69A45F91AF157D9001D8A8F /* tool-cmd-cd.h */,
+				B69A45FA1AF157D9001D8A8F /* tool-cmd-config-gateway.c */,
+				B69A45FB1AF157D9001D8A8F /* tool-cmd-config-gateway.h */,
+				B69A45FC1AF157D9001D8A8F /* tool-cmd-form.c */,
+				B69A45FD1AF157D9001D8A8F /* tool-cmd-form.h */,
+				B69A45FE1AF157D9001D8A8F /* tool-cmd-getprop.c */,
+				B69A45FF1AF157D9001D8A8F /* tool-cmd-getprop.h */,
+				B69A46021AF157D9001D8A8F /* tool-cmd-join.c */,
+				B69A46031AF157D9001D8A8F /* tool-cmd-join.h */,
+				B69A46041AF157D9001D8A8F /* tool-cmd-leave.c */,
+				B69A45F61AF157D9001D8A8F /* tool-cmd-leave.h */,
+				B69A46051AF157D9001D8A8F /* tool-cmd-list.c */,
+				B69A46061AF157D9001D8A8F /* tool-cmd-list.h */,
+				B69A46001AF157D9001D8A8F /* tool-cmd-host-did-wake.c */,
+				B69A46011AF157D9001D8A8F /* tool-cmd-host-did-wake.h */,
+				B69A46071AF157D9001D8A8F /* tool-cmd-begin-low-power.c */,
+				B69A46081AF157D9001D8A8F /* tool-cmd-begin-low-power.h */,
+				B69A46091AF157D9001D8A8F /* tool-cmd-permit-join.c */,
+				B69A460A1AF157D9001D8A8F /* tool-cmd-permit-join.h */,
+				B69A460D1AF157D9001D8A8F /* tool-cmd-poll.c */,
+				B69A460E1AF157D9001D8A8F /* tool-cmd-poll.h */,
+				B69A460F1AF157D9001D8A8F /* tool-cmd-reset.c */,
+				B69A46101AF157D9001D8A8F /* tool-cmd-reset.h */,
+				B69A46111AF157D9001D8A8F /* tool-cmd-resume.c */,
+				B69A46121AF157D9001D8A8F /* tool-cmd-resume.h */,
+				B69A46131AF157D9001D8A8F /* tool-cmd-scan.c */,
+				B69A46141AF157D9001D8A8F /* tool-cmd-scan.h */,
+				B69A46151AF157D9001D8A8F /* tool-cmd-setprop.c */,
+				B69A46161AF157D9001D8A8F /* tool-cmd-setprop.h */,
+				B69A46171AF157D9001D8A8F /* tool-cmd-status.c */,
+				B69A46181AF157D9001D8A8F /* tool-cmd-status.h */,
+				B68B78971C56EA7100EC9FB8 /* tool-cmd-add-route.c */,
+				B68B78981C56EA7100EC9FB8 /* tool-cmd-add-route.h */,
+				B68B789D1C56EC2400EC9FB8 /* tool-cmd-remove-route.c */,
+				B68B789E1C56EC2400EC9FB8 /* tool-cmd-remove-route.h */,
+				B68B78991C56EA7100EC9FB8 /* tool-cmd-begin-net-wake.c */,
+				B69A45F71AF157D9001D8A8F /* tool-cmd-begin-net-wake.h */,
+				B69A46191AF157D9001D8A8F /* wpanctl-utils.c */,
+				B69A461A1AF157D9001D8A8F /* wpanctl-utils.h */,
+				A618B063175A8DBE0097500B /* wpanctl.c */,
+				E19462181768D8C20001279F /* wpanctl-cmds.h */,
+				B69A460B1AF157D9001D8A8F /* tool-cmd-ping.c */,
+				B69A460C1AF157D9001D8A8F /* tool-cmd-ping.h */,
+			);
+			path = wpanctl;
+			sourceTree = "<group>";
+		};
+		E123EE8D18327B7200467C2F /* connman */ = {
+			isa = PBXGroup;
+			children = (
+				E194621217664A4E0001279F /* wpan-connman-plugin.c */,
+				B69A45F51AF042A6001D8A8F /* Makefile.am */,
+			);
+			name = connman;
+			path = "connman-plugin";
+			sourceTree = "<group>";
+		};
+		E123EE8E18327BA200467C2F /* wpantund */ = {
+			isa = PBXGroup;
+			children = (
+				B612E28B1AC9E4B000E418E0 /* Makefile.am */,
+				E1102C17183AB2540081771A /* DBus */,
+				A618B062175A8DBE0097500B /* wpantund.cpp */,
+				B61206651CADC84400A4E683 /* wpantund.h */,
+				B69C84801BFE69D10087EF73 /* wpantund.conf */,
+				E164541D175FD8F30013F188 /* IPCServer.h */,
+				B612064F1CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp */,
+				B61206501CADBF6C00A4E683 /* RunawayResetBackoffManager.h */,
+				B61206511CADBF6C00A4E683 /* StatCollector.cpp */,
+				B61206521CADBF6C00A4E683 /* StatCollector.h */,
+				B6F27E461AAF86EC00A6B996 /* NCPConstants.h */,
+				B6026B671BDAD356000D07DD /* FirmwareUpgrade.cpp */,
+				B6026B681BDAD356000D07DD /* FirmwareUpgrade.h */,
+				B61206671CADCD8200A4E683 /* NCPTypes.cpp */,
+				B61206681CADCD8200A4E683 /* NCPTypes.h */,
+				B6F27E501AB3A23600A6B996 /* NCPInstanceBase.h */,
+				B6F27E4F1AB3A23600A6B996 /* NCPInstanceBase.cpp */,
+				B688ACD31C8F63670072622D /* NCPInstanceBase-NetInterface.cpp */,
+				B688ACD41C8F63670072622D /* NCPInstanceBase-Addresses.cpp */,
+				B688ACD51C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp */,
+				E1102C09183A9AF60081771A /* NCPInstance.cpp */,
+				E1102C0A183A9AF60081771A /* NCPInstance.h */,
+				A618B06B175BD69E0097500B /* NCPControlInterface.cpp */,
+				E1E20E3A17FF2FC1000F39AA /* NCPControlInterface.h */,
+				B6D23B071AB8A99500441CB5 /* NCPMfgInterface.h */,
+				E1E20E3817FF2F5B000F39AA /* NetworkInstance.h */,
+				B612E2891AC9E47000E418E0 /* wpan-properties.h */,
+				B602785F1C56BF510066DA9E /* wpan-error.h */,
+				B6E13FC51D5CF2A4001233C4 /* NetworkRetain.cpp */,
+				B6E13FC61D5CF2A4001233C4 /* NetworkRetain.h */,
+			);
+			path = wpantund;
+			sourceTree = "<group>";
+		};
+		E1946215176802EC0001279F /* util */ = {
+			isa = PBXGroup;
+			children = (
+				B649D15F1BE83BFD00C2E83A /* Makefile.am */,
+				A6F8206E175D45C8002A732F /* tunnel.h */,
+				A6F8206F175D45D2002A732F /* tunnel.c */,
+				A618B054175A8DBE0097500B /* args.h */,
+				A618B055175A8DBE0097500B /* assert-macros.h */,
+				A618B056175A8DBE0097500B /* config-file.c */,
+				A618B057175A8DBE0097500B /* config-file.h */,
+				E1102C18183AB3910081771A /* socket-utils.h */,
+				E1102C19183AB3990081771A /* socket-utils.c */,
+				E1102C1B183AB9840081771A /* string-utils.h */,
+				E1102C1C183ABA530081771A /* string-utils.c */,
+				E1102C1E183ABE7A0081771A /* any-to.h */,
+				E1102C1F183ABE880081771A /* any-to.cpp */,
+				DC6F470818C93A2700DA3EDF /* time-utils.h */,
+				E17D837218D8FB1500755867 /* time-utils.c */,
+				E1645423176121E30013F188 /* CallbackStore.hpp */,
+				E123EE881832792D00467C2F /* Data.cpp */,
+				E123EE891832792D00467C2F /* Data.h */,
+				E1102C0C183A9B470081771A /* NilReturn.h */,
+				E1FD94091A81821600CB3CC7 /* IPv6Helpers.h */,
+				E123EE85183272D200467C2F /* IPv6PacketMatcher.cpp */,
+				E123EE86183272D200467C2F /* IPv6PacketMatcher.h */,
+				E127376D18C5100C00789919 /* SocketWrapper.cpp */,
+				E127376E18C5100C00789919 /* SocketWrapper.h */,
+				B6F27E3C1AAF7E0B00A6B996 /* SocketAdapter.cpp */,
+				B6F27E3D1AAF7E0B00A6B996 /* SocketAdapter.h */,
+				B6F27E3F1AAF7EB400A6B996 /* UnixSocket.cpp */,
+				B6F27E401AAF7EB400A6B996 /* UnixSocket.h */,
+				B6F27E421AAF7F2800A6B996 /* SuperSocket.cpp */,
+				B6F27E431AAF7F2800A6B996 /* SuperSocket.h */,
+				E1FD94061A81777500CB3CC7 /* TunnelIPv6Interface.cpp */,
+				E1FD94071A81777500CB3CC7 /* TunnelIPv6Interface.h */,
+				B6F27E451AAF837000A6B996 /* Callbacks.h */,
+				B6F27E4C1AB21B8600A6B996 /* EventHandler.cpp */,
+				B6F27E4D1AB21B8600A6B996 /* EventHandler.h */,
+				B6F27E531AB3A93C00A6B996 /* SocketAsyncOp.h */,
+				E1645422175FFD540013F188 /* nlpt.h */,
+				E19462141767F62D0001279F /* nlpt-select.h */,
+				B6CFE7331AC36CD2007D281D /* nlpt-select.c */,
+				E1102C0E183A9FE00081771A /* DBUSHelpers.cpp */,
+				E1102C0F183A9FE00081771A /* DBUSHelpers.h */,
+				B6BF2C841C1F710D0083AD96 /* RingBuffer.h */,
+				B6A683F41C50212B00D0FCAC /* ValueMap.h */,
+				B6A683F71C50457400D0FCAC /* ValueMap.cpp */,
+				B61206581CADC10E00A4E683 /* Timer.cpp */,
+				B61206591CADC10E00A4E683 /* ObjectPool.h */,
+				B612065A1CADC10E00A4E683 /* Timer.h */,
+				B69D8A981D5110020060D2A8 /* sec-random.c */,
+				B69D8A991D5110020060D2A8 /* sec-random.h */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		E19462161768036B0001279F /* pt */ = {
+			isa = PBXGroup;
+			children = (
+				A618B060175A8DBE0097500B /* pt-sem.h */,
+				A618B058175A8DBE0097500B /* lc-addrlabels.h */,
+				A618B059175A8DBE0097500B /* lc-switch.h */,
+				A618B05A175A8DBE0097500B /* lc.h */,
+				A618B061175A8DBE0097500B /* pt.h */,
+			);
+			name = pt;
+			path = ../third_party/pt;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A618B070175BF2E10097500B /* wpantund */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A618B07A175BF2E20097500B /* Build configuration list for PBXNativeTarget "wpantund" */;
+			buildPhases = (
+				A618B06D175BF2E10097500B /* Sources */,
+				A618B06E175BF2E10097500B /* Frameworks */,
+				A618B06F175BF2E10097500B /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = wpantund;
+			productName = wpantund;
+			productReference = A618B071175BF2E10097500B /* wpantund */;
+			productType = "com.apple.product-type.tool";
+		};
+		B612066B1CADDDA700A4E683 /* wpantund-ncp-dummy */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B61206A71CADDDA700A4E683 /* Build configuration list for PBXNativeTarget "wpantund-ncp-dummy" */;
+			buildPhases = (
+				B612066C1CADDDA700A4E683 /* Sources */,
+				B61206A31CADDDA700A4E683 /* Frameworks */,
+				B61206A61CADDDA700A4E683 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "wpantund-ncp-dummy";
+			productName = wpantund;
+			productReference = B61206AA1CADDDA700A4E683 /* wpantund copy */;
+			productType = "com.apple.product-type.tool";
+		};
+		B64B680A1CE153F000A113B4 /* spinel-unit-test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B64B680F1CE153F000A113B4 /* Build configuration list for PBXNativeTarget "spinel-unit-test" */;
+			buildPhases = (
+				B64B68071CE153F000A113B4 /* Sources */,
+				B64B68081CE153F000A113B4 /* Frameworks */,
+				B64B68091CE153F000A113B4 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "spinel-unit-test";
+			productName = "spinel-unit-test";
+			productReference = B64B680B1CE153F000A113B4 /* spinel-unit-test */;
+			productType = "com.apple.product-type.tool";
+		};
+		B65301811CC6E9F200B4F3DD /* wpantund-ncp-spinel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B65301A91CC6E9F200B4F3DD /* Build configuration list for PBXNativeTarget "wpantund-ncp-spinel" */;
+			buildPhases = (
+				B65301821CC6E9F200B4F3DD /* Sources */,
+				B65301A51CC6E9F200B4F3DD /* Frameworks */,
+				B65301A81CC6E9F200B4F3DD /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "wpantund-ncp-spinel";
+			productName = wpantund;
+			productReference = B65301AC1CC6E9F200B4F3DD /* wpantund-ncp-dummy copy */;
+			productType = "com.apple.product-type.tool";
+		};
+		B68B79BA1C65268500EC9FB8 /* wpantund-ncp-silabs-tmsp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B68B79EF1C65268500EC9FB8 /* Build configuration list for PBXNativeTarget "wpantund-ncp-silabs-tmsp" */;
+			buildPhases = (
+				B68B79BB1C65268500EC9FB8 /* Sources */,
+				B68B79EB1C65268500EC9FB8 /* Frameworks */,
+				B68B79EE1C65268500EC9FB8 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "wpantund-ncp-silabs-tmsp";
+			productName = wpantund;
+			productReference = B68B79F21C65268500EC9FB8 /* wpantund-ncp-silabs-tmsp */;
+			productType = "com.apple.product-type.tool";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A618B044175A8D740097500B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+				TargetAttributes = {
+					B64B680A1CE153F000A113B4 = {
+						CreatedOnToolsVersion = 6.4;
+					};
+				};
+			};
+			buildConfigurationList = A618B047175A8D740097500B /* Build configuration list for PBXProject "wpantund" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = A618B043175A8D740097500B;
+			productRefGroup = A618B072175BF2E10097500B /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = B68B78B51C58046000EC9FB8 /* Products */;
+					ProjectRef = B649D1C01BEACA8200C2E83A /* soot.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				A618B070175BF2E10097500B /* wpantund */,
+				B68B79BA1C65268500EC9FB8 /* wpantund-ncp-silabs-tmsp */,
+				B612066B1CADDDA700A4E683 /* wpantund-ncp-dummy */,
+				B65301811CC6E9F200B4F3DD /* wpantund-ncp-spinel */,
+				B64B680A1CE153F000A113B4 /* spinel-unit-test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		B68B78B91C58046000EC9FB8 /* soot.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = soot.framework;
+			remoteRef = B68B78B81C58046000EC9FB8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A618B06D175BF2E10097500B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B61206531CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp in Sources */,
+				B643F6881B754DC2004F1AB1 /* EmberPacked.cpp in Sources */,
+				A618B07C175BF2F30097500B /* config-file.c in Sources */,
+				E1102C16183AAD6F0081771A /* FirmwareInterface.cpp in Sources */,
+				E1102C20183ABE880081771A /* any-to.cpp in Sources */,
+				B6D1F6121A8AABCA00F70266 /* FirmwareInterface-1.1.3.cpp in Sources */,
+				B69D8A9A1D5110020060D2A8 /* sec-random.c in Sources */,
+				E127376F18C5100C00789919 /* SocketWrapper.cpp in Sources */,
+				B6B99A781BC324020043526B /* SootAdapter.cpp in Sources */,
+				E1102C13183AAC030081771A /* EmberNCPInstance.cpp in Sources */,
+				A618B07D175BF2F30097500B /* wpantund.cpp in Sources */,
+				B6F27E351AAE241C00A6B996 /* EmberNCPControlInterface-MfgFinish.cpp in Sources */,
+				B6F27E411AAF7EB400A6B996 /* UnixSocket.cpp in Sources */,
+				B6F27E3E1AAF7E0B00A6B996 /* SocketAdapter.cpp in Sources */,
+				A6F82070175D45D2002A732F /* tunnel.c in Sources */,
+				E1102C10183A9FE00081771A /* DBUSHelpers.cpp in Sources */,
+				B6CFE7341AC36CD2007D281D /* nlpt-select.c in Sources */,
+				B6D1F6181A8AAF2E00F70266 /* FirmwareInterface-Base.cpp in Sources */,
+				B6D1F6151A8AABF400F70266 /* FirmwareInterface-2.0.0.cpp in Sources */,
+				B6A683FF1C518FEE00D0FCAC /* DBusIPCAPI_v1.cpp in Sources */,
+				E1645420175FE4E90013F188 /* DBUSIPCServer.cpp in Sources */,
+				4C9B21B01B167277002F07A4 /* FirmwareInterface-Thread-1.0.0.cpp in Sources */,
+				B6F27E441AAF7F2800A6B996 /* SuperSocket.cpp in Sources */,
+				B6E13FC71D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */,
+				E1EB488B196C56F50018B2ED /* EmberNCPControlInterface-JoinTask.cpp in Sources */,
+				E1EB4891196C5AD30018B2ED /* EmberNCPControlInterface-ScanTask.cpp in Sources */,
+				B6174A221AC0C33E00048E4F /* EmberNCPControlInterface-SetNetworkKeyTask.cpp in Sources */,
+				B69A46241B0130B6001D8A8F /* EmberNCPControlInterface-WakeupTask.cpp in Sources */,
+				E1102C1D183ABA530081771A /* string-utils.c in Sources */,
+				B688ACDA1C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp in Sources */,
+				E123EE87183272D200467C2F /* IPv6PacketMatcher.cpp in Sources */,
+				B69A46271B0130F2001D8A8F /* EmberNCPControlInterface-DeepSleepTask.cpp in Sources */,
+				E1EB4894196C5B0F0018B2ED /* EmberNCPControlInterface-LurkTask.cpp in Sources */,
+				B61206551CADBF6C00A4E683 /* StatCollector.cpp in Sources */,
+				E1EB489D196C92160018B2ED /* EmberNCPControlInterface-SendCommandTask.cpp in Sources */,
+				E1EB488E196C5AB80018B2ED /* EmberNCPControlInterface-FormTask.cpp in Sources */,
+				B693A50F1BC6FE6A0043C558 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp in Sources */,
+				E1FD94081A81777500CB3CC7 /* TunnelIPv6Interface.cpp in Sources */,
+				B6F27E511AB3A23600A6B996 /* NCPInstanceBase.cpp in Sources */,
+				B6F27E4E1AB21B8600A6B996 /* EventHandler.cpp in Sources */,
+				E123EE8A1832792D00467C2F /* Data.cpp in Sources */,
+				E17D837318D8FB1500755867 /* time-utils.c in Sources */,
+				E1102C1A183AB3990081771A /* socket-utils.c in Sources */,
+				E1EB489A196C8A150018B2ED /* EmberNCPControlInterface-GetRIPEntryTask.cpp in Sources */,
+				B6A683F81C50457400D0FCAC /* ValueMap.cpp in Sources */,
+				B69A46201AF7F608001D8A8F /* EmberNCPControlInterface-LeaveTask.cpp in Sources */,
+				B612065B1CADC10E00A4E683 /* Timer.cpp in Sources */,
+				B6026B691BDAD356000D07DD /* FirmwareUpgrade.cpp in Sources */,
+				E194620E17615FA10001279F /* NCPControlInterface.cpp in Sources */,
+				B61206691CADCD8200A4E683 /* NCPTypes.cpp in Sources */,
+				A66B37EB1762466000B0E219 /* EmberNCPControlInterface.cpp in Sources */,
+				E1102C0B183A9AF60081771A /* NCPInstance.cpp in Sources */,
+				B688ACD81C8F63670072622D /* NCPInstanceBase-Addresses.cpp in Sources */,
+				B6D23B0A1AB8ACCD00441CB5 /* EmberNCPControlInterface-Mfg.cpp in Sources */,
+				B688ACD61C8F63670072622D /* NCPInstanceBase-NetInterface.cpp in Sources */,
+				B6A683FC1C518FC800D0FCAC /* DBusIPCAPI_v0.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B612066C1CADDDA700A4E683 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B612066D1CADDDA700A4E683 /* RunawayResetBackoffManager.cpp in Sources */,
+				B612066F1CADDDA700A4E683 /* config-file.c in Sources */,
+				B61206711CADDDA700A4E683 /* any-to.cpp in Sources */,
+				B61206731CADDDA700A4E683 /* SocketWrapper.cpp in Sources */,
+				B61206761CADDDA700A4E683 /* wpantund.cpp in Sources */,
+				B61206BB1CADDE0E00A4E683 /* DummyNCPInstance.cpp in Sources */,
+				B61206781CADDDA700A4E683 /* UnixSocket.cpp in Sources */,
+				B61206791CADDDA700A4E683 /* SocketAdapter.cpp in Sources */,
+				B612067A1CADDDA700A4E683 /* tunnel.c in Sources */,
+				B612067B1CADDDA700A4E683 /* DBUSHelpers.cpp in Sources */,
+				B612067C1CADDDA700A4E683 /* nlpt-select.c in Sources */,
+				B612067F1CADDDA700A4E683 /* DBusIPCAPI_v1.cpp in Sources */,
+				B61206801CADDDA700A4E683 /* DBUSIPCServer.cpp in Sources */,
+				B69D8A9C1D5110020060D2A8 /* sec-random.c in Sources */,
+				B61206821CADDDA700A4E683 /* SuperSocket.cpp in Sources */,
+				B61206871CADDDA700A4E683 /* string-utils.c in Sources */,
+				B61206881CADDDA700A4E683 /* NCPInstanceBase-AsyncIO.cpp in Sources */,
+				B61206891CADDDA700A4E683 /* IPv6PacketMatcher.cpp in Sources */,
+				B612068C1CADDDA700A4E683 /* StatCollector.cpp in Sources */,
+				B61206901CADDDA700A4E683 /* TunnelIPv6Interface.cpp in Sources */,
+				B61206BA1CADDE0A00A4E683 /* DummyNCPControlInterface.cpp in Sources */,
+				B61206911CADDDA700A4E683 /* NCPInstanceBase.cpp in Sources */,
+				B61206921CADDDA700A4E683 /* EventHandler.cpp in Sources */,
+				B61206931CADDDA700A4E683 /* Data.cpp in Sources */,
+				B61206941CADDDA700A4E683 /* time-utils.c in Sources */,
+				B61206951CADDDA700A4E683 /* socket-utils.c in Sources */,
+				B61206971CADDDA700A4E683 /* ValueMap.cpp in Sources */,
+				B6E13FC91D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */,
+				B61206991CADDDA700A4E683 /* Timer.cpp in Sources */,
+				B612069A1CADDDA700A4E683 /* FirmwareUpgrade.cpp in Sources */,
+				B612069B1CADDDA700A4E683 /* NCPControlInterface.cpp in Sources */,
+				B612069C1CADDDA700A4E683 /* NCPTypes.cpp in Sources */,
+				B612069E1CADDDA700A4E683 /* NCPInstance.cpp in Sources */,
+				B612069F1CADDDA700A4E683 /* NCPInstanceBase-Addresses.cpp in Sources */,
+				B61206A11CADDDA700A4E683 /* NCPInstanceBase-NetInterface.cpp in Sources */,
+				B61206A21CADDDA700A4E683 /* DBusIPCAPI_v0.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B64B68071CE153F000A113B4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B64B68121CE1542A00A113B4 /* spinel.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B65301821CC6E9F200B4F3DD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B618F7701CCACA6F008B4AD4 /* SpinelNCPInstance-Protothreads.cpp in Sources */,
+				B65301831CC6E9F200B4F3DD /* RunawayResetBackoffManager.cpp in Sources */,
+				B65301841CC6E9F200B4F3DD /* config-file.c in Sources */,
+				B67DE7621CF4DE1300E4AE53 /* spinel-extra.c in Sources */,
+				B618F7851CCAEC4B008B4AD4 /* SpinelNCPTaskWake.cpp in Sources */,
+				B65301851CC6E9F200B4F3DD /* any-to.cpp in Sources */,
+				B65301861CC6E9F200B4F3DD /* SocketWrapper.cpp in Sources */,
+				B65301871CC6E9F200B4F3DD /* wpantund.cpp in Sources */,
+				B65301891CC6E9F200B4F3DD /* UnixSocket.cpp in Sources */,
+				B653018A1CC6E9F200B4F3DD /* SocketAdapter.cpp in Sources */,
+				B653018B1CC6E9F200B4F3DD /* tunnel.c in Sources */,
+				B618F7821CCAEC4B008B4AD4 /* SpinelNCPTaskForm.cpp in Sources */,
+				B653018C1CC6E9F200B4F3DD /* DBUSHelpers.cpp in Sources */,
+				B618F76D1CCAC260008B4AD4 /* SpinelNCPInstance-DataPump.cpp in Sources */,
+				B653018D1CC6E9F200B4F3DD /* nlpt-select.c in Sources */,
+				B653018E1CC6E9F200B4F3DD /* DBusIPCAPI_v1.cpp in Sources */,
+				B65301B41CC6EA2500B4F3DD /* SpinelNCPControlInterface.cpp in Sources */,
+				B618F7881CCAEC78008B4AD4 /* SpinelNCPTaskDeepSleep.cpp in Sources */,
+				B6B0D40F1D4FE0B500092F1F /* SpinelNCPTaskChangeNetData.cpp in Sources */,
+				B653018F1CC6E9F200B4F3DD /* DBUSIPCServer.cpp in Sources */,
+				B65301901CC6E9F200B4F3DD /* SuperSocket.cpp in Sources */,
+				B65301911CC6E9F200B4F3DD /* string-utils.c in Sources */,
+				B65301921CC6E9F200B4F3DD /* NCPInstanceBase-AsyncIO.cpp in Sources */,
+				B65301931CC6E9F200B4F3DD /* IPv6PacketMatcher.cpp in Sources */,
+				B618F7811CCAEC4B008B4AD4 /* SpinelNCPTaskScan.cpp in Sources */,
+				B618F7841CCAEC4B008B4AD4 /* SpinelNCPTaskJoin.cpp in Sources */,
+				B65301941CC6E9F200B4F3DD /* StatCollector.cpp in Sources */,
+				B65301951CC6E9F200B4F3DD /* TunnelIPv6Interface.cpp in Sources */,
+				B618F7861CCAEC4B008B4AD4 /* SpinelNCPTask.cpp in Sources */,
+				B65301971CC6E9F200B4F3DD /* NCPInstanceBase.cpp in Sources */,
+				B618F7651CC82E79008B4AD4 /* spinel.c in Sources */,
+				B65301981CC6E9F200B4F3DD /* EventHandler.cpp in Sources */,
+				B65301991CC6E9F200B4F3DD /* Data.cpp in Sources */,
+				B653019A1CC6E9F200B4F3DD /* time-utils.c in Sources */,
+				B653019B1CC6E9F200B4F3DD /* socket-utils.c in Sources */,
+				B653019C1CC6E9F200B4F3DD /* ValueMap.cpp in Sources */,
+				B65301B51CC6EA2500B4F3DD /* SpinelNCPInstance.cpp in Sources */,
+				B6E13FCA1D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */,
+				B653019D1CC6E9F200B4F3DD /* Timer.cpp in Sources */,
+				B69D8A9D1D5110020060D2A8 /* sec-random.c in Sources */,
+				B653019E1CC6E9F200B4F3DD /* FirmwareUpgrade.cpp in Sources */,
+				B653019F1CC6E9F200B4F3DD /* NCPControlInterface.cpp in Sources */,
+				B65301A01CC6E9F200B4F3DD /* NCPTypes.cpp in Sources */,
+				B65301A11CC6E9F200B4F3DD /* NCPInstance.cpp in Sources */,
+				B65301A21CC6E9F200B4F3DD /* NCPInstanceBase-Addresses.cpp in Sources */,
+				B65301A31CC6E9F200B4F3DD /* NCPInstanceBase-NetInterface.cpp in Sources */,
+				B65301A41CC6E9F200B4F3DD /* DBusIPCAPI_v0.cpp in Sources */,
+				B618F7831CCAEC4B008B4AD4 /* SpinelNCPTaskLeave.cpp in Sources */,
+				B618F7801CCAEC4B008B4AD4 /* SpinelNCPTaskSendCommand.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B68B79BB1C65268500EC9FB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B68B79FE1C6526F700EC9FB8 /* EmberNCPControlInterface-SetNetworkKeyTask.cpp in Sources */,
+				B68B79BD1C65268500EC9FB8 /* config-file.c in Sources */,
+				B64F02F21C6BE43B00F4FACA /* tmsp-host-nest-specific.c in Sources */,
+				B68B79BF1C65268500EC9FB8 /* any-to.cpp in Sources */,
+				B68B7A001C6526F700EC9FB8 /* EmberNCPControlInterface.cpp in Sources */,
+				B68B79C11C65268500EC9FB8 /* SocketWrapper.cpp in Sources */,
+				B68B79FA1C6526F700EC9FB8 /* EmberNCPControlInterface-Mfg.cpp in Sources */,
+				B64F02F31C6BE89600F4FACA /* ember-ip-configuration.c in Sources */,
+				B688ACDB1C8F63670072622D /* NCPInstanceBase-AsyncIO.cpp in Sources */,
+				B68B79F51C6526F700EC9FB8 /* EmberNCPControlInterface-GetGlobalAddressesTask.cpp in Sources */,
+				B63BBCC01C77B18600083591 /* EmberNCPControlInterface-GetCounter.cpp in Sources */,
+				B653017A1CB7070500B4F3DD /* log.c in Sources */,
+				B612066A1CADCD8200A4E683 /* NCPTypes.cpp in Sources */,
+				B68B79C41C65268500EC9FB8 /* wpantund.cpp in Sources */,
+				B64F02EE1C6BE2FA00F4FACA /* host-mfglib.c in Sources */,
+				B68B79C61C65268500EC9FB8 /* UnixSocket.cpp in Sources */,
+				B64F02D51C6BE23D00F4FACA /* random.c in Sources */,
+				B68B79C71C65268500EC9FB8 /* SocketAdapter.cpp in Sources */,
+				B68B79C81C65268500EC9FB8 /* tunnel.c in Sources */,
+				B64F02CC1C6BE11900F4FACA /* tmsp-host-utilities.c in Sources */,
+				B68B79C91C65268500EC9FB8 /* DBUSHelpers.cpp in Sources */,
+				B61206541CADBF6C00A4E683 /* RunawayResetBackoffManager.cpp in Sources */,
+				B63BBCCD1C7BA5FD00083591 /* crc.c in Sources */,
+				B68B79F41C6526F700EC9FB8 /* EmberNCPControlInterface-FormTask.cpp in Sources */,
+				B6E13FC81D5CF2A4001233C4 /* NetworkRetain.cpp in Sources */,
+				B68B79F71C6526F700EC9FB8 /* EmberNCPControlInterface-JoinTask.cpp in Sources */,
+				B68757051C6BDDFE00C879D1 /* Makefile in Sources */,
+				B68B79CA1C65268500EC9FB8 /* nlpt-select.c in Sources */,
+				B68B79FC1C6526F700EC9FB8 /* EmberNCPControlInterface-ScanTask.cpp in Sources */,
+				B68756951C6BDDFE00C879D1 /* command-interpreter2-binary.c in Sources */,
+				B64F02CA1C6BE0D000F4FACA /* binary-management.c in Sources */,
+				B68B79FF1C6526F700EC9FB8 /* EmberNCPControlInterface-WakeupTask.cpp in Sources */,
+				B68B79FB1C6526F700EC9FB8 /* EmberNCPControlInterface-MfgFinish.cpp in Sources */,
+				B64F02CD1C6BE11900F4FACA /* tmsp-host.c in Sources */,
+				B68B7A011C6526F700EC9FB8 /* EmberNCPInstance.cpp in Sources */,
+				B68B79CD1C65268500EC9FB8 /* DBusIPCAPI_v1.cpp in Sources */,
+				B68B79CE1C65268500EC9FB8 /* DBUSIPCServer.cpp in Sources */,
+				B63BBCC21C77B1E200083591 /* ash-v3.c in Sources */,
+				B64F02ED1C6BE2FA00F4FACA /* host-address-table.c in Sources */,
+				B68B79D01C65268500EC9FB8 /* SuperSocket.cpp in Sources */,
+				B68B7A021C6526F700EC9FB8 /* EmberPacked.cpp in Sources */,
+				B68B79D51C65268500EC9FB8 /* string-utils.c in Sources */,
+				B68B79D61C65268500EC9FB8 /* IPv6PacketMatcher.cpp in Sources */,
+				B68B7A1C1C69429B00EC9FB8 /* EmberAPIGlue.cpp in Sources */,
+				B68B79F81C6526F700EC9FB8 /* EmberNCPControlInterface-LeaveTask.cpp in Sources */,
+				B68B79F31C6526F700EC9FB8 /* EmberNCPControlInterface-DeepSleepTask.cpp in Sources */,
+				B68B79FD1C6526F700EC9FB8 /* EmberNCPControlInterface-SendCommandTask.cpp in Sources */,
+				B68B79DC1C65268500EC9FB8 /* TunnelIPv6Interface.cpp in Sources */,
+				B68756B31C6BDDFE00C879D1 /* micro.c in Sources */,
+				B68756C91C6BDDFE00C879D1 /* byte-utilities.c in Sources */,
+				B68B79DD1C65268500EC9FB8 /* NCPInstanceBase.cpp in Sources */,
+				B688ACD71C8F63670072622D /* NCPInstanceBase-NetInterface.cpp in Sources */,
+				B68756CB1C6BDDFE00C879D1 /* event-queue.c in Sources */,
+				B68B79DE1C65268500EC9FB8 /* EventHandler.cpp in Sources */,
+				B68756CA1C6BDDFE00C879D1 /* event-control.c in Sources */,
+				B68B79DF1C65268500EC9FB8 /* Data.cpp in Sources */,
+				B612065C1CADC10E00A4E683 /* Timer.cpp in Sources */,
+				B64F02D11C6BE1BF00F4FACA /* counters.c in Sources */,
+				B63BBCC11C77B1C500083591 /* EmberASHAdapter.cpp in Sources */,
+				B68B79E01C65268500EC9FB8 /* time-utils.c in Sources */,
+				B688ACD91C8F63670072622D /* NCPInstanceBase-Addresses.cpp in Sources */,
+				B61206561CADBF6C00A4E683 /* StatCollector.cpp in Sources */,
+				B64F02F01C6BE30600F4FACA /* ip-address.c in Sources */,
+				B68B79E11C65268500EC9FB8 /* socket-utils.c in Sources */,
+				B68B7A081C6526F700EC9FB8 /* SootAdapter.cpp in Sources */,
+				B68B79F91C6526F700EC9FB8 /* EmberNCPControlInterface-LurkTask.cpp in Sources */,
+				B68756981C6BDDFE00C879D1 /* command-interpreter2.c in Sources */,
+				B68B79E31C65268500EC9FB8 /* ValueMap.cpp in Sources */,
+				B68B79E51C65268500EC9FB8 /* FirmwareUpgrade.cpp in Sources */,
+				B68B79E61C65268500EC9FB8 /* NCPControlInterface.cpp in Sources */,
+				B69D8A9B1D5110020060D2A8 /* sec-random.c in Sources */,
+				B68B79F61C6526F700EC9FB8 /* EmberNCPControlInterface-GetRIPEntryTask.cpp in Sources */,
+				B68B79E81C65268500EC9FB8 /* NCPInstance.cpp in Sources */,
+				B68756971C6BDDFE00C879D1 /* command-interpreter2-util.c in Sources */,
+				B64F02D61C6BE23D00F4FACA /* system-timer.c in Sources */,
+				B64F02CB1C6BE11900F4FACA /* tmsp-frame-utilities.c in Sources */,
+				B64F02EF1C6BE2FA00F4FACA /* unix-driver-utilities.c in Sources */,
+				B6820BBC1C7F894A0079130D /* host-stream.c in Sources */,
+				B68B79EA1C65268500EC9FB8 /* DBusIPCAPI_v0.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		A618B048175A8D740097500B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				ONLY_ACTIVE_ARCH = YES;
+			};
+			name = Debug;
+		};
+		A618B049175A8D740097500B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		A618B078175BF2E20097500B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = wpantund;
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Debug;
+		};
+		A618B079175BF2E20097500B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = wpantund;
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+		B61206A81CADDDA700A4E683 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "wpantund copy";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Debug;
+		};
+		B61206A91CADDDA700A4E683 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "wpantund copy";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+		B64B68101CE153F000A113B4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPINEL_SELF_TEST=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		B64B68111CE153F000A113B4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SPINEL_SELF_TEST=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		B65301AA1CC6E9F200B4F3DD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "wpantund-ncp-dummy copy";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Debug;
+		};
+		B65301AB1CC6E9F200B4F3DD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PRODUCT_NAME = "wpantund-ncp-dummy copy";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+		B68B79F01C65268500EC9FB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONNECTIP_CPPFLAGS = "-I'${SRCROOT}/third_party/silabs-thread-1.0' -I'${SRCROOT}/third_party/silabs-thread-1.0/stack' -DPLATFORM_HEADER=\\\"hal/micro/unix/compiler/gcc.h\\\" -DUNIX_HOST=1 -DEMBER_RIP_STACK=1 -DEMBER_STACK_IP=1 -DAPP_SERIAL=0 -DPHY_NULL=1 -DBOARD_HEADER=\\\"${SRCROOT}/third_party/silabs-thread-1.0/hal/micro/unix/host/board/host.h\\\" -DHAL_MICRO=1 -DUNIX_HOST=1 -DUNIX=1 -DBOARD_HOST -DEMBER_ASSERT_SERIAL_PORT=0 -DEMBER_SERIAL0_BLOCKING=1 -DEMBER_SERIAL0_MODE=EMBER_SERIAL_FIFO -DEMBER_SERIAL0_TX_QUEUE_SIZE=128 -DEMBER_SERIAL0_RX_QUEUE_SIZE=128 -DEMBER_WAKEUP_STACK -DMFGLIB '-DCONFIGURATION_HEADER=\"wpantund-configuration.h\"'";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "${CONNECTIP_CPPFLAGS}";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				PRODUCT_NAME = "wpantund-ncp-silabs-tmsp";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Debug;
+		};
+		B68B79F11C65268500EC9FB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_SECURITY_FLOATLOOPCOUNTER = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
+				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libstdc++";
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CONNECTIP_CPPFLAGS = "-I'${SRCROOT}/third_party/silabs-thread-1.0' -I'${SRCROOT}/third_party/silabs-thread-1.0/stack' -DPLATFORM_HEADER=\\\"hal/micro/unix/compiler/gcc.h\\\" -DUNIX_HOST=1 -DEMBER_RIP_STACK=1 -DEMBER_STACK_IP=1 -DAPP_SERIAL=0 -DPHY_NULL=1 -DBOARD_HEADER=\\\"${SRCROOT}/third_party/silabs-thread-1.0/hal/micro/unix/host/board/host.h\\\" -DHAL_MICRO=1 -DUNIX_HOST=1 -DUNIX=1 -DBOARD_HOST -DEMBER_ASSERT_SERIAL_PORT=0 -DEMBER_SERIAL0_BLOCKING=1 -DEMBER_SERIAL0_MODE=EMBER_SERIAL_FIFO -DEMBER_SERIAL0_TX_QUEUE_SIZE=128 -DEMBER_SERIAL0_RX_QUEUE_SIZE=128 -DEMBER_WAKEUP_STACK -DMFGLIB '-DCONFIGURATION_HEADER=\"wpantund-configuration.h\"'";
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"${inherited}",
+					"'PACKAGE_VERSION=\"1.00.00-xcode\"'",
+					"HAVE_FORKPTY=1",
+					"HAVE_UTIL_H=1",
+					"HAVE_SYS_UN_H=1",
+					"HAVE_FORKPTY=1",
+					"BOOST_NO_CXX11_RVALUE_REFERENCES=1",
+					"BOOST_NO_CXX11_REF_QUALIFIERS=1",
+					"BOOST_NO_CXX11_VARIADIC_TEMPLATES=1",
+					"ASSERT_MACROS_USE_SYSLOG=1",
+					"WPANTUND_PLUGIN_STATICLY_LINKED=1",
+				);
+				GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS = YES;
+				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_HIDDEN_VIRTUAL_FUNCTIONS = YES;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/include,
+					"~/homebrew/lib/dbus-1.0/include",
+					"~/homebrew/include/dbus-1.0",
+					"/usr/local/include/dbus-1.0",
+					"/usr/local/lib/dbus-1.0/include",
+					"${SRCROOT}/third_party",
+					"${SRCROOT}/src/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"${inherit}",
+					/usr/local/lib,
+					"/usr/local/Library/LinkedKegs/d-bus/lib",
+					"~/homebrew/Library/LinkedKegs/d-bus/lib/",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				OTHER_CFLAGS = "${CONNECTIP_CPPFLAGS}";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				PRODUCT_NAME = "wpantund-ncp-silabs-tmsp";
+				SDKROOT = macosx;
+				WARNING_CFLAGS = "-Wall";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A618B047175A8D740097500B /* Build configuration list for PBXProject "wpantund" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A618B048175A8D740097500B /* Debug */,
+				A618B049175A8D740097500B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A618B07A175BF2E20097500B /* Build configuration list for PBXNativeTarget "wpantund" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A618B078175BF2E20097500B /* Debug */,
+				A618B079175BF2E20097500B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B61206A71CADDDA700A4E683 /* Build configuration list for PBXNativeTarget "wpantund-ncp-dummy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B61206A81CADDDA700A4E683 /* Debug */,
+				B61206A91CADDDA700A4E683 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B64B680F1CE153F000A113B4 /* Build configuration list for PBXNativeTarget "spinel-unit-test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B64B68101CE153F000A113B4 /* Debug */,
+				B64B68111CE153F000A113B4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B65301A91CC6E9F200B4F3DD /* Build configuration list for PBXNativeTarget "wpantund-ncp-spinel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B65301AA1CC6E9F200B4F3DD /* Debug */,
+				B65301AB1CC6E9F200B4F3DD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B68B79EF1C65268500EC9FB8 /* Build configuration list for PBXNativeTarget "wpantund-ncp-silabs-tmsp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B68B79F01C65268500EC9FB8 /* Debug */,
+				B68B79F11C65268500EC9FB8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A618B044175A8D740097500B /* Project object */;
+}


### PR DESCRIPTION
This commit adds support for in-band assisted joining. This capability
allows a node (which does not yet have network credentials) to communicate
in a very limited fashion (a single application-defined port using IPv6
link-local addresses) with an "assisting device" (Joinable bit set).
Using an undefined application protocol, the joining device can learn the
network credentials from the assisting device and then proceed to join the
network normally.

This change relies on the changes from [OpenThread Pull Request #497][1].

[1]: https://github.com/openthread/openthread/pull/497