### PR TITLE
SpinelTaskJoin: Add support for joining as an end-devcie

### DIFF
--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1114,6 +1114,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
         break;
 
+    case SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED:
+        ret = "SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED";
+        break;
+
     case SPINEL_PROP_MAC_WHITELIST:
         ret = "PROP_MAC_WHITELIST";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -502,6 +502,12 @@ typedef enum
     SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
 
+    /// This property indicates whether or not the `Router Role` is enabled.
+    /** Format `b`
+     */
+    SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
This commit adds support to `SpinelNCPTaskJoin` to enable joining as an `end-device`. It uses the newly added spinel property `SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED`.

This relies on the changes in openthread PR [523](https://github.com/openthread/openthread/pull/553)