### PR TITLE
Add support for Energy Scan operation in Spinel plugin

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -416,7 +416,23 @@ SpinelNCPControlInterface::energyscan_start(
     const ValueMap& options,
     CallbackWithStatus cb
 ) {
-	cb(kWPANTUNDStatus_FeatureNotImplemented);
+	ChannelMask channel_mask(mNCPInstance->mDefaultChannelMask);
+
+	if (options.count(kWPANTUNDProperty_NCPChannelMask)) {
+		channel_mask = any_to_int(options.at(kWPANTUNDProperty_NCPChannelMask));
+	}
+
+	if (-1 == mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
+		new SpinelNCPTaskScan(
+			mNCPInstance,
+			boost::bind(cb,_1),
+			channel_mask,
+			SpinelNCPTaskScan::kDefaultScanPeriod,
+			SpinelNCPTaskScan::kScanTypeEnergy
+		)
+	))) {
+		cb(kWPANTUNDStatus_InvalidForCurrentState);
+	}
 }
 
 void

--- a/src/ncp-spinel/SpinelNCPTaskScan.h
+++ b/src/ncp-spinel/SpinelNCPTaskScan.h
@@ -32,10 +32,21 @@ namespace wpantund {
 class SpinelNCPTaskScan : public SpinelNCPTask
 {
 public:
+	enum ScanType {
+		kScanTypeNet = 0,
+		kScanTypeEnergy,
+	};
+
+	enum {
+		kDefaultScanPeriod = 200,
+	};
+
 	SpinelNCPTaskScan(
 		SpinelNCPInstance* instance,
 		CallbackWithStatusArg1 cb,
-		uint32_t channel_mask
+		uint32_t channel_mask,
+		uint16_t channel_scan_period = kDefaultScanPeriod,   // per channel in ms
+		ScanType scan_type = kScanTypeNet
 	);
 	virtual int vprocess_event(int event, va_list args);
 	virtual void finish(int status, const boost::any& value = boost::any());
@@ -43,7 +54,8 @@ public:
 private:
 	uint8_t mChannelMaskData[32];
 	uint8_t mChannelMaskLen;
-	uint16_t mChannelDelayPeriod;
+	uint16_t mScanPeriod;  // per channel
+	ScanType mScanType;
 };
 
 }; // namespace wpantund

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -978,6 +978,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_MAC_SCAN_BEACON";
         break;
 
+    case SPINEL_PROP_MAC_ENERGY_SCAN_RESULT:
+        ret = "PROP_MAC_SCAN_ENERGY_SCAN_RESULT";
+        break;
+
     case SPINEL_PROP_MAC_SCAN_PERIOD:
         ret = "PROP_MAC_SCAN_PERIOD";
         break;


### PR DESCRIPTION
This commit adds support to spinel plugin for energy scan operation, specifically it modifies the `SpinelNCPTaskScan` to handle both netscan (active scan) and energy scan operations.

The counterpart of this change in openthread is in [PR580](https://github.com/openthread/openthread/pull/580).