### PR TITLE
Add ON_MESH_NETs and LOCAL_ROUTs with stable flag set to true

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -225,7 +225,7 @@ SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefi
 					SPINEL_PROP_THREAD_ON_MESH_NETS,
 					&addr,
 					64,
-					false,
+					true,
 					flags
 				)
 			)
@@ -245,7 +245,7 @@ SpinelNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefi
 					SPINEL_PROP_THREAD_ON_MESH_NETS,
 					&addr,
 					64,
-					false,
+					true,
 					flags
 				)
 			)
@@ -291,7 +291,7 @@ SpinelNCPControlInterface::add_external_route(const uint8_t *route, int route_pr
 				SPINEL_PROP_THREAD_LOCAL_ROUTES,
 				&addr,
 				route_prefix_len*8, // because route_prefix_len is in bytes
-				false,
+				true,
 				flags
 			)
 		)
@@ -324,7 +324,7 @@ SpinelNCPControlInterface::remove_external_route(const uint8_t *route, int route
 				SPINEL_PROP_THREAD_LOCAL_ROUTES,
 				&addr,
 				route_prefix_len*8, // because route_prefix_len is in bytes
-				false,
+				true,
 				0
 			)
 		)


### PR DESCRIPTION
This commit changes the `SpinelNCPControlInterface::config_gateway` implementation so that when an `ON_MESH_PREFIX` is added the stable flag is set to `true` by default.