### PR TITLE
Adding support for getting child table

### DIFF
--- a/src/ncp-spinel/Makefile.am
+++ b/src/ncp-spinel/Makefile.am
@@ -58,6 +58,8 @@ NCP_SOURCES = \
 	SpinelNCPTaskChangeNetData.cpp \
 	SpinelNCPTaskChangeNetData.h \
 	SpinelNCPTaskDeepSleep.cpp \
+	SpinelNCPTaskGetChildTable.h \
+	SpinelNCPTaskGetChildTable.cpp \
 	SpinelNCPTaskDeepSleep.h \
 	SpinelNCPTaskForm.cpp \
 	SpinelNCPTaskForm.h \

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -35,6 +35,7 @@
 #include "SpinelNCPTaskSendCommand.h"
 #include "SpinelNCPTaskChangeNetData.h"
 #include "SpinelNCPTaskJoin.h"
+#include "SpinelNCPTaskGetChildTable.h"
 #include "any-to.h"
 #include "spinel-extra.h"
 
@@ -511,6 +512,17 @@ SpinelNCPInstance::get_property(
 				SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_IPV6_LL_ADDR),
 				NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
 				SPINEL_DATATYPE_IPv6ADDR_S
+			)
+		))) {
+			cb(kWPANTUNDStatus_InvalidForCurrentState, boost::any());
+		}
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadChildTable)) {
+		if (-1 == start_new_task(boost::shared_ptr<SpinelNCPTask>(
+			new SpinelNCPTaskGetChildTable(
+				this,
+				cb,
+				SpinelNCPTaskGetChildTable::kResultFormat_StringArray
 			)
 		))) {
 			cb(kWPANTUNDStatus_InvalidForCurrentState, boost::any());

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -96,6 +96,8 @@ class SpinelNCPInstance : public NCPInstanceBase {
 	friend class SpinelNCPTaskScan;
 	friend class SpinelNCPTaskLeave;
 	friend class SpinelNCPTaskSendCommand;
+	friend class SpinelNCPTaskGetChildTable;
+
 public:
 
 	enum DriverState {

--- a/src/ncp-spinel/SpinelNCPTaskGetChildTable.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetChildTable.cpp
@@ -1,0 +1,228 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+#include <syslog.h>
+#include <errno.h>
+#include "SpinelNCPTaskGetChildTable.h"
+#include "SpinelNCPInstance.h"
+#include "spinel-extra.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+nl::wpantund::SpinelNCPTaskGetChildTable::SpinelNCPTaskGetChildTable(
+	SpinelNCPInstance* instance,
+	CallbackWithStatusArg1 cb,
+	ResultFormat result_format
+):	SpinelNCPTask(instance, cb), mResultFormat(result_format), mChildTable()
+{
+}
+
+int
+nl::wpantund::SpinelNCPTaskGetChildTable::vprocess_event(int event, va_list args)
+{
+	int ret = kWPANTUNDStatus_Failure;
+	unsigned int prop_key;
+	const uint8_t *data_in;
+	spinel_size_t data_len;
+
+	EH_BEGIN();
+
+	if (!mInstance->mEnabled) {
+		ret = kWPANTUNDStatus_InvalidWhenDisabled;
+		finish(ret);
+		EH_EXIT();
+	}
+
+	if (mInstance->get_ncp_state() == UPGRADING) {
+		ret = kWPANTUNDStatus_InvalidForCurrentState;
+		finish(ret);
+		EH_EXIT();
+	}
+
+	// Wait for a bit to see if the NCP will enter the right state.
+	EH_REQUIRE_WITHIN(
+		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
+		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		on_error
+	);
+
+	// The first event to a task is EVENT_STARTING_TASK. The following
+	// line makes sure that we don't start processing this task
+	// until it is properly scheduled. All tasks immediately receive
+	// the initial `EVENT_STARTING_TASK` event, but further events
+	// will only be received by that task once it is that task's turn
+	// to execute.
+	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
+
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET,
+		SPINEL_PROP_THREAD_CHILD_TABLE
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	ret = mNextCommandRet;
+
+	require_noerr(ret, on_error);
+
+	require(EVENT_NCP_PROP_VALUE_IS == event, on_error);
+
+	prop_key = va_arg(args, unsigned int);
+	data_in = va_arg(args, const uint8_t*);
+	data_len = va_arg_small(args, spinel_size_t);
+
+	require(prop_key == SPINEL_PROP_THREAD_CHILD_TABLE, on_error);
+
+	mChildTable.clear();
+
+	while (data_len > 0)
+	{
+		spinel_ssize_t len = 0;
+		ChildInfoEntry child_info;
+		const spinel_eui64_t *eui64 = NULL;
+		uint8_t mode;
+
+		len = spinel_datatype_unpack(
+			data_in,
+			data_len,
+			"T("
+				SPINEL_DATATYPE_EUI64_S         // EUI64 Address
+				SPINEL_DATATYPE_UINT16_S        // Rloc16
+				SPINEL_DATATYPE_UINT32_S        // Timeout
+				SPINEL_DATATYPE_UINT32_S        // Age
+				SPINEL_DATATYPE_UINT8_S         // Network Data Version
+				SPINEL_DATATYPE_UINT8_S         // Link Quality In
+				SPINEL_DATATYPE_INT8_S          // Average RSS
+				SPINEL_DATATYPE_UINT8_S         // Mode (flags)
+			")",
+			&eui64,
+			&child_info.mRloc16,
+			&child_info.mTimeout,
+			&child_info.mAge,
+			&child_info.mNetworkDataVersion,
+			&child_info.mLinkQualityIn,
+			&child_info.mAverageRssi,
+            &mode
+		);
+
+		if (len <= 0)
+		{
+			break;
+		}
+
+		memcpy(child_info.mExtAddress, eui64, sizeof(child_info.mExtAddress));
+
+		child_info.mRxOnWhenIdle = ((mode & kThreadMode_RxOnWhenIdle) != 0);
+		child_info.mSecureDataRequest = ((mode & kThreadMode_SecureDataRequest) != 0);
+		child_info.mFullFunction = ((mode & kThreadMode_FullFunctionDevice) != 0);
+		child_info.mFullNetworkData = ((mode & kThreadMode_FullNetworkData) != 0);
+
+		mChildTable.push_back(child_info);
+
+		data_in += len;
+		data_len -= len;
+	}
+
+	ret = kWPANTUNDStatus_Ok;
+
+	if (mResultFormat == kResultFormat_StringArray)
+	{
+		std::list<std::string> result;
+		std::list<ChildInfoEntry>::iterator it;
+
+		for (it = mChildTable.begin(); it != mChildTable.end(); it++)
+		{
+			result.push_back(it->get_as_string());
+		}
+
+		finish(ret, result);
+	}
+	else if (mResultFormat == kResultFormat_ValueMapArray)
+	{
+		std::list<ValueMap> result;
+		std::list<ChildInfoEntry>::iterator it;
+
+		for (it = mChildTable.begin(); it != mChildTable.end(); it++)
+		{
+			result.push_back(it->get_as_valuemap());
+		}
+
+		finish(ret, result);
+	}
+	else
+	{
+		finish(ret);
+	}
+
+	mChildTable.clear();
+
+	EH_EXIT();
+
+on_error:
+
+	if (ret == kWPANTUNDStatus_Ok) {
+		ret = kWPANTUNDStatus_Failure;
+	}
+
+	syslog(LOG_ERR, "Getting child table failed: %d", ret);
+
+	finish(ret);
+
+	mChildTable.clear();
+
+	EH_END();
+}
+
+std::string
+SpinelNCPTaskGetChildTable::ChildInfoEntry::get_as_string(void) const
+{
+	char c_string[800];
+
+	snprintf(c_string, sizeof(c_string),
+		"%02X%02X%02X%02X%02X%02X%02X%02X, rolc16: %04x, netDataVer: %-3d, inLQI: %-2d, aveRSS: %-3d, timeout: %-5u, "
+		"age: %-5u, RxOnWhenIdle: %s, FFD: %s, secureDataReq: %s, fullNetData: %s",
+		mExtAddress[0], mExtAddress[1], mExtAddress[2], mExtAddress[3],
+		mExtAddress[4], mExtAddress[5], mExtAddress[6], mExtAddress[7],
+		mRloc16,
+		mNetworkDataVersion,
+		mLinkQualityIn,
+		mAverageRssi,
+		mTimeout,
+		mAge,
+		mRxOnWhenIdle ? "yes" : "no",
+		mFullFunction ? "yes" : "no",
+		mSecureDataRequest ? "yes" : "no",
+		mFullNetworkData ? "yes" : "no"
+	);
+
+	return std::string(c_string);
+}
+
+ValueMap
+SpinelNCPTaskGetChildTable::ChildInfoEntry::get_as_valuemap(void) const
+{
+	// TODO: return the child info as a value map dictionary.
+	return ValueMap();
+}

--- a/src/ncp-spinel/SpinelNCPTaskGetChildTable.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetChildTable.h
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __wpantund__SpinelNCPTaskGetChildTable__
+#define __wpantund__SpinelNCPTaskGetChildTable__
+
+#include <list>
+#include <string>
+#include "ValueMap.h"
+#include "SpinelNCPTask.h"
+#include "SpinelNCPInstance.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+namespace nl {
+namespace wpantund {
+
+class SpinelNCPTaskGetChildTable : public SpinelNCPTask
+{
+public:
+	enum ResultFormat
+	{
+		kResultFormat_StringArray,     // Returns the child table as an array of std::string(s) (one per child).
+		kResultFormat_ValueMapArray,   // Returns the child table as an array of ValueMap dictionary.
+	};
+
+	SpinelNCPTaskGetChildTable(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		ResultFormat result_format = kResultFormat_StringArray
+	);
+	virtual int vprocess_event(int event, va_list args);
+
+private:
+	enum
+	{
+		kThreadMode_RxOnWhenIdle        = (1 << 3),
+		kThreadMode_SecureDataRequest   = (1 << 2),
+		kThreadMode_FullFunctionDevice  = (1 << 1),
+		kThreadMode_FullNetworkData     = (1 << 0),
+	};
+
+	struct ChildInfoEntry
+	{
+		uint8_t   mExtAddress[8];
+		uint32_t  mTimeout;
+		uint32_t  mAge;
+		uint16_t  mRloc16;
+		uint8_t   mNetworkDataVersion;
+		uint8_t   mLinkQualityIn;
+		int8_t    mAverageRssi;
+		bool      mRxOnWhenIdle : 1;
+		bool      mSecureDataRequest : 1;
+		bool      mFullFunction : 1;
+		bool      mFullNetworkData : 1;
+
+		std::string get_as_string(void) const;
+		ValueMap get_as_valuemap(void) const;
+	};
+
+	ResultFormat mResultFormat;
+	std::list<ChildInfoEntry> mChildTable;
+};
+
+
+}; // namespace wpantund
+}; // namespace nl
+
+
+#endif /* defined(__wpantund__SpinelNCPTaskGetChildTable__) */

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -81,12 +81,12 @@
 #define kWPANTUNDProperty_ThreadLeaderWeight      "Thread:Leader:Weight"
 #define kWPANTUNDProperty_ThreadLeaderLocalWeight "Thread:Leader:LocalWeight"
 #define kWPANTUNDProperty_ThreadNetworkData       "Thread:NetworkData"
+#define kWPANTUNDProperty_ThreadChildTable        "Thread:ChildTable"
 #define kWPANTUNDProperty_ThreadNetworkDataVersion       "Thread:NetworkDataVersion"
 #define kWPANTUNDProperty_ThreadStableNetworkData        "Thread:StableNetworkData"
 #define kWPANTUNDProperty_ThreadStableNetworkDataVersion "Thread:StableNetworkDataVersion"
 
 #define kWPANTUNDProperty_DebugIPv6GlobalIPAddressList         "Debug:IPv6:GlobalIPAddressList"
-
 
 #define kWPANTUNDProperty_NestLabs_NetworkAllowingJoin         "com.nestlabs.internal:Network:AllowingJoin"
 #define kWPANTUNDProperty_NestLabs_NetworkPassthruPort         "com.nestlabs.internal:Network:PassthruPort"


### PR DESCRIPTION
This commit adds support to spinel plugin for getting the child table property `SPINEL_PROP_THREAD_CHILD_TABLE`. It also adds a new read-only wpantund property `Thread:ChildTable` to retrieve the child table along with info about each child.

This is the counterpart of the openthread PR [#515](https://github.com/openthread/openthread/pull/515).