### PR TITLE
wpanctl: Print node-type in `join`/`form` commands

### DIFF
--- a/src/util/args.h
+++ b/src/util/args.h
@@ -62,7 +62,12 @@ print_arg_list_help(
 			printf("                       ");
 		}
 
-		printf(" %s\n", arg_list[i].desc);
+		if (arg_list[i].param != NULL) {
+			printf(" %s [%s]\n", arg_list[i].desc, arg_list[i].param);
+		} else {
+			printf(" %s\n", arg_list[i].desc);
+		}
+
 	}
 }
 

--- a/src/wpanctl/tool-cmd-form.c
+++ b/src/wpanctl/tool-cmd-form.c
@@ -38,7 +38,8 @@ static const arg_list_item_t form_option_list[] = {
 	{'h', "help", NULL, "Print Help"},
 	{'t', "timeout", "ms", "Set timeout period"},
 	{'c', "channel", "channel", "Set the desired channel"},
-	{'T', "type", "node-type", "Join as a specific node type"},
+	{'T', "type", "node-type: router(r,2), end-device(end,e,3), sleepy-end-device(sleepy,sed,4), nl-lurker(lurker,l,6)",
+		"Join as a specific node type" },
 //	{'u', "ula-prefix", "ULA Prefix", "Specify a specific *LEGACY* ULA prefix"},
 	{'M', "mesh-local-prefix", "Mesh-Local IPv6 Prefix", "Specify a non-default mesh-local IPv6 prefix"},
 	{'L', "legacy-prefix", "Legacy IPv6 Prefix", "Specify a specific *LEGACY* IPv6 prefix"},
@@ -228,9 +229,10 @@ int tool_cmd_form(int argc, char* argv[])
 		}
 
 		fprintf(stderr,
-		        "Forming WPAN \"%s\" as node type %d\n",
+		        "Forming WPAN \"%s\" as node type \"%s\"\n",
 		        network_name,
-		        node_type);
+		        node_type_int2str(node_type));
+
 
 		reply = dbus_connection_send_with_reply_and_block(
 		    connection,

--- a/src/wpanctl/tool-cmd-join.c
+++ b/src/wpanctl/tool-cmd-join.c
@@ -38,7 +38,8 @@ const char join_cmd_syntax[] = "[args] [network-name]";
 static const arg_list_item_t join_option_list[] = {
 	{'h', "help", NULL, "Print Help"},
 	{'t', "timeout", "ms", "Set timeout period"},
-	{'T', "type", "node-type", "Join as a specific node type"},
+	{'T', "type", "node-type: router(r,2), end-device(end,e,3), sleepy-end-device(sleepy,sed,4), nl-lurker(lurker,l,6)",
+		"Join as a specific node type"},
 	{'p', "panid", "panid", "Specify a specific PAN ID"},
 	{'x', "xpanid", "xpanid", "Specify a specific Extended PAN ID"},
 	{'c', "channel", "channel", "Specify a specific channel"},
@@ -185,9 +186,10 @@ int tool_cmd_join(int argc, char* argv[])
 		    );
 
 		fprintf(stderr,
-		        "Joining \"%s\" %016llX\n",
+		        "Joining \"%s\" %016llX as node type \"%s\"\n",
 		        target_network.network_name,
-		        (unsigned long long)target_network.xpanid);
+		        (unsigned long long)target_network.xpanid,
+		        node_type_int2str(node_type));
 
 		dbus_message_append_args(
 		    message,

--- a/src/wpanctl/wpanctl-utils.c
+++ b/src/wpanctl/wpanctl-utils.c
@@ -570,6 +570,8 @@ node_type_str2int(const char *node_type)
 		return WPAN_IFACE_ROLE_SLEEPY_END_DEVICE;
 	} else if (strcasecmp(node_type, "sleepy") == 0) {
 		return WPAN_IFACE_ROLE_SLEEPY_END_DEVICE;
+	} else if (strcasecmp(node_type, "sed") == 0) {
+		return WPAN_IFACE_ROLE_SLEEPY_END_DEVICE;
 	} else if (strcasecmp(node_type, "s") == 0) {
 		return WPAN_IFACE_ROLE_SLEEPY_END_DEVICE;
 
@@ -584,4 +586,19 @@ node_type_str2int(const char *node_type)
 		// At this moment it should be a number
 		return strtol(node_type, NULL, 0);
 	}
+}
+
+const char *
+node_type_int2str(uint16_t node_type)
+{
+	switch (node_type)
+	{
+	case WPAN_IFACE_ROLE_ROUTER:            return "router";
+	case WPAN_IFACE_ROLE_END_DEVICE:        return "end-device";
+	case WPAN_IFACE_ROLE_SLEEPY_END_DEVICE: return "sleepy-end-device";
+	case WPAN_IFACE_ROLE_LURKER:            return "nl-lurker";
+	default: break;
+	}
+
+	return "unknown";
 }

--- a/src/wpanctl/wpanctl-utils.h
+++ b/src/wpanctl/wpanctl-utils.h
@@ -75,6 +75,7 @@ int parse_energy_scan_result_from_iter(int16_t *channel, int8_t *maxRssi, DBusMe
 int lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name);
 void dump_info_from_iter(FILE* file, DBusMessageIter *iter, int indent, bool bare, bool indentFirstLine);
 uint16_t node_type_str2int(const char *node_type);
+const char *node_type_int2str(uint16_t node_type);
 
 extern char gInterfaceName[32];
 extern int gRet;


### PR DESCRIPTION
This commits adds to output of `wpanctl` `join` and `form` commands to inlcude the `node-type`. It also modifies the `arg.h` to include the arg type in the printout and adds info in help for valid node types.