### PR TITLE
wpantund: Support for raw packet capture (Packet sniffing)

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -92,6 +92,9 @@ DBusIPCAPI_v1::init_callback_tables()
 
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_PROP_GET, interface_get_prop_handler);
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_PROP_SET, interface_set_prop_handler);
+
+	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_PCAP_TO_FD, interface_pcap_to_fd_handler);
+	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_PCAP_TERMINATE, interface_pcap_terminate_handler);
 }
 
 static void
@@ -940,6 +943,60 @@ DBusIPCAPI_v1::interface_energy_scan_start_handler(
 			message
 		)
 	);
+	ret = DBUS_HANDLER_RESULT_HANDLED;
+
+	return ret;
+}
+
+DBusHandlerResult
+DBusIPCAPI_v1::interface_pcap_to_fd_handler(
+	NCPControlInterface* interface,
+	DBusMessage *        message
+) {
+	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+	int fd = -1;
+
+	dbus_message_ref(message);
+
+	dbus_message_get_args(
+		message, NULL,
+		DBUS_TYPE_UNIX_FD, &fd,
+		DBUS_TYPE_INVALID
+	);
+
+	interface->pcap_to_fd(
+		fd,
+		boost::bind(
+			&DBusIPCAPI_v1::CallbackWithStatus_Helper,
+			this,
+			_1,
+			message
+		)
+	);
+
+	ret = DBUS_HANDLER_RESULT_HANDLED;
+
+	return ret;
+}
+
+DBusHandlerResult
+DBusIPCAPI_v1::interface_pcap_terminate_handler(
+	NCPControlInterface* interface,
+	DBusMessage *        message
+) {
+	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+
+	dbus_message_ref(message);
+
+	interface->pcap_terminate(
+		boost::bind(
+			&DBusIPCAPI_v1::CallbackWithStatus_Helper,
+			this,
+			_1,
+			message
+		)
+	);
+
 	ret = DBUS_HANDLER_RESULT_HANDLED;
 
 	return ret;

--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -133,10 +133,21 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_pcap_to_fd_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_pcap_terminate_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 	DBusHandlerResult interface_get_prop_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message
 	);
+
 	DBusHandlerResult interface_set_prop_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -61,6 +61,9 @@
 #define WPANTUND_IF_CMD_BEGIN_LOW_POWER       "BeginLowPower"
 #define WPANTUND_IF_CMD_HOST_DID_WAKE         "HostDidWake"
 
+#define WPANTUND_IF_CMD_PCAP_TO_FD            "PcapToFd"
+#define WPANTUND_IF_CMD_PCAP_TERMINATE        "PcapTerminate"
+
 #define WPANTUND_IF_CMD_NET_SCAN_START        "NetScanStart"
 #define WPANTUND_IF_CMD_NET_SCAN_STOP         "NetScanStop"
 #define WPANTUND_IF_SIGNAL_NET_SCAN_BEACON    "NetScanBeacon"

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -216,6 +216,18 @@ DummyNCPControlInterface::get_ncp_instance()
 	return (*mNCPInstance);
 }
 
+void
+DummyNCPControlInterface::pcap_to_fd(int fd, CallbackWithStatus cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
+void
+DummyNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
 
 // ----------------------------------------------------------------------------
 // MARK: -

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -95,6 +95,10 @@ public:
 
 	virtual NCPInstance& get_ncp_instance(void);
 
+	virtual void pcap_to_fd(int fd, CallbackWithStatus cb = NilReturn());
+
+	virtual void pcap_terminate(CallbackWithStatus cb = NilReturn());
+
 private:
 
 	DummyNCPInstance* mNCPInstance;

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -475,6 +475,29 @@ SpinelNCPControlInterface::get_ncp_instance()
 	return (*mNCPInstance);
 }
 
+void
+SpinelNCPControlInterface::pcap_to_fd(int fd, CallbackWithStatus cb)
+{
+	int ret = mNCPInstance->mPcapManager.insert_fd(fd);
+
+	if (ret < 0) {
+		syslog(LOG_ERR, "pcap_to_fd: Failed: \"%s\" (%d)", strerror(errno), errno);
+
+		cb(kWPANTUNDStatus_Failure);
+
+	} else {
+		cb(kWPANTUNDStatus_Ok);
+	}
+}
+
+void
+SpinelNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
+{
+	mNCPInstance->mPcapManager.close_fd_set(mNCPInstance->mPcapManager.get_fd_set());
+	cb(kWPANTUNDStatus_Ok);
+}
+
+
 
 // ----------------------------------------------------------------------------
 // MARK: -

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -94,6 +94,10 @@ public:
 
 	virtual NCPInstance& get_ncp_instance(void);
 
+	virtual void pcap_to_fd(int fd, CallbackWithStatus cb = NilReturn());
+
+	virtual void pcap_terminate(CallbackWithStatus cb = NilReturn());
+
 	/******************* NCPMfgInterface_v1 ********************/
 	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
 

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -379,6 +379,14 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 		// point to cause the control protothread to be restarted.
 		mDriverState = INITIALIZING;
 
+		if (mIsPcapInProgress) {
+			CONTROL_REQUIRE_PREP_TO_SEND_COMMAND_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
+			GetInstance(this)->mOutboundBufferLen = spinel_cmd_prop_value_set_uint(GetInstance(this)->mOutboundBuffer, sizeof(GetInstance(this)->mOutboundBuffer), SPINEL_PROP_MAC_RAW_STREAM_ENABLED, 1);
+			CONTROL_REQUIRE_OUTBOUND_BUFFER_FLUSHED_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
+
+			CONTROL_REQUIRE_COMMAND_RESPONSE_WITHIN(NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT, on_error);
+		}
+
 		if (mEnabled) {
 			// Refresh our internal copies of the following radio parameters:
 			static const spinel_prop_key_t keys_to_fetch[] = {

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -165,6 +165,8 @@ public:
 
 	static void handle_ncp_log(const uint8_t* data_ptr, int data_len);
 
+	virtual void process(void);
+
 private:
 	SpinelNCPControlInterface mControlInterface;
 
@@ -207,6 +209,8 @@ private:
 	uint32_t mNetworkKeyIndex;
 
 	bool mResetIsExpected;
+
+	bool mIsPcapInProgress;
 
 	// Task management
 	std::list<boost::shared_ptr<SpinelNCPTask> > mTaskQueue;

--- a/src/wpanctl/Makefile.am
+++ b/src/wpanctl/Makefile.am
@@ -73,6 +73,8 @@ wpanctl_SOURCES = \
 	tool-cmd-host-did-wake.h \
 	tool-cmd-add-route.h \
 	tool-cmd-remove-route.h \
+	tool-cmd-pcap.h \
+	tool-cmd-pcap.c \
 	$(NULL)
 
 wpanctl_LDADD = \

--- a/src/wpanctl/tool-cmd-pcap.c
+++ b/src/wpanctl/tool-cmd-pcap.c
@@ -1,0 +1,300 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <getopt.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+
+#include "wpanctl-utils.h"
+#include "tool-cmd-pcap.h"
+#include "assert-macros.h"
+#include "args.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+
+const char pcap_cmd_syntax[] = "[args] <capture-file>";
+
+static const arg_list_item_t pcap_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'f', NULL, NULL, "Force use of stdout, even if it is a tty"},
+	{0}
+};
+
+
+static int do_pcap_to_fd(int fd, int timeout, DBusError *error)
+{
+	int ret = ERRORCODE_UNKNOWN;
+	DBusConnection *connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	char path[DBUS_MAXIMUM_NAME_LENGTH+1];
+	char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, error);
+
+	if (!connection) {
+		if (error != NULL) {
+			dbus_error_free(error);
+			dbus_error_init(error);
+		}
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, error);
+	}
+
+	require(connection != NULL, bail);
+
+	ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+
+	require_noerr(ret, bail);
+
+	snprintf(
+		path,
+		sizeof(path),
+		"%s/%s",
+		WPANTUND_DBUS_PATH,
+		gInterfaceName
+	);
+
+	message = dbus_message_new_method_call(
+		interface_dbus_name,
+		path,
+		WPANTUND_DBUS_APIv1_INTERFACE,
+		WPANTUND_IF_CMD_PCAP_TO_FD
+	);
+
+	dbus_message_append_args(
+		message,
+		DBUS_TYPE_UNIX_FD, &fd,
+		DBUS_TYPE_INVALID
+	);
+
+	ret = ERRORCODE_TIMEOUT;
+
+	reply = dbus_connection_send_with_reply_and_block(
+		connection,
+		message,
+		timeout,
+		error
+	);
+
+	require(reply != NULL, bail);
+
+	dbus_message_get_args(
+		reply,
+		error,
+		DBUS_TYPE_INT32, &ret,
+		DBUS_TYPE_INVALID
+	);
+
+	if (ret) {
+		fprintf(stderr, "pcap: failed with error %d. %s\n", ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
+		goto bail;
+	}
+
+bail:
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	return ret;
+}
+
+int
+tool_cmd_pcap(int argc, char *argv[])
+{
+	static const int set = 1;
+	int ret = 0;
+	int timeout = 10 * 1000;
+
+	int fd_out = -1;
+	int fd_pair[2] = { -1, -1 };
+	bool force_stdout = false;
+
+	DBusError error;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"timeout", required_argument, 0, 't'},
+			{0, 0, 0, 0}
+		};
+
+		int option_index = 0;
+		int c;
+
+		c = getopt_long(argc, argv, "fht:", long_options, &option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(pcap_option_list, argv[0],
+					    pcap_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 'f':
+			force_stdout = true;
+			break;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		// Capture packets to a file path
+
+		fd_out = open(argv[optind], O_WRONLY|O_CREAT|O_TRUNC, 0666);
+
+		optind++;
+
+	} else {
+		// Capture packets to stdout
+
+		if (!force_stdout && isatty(STDOUT_FILENO)) {
+			fprintf(stderr, "%s: error: Cowardly refusing write binary data to stdout tty\n", argv[0]);
+			ret = ERRORCODE_REFUSED;
+			goto bail;
+		}
+
+		// Update fd_out, close the original stdout.
+		fd_out = dup(STDOUT_FILENO);
+		close(STDOUT_FILENO);
+	}
+
+	if (optind < argc) {
+		fprintf(
+			stderr,
+		    "%s: error: Unexpected extra argument: \"%s\"\n",
+			argv[0],
+			argv[optind]
+		);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (fd_out < 0) {
+		fprintf(
+			stderr,
+			"%s: error: Unable to open file for pcap: \"%s\"\n",
+			argv[0],
+			strerror(errno)
+		);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	// We use a socket pair for the socket we hand to wpantund,
+	// so that the termination of this process will stop packet
+	// capture.
+	if (socketpair(PF_UNIX, SOCK_DGRAM, 0, fd_pair) < 0) {
+		perror("socketpair");
+		ret = ERRORCODE_UNKNOWN;
+		goto bail;
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(
+			stderr,
+		    "%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
+		    argv[0]
+		);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	// Have wpantund start writing PCAP data to one end of our socket pair.
+	ret = do_pcap_to_fd(fd_pair[1], timeout, &error);
+
+	if (ret) {
+		if (error.message != NULL) {
+			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+		}
+		goto bail;
+	}
+
+	// Close this side of the socket pair so that we can
+	// detect if wpantund closed the socket.
+	close(fd_pair[1]);
+
+#ifdef SO_NOSIGPIPE
+	// Turn off sigpipe so we can gracefully exit.
+	setsockopt(fd_pair[0], SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+	setsockopt(fd_out, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+#endif
+
+	fprintf(stderr, "%s: Capture started\n", argv[0]);
+
+	// Data pump
+	while (true) {
+		char buffer[2048];
+		ssize_t buffer_len;
+
+		// Read in from datagram socket
+		buffer_len = read(fd_pair[0], buffer, sizeof(buffer));
+
+		if (buffer_len <= 0) {
+			break;
+		}
+
+		// Write out the buffer to our file descriptor
+		buffer_len = write(fd_out, buffer, buffer_len);
+		if (buffer_len <= 0) {
+			break;
+		}
+	}
+
+	fprintf(stderr, "%s: Capture terminated\n", argv[0]);
+
+bail:
+
+	// Clean up.
+
+	close(fd_out);
+
+	close(fd_pair[0]);
+
+	close(fd_pair[1]);
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-pcap.h
+++ b/src/wpanctl/tool-cmd-pcap.h
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_PCAP_H
+#define WPANCTL_TOOL_CMD_PCAP_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_pcap(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/wpanctl-cmds.h
+++ b/src/wpanctl/wpanctl-cmds.h
@@ -39,6 +39,7 @@
 #include "tool-cmd-config-gateway.h"
 #include "tool-cmd-add-route.h"
 #include "tool-cmd-remove-route.h"
+#include "tool-cmd-pcap.h"
 
 #include "wpanctl-utils.h"
 
@@ -142,6 +143,11 @@
 		"host-did-wake", \
 		"Perform any host-wakeup related tasks", \
 		&tool_cmd_host_did_wake \
+	}, \
+	{ \
+		"pcap", \
+		"Start a packet capture", \
+		&tool_cmd_pcap \
 	}, \
 	{ "cd",   "Change current interface (command mode)", \
 	  &tool_cmd_cd                                            }

--- a/src/wpanctl/wpanctl-utils.h
+++ b/src/wpanctl/wpanctl-utils.h
@@ -43,6 +43,7 @@
 #define ERRORCODE_BADVERSION     (12)
 #define ERRORCODE_ALLOC           (13)
 #define ERRORCODE_NOTFOUND     (14)
+#define ERRORCODE_REFUSED     (15)
 
 #define ERRORCODE_INTERRUPT     (128 + SIGINT)
 #define ERRORCODE_SIGHUP        (128 + SIGHUP)

--- a/src/wpantund/Makefile.am
+++ b/src/wpantund/Makefile.am
@@ -70,6 +70,8 @@ wpantund_SOURCES = \
 	NCPTypes.cpp \
 	NetworkRetain.h \
 	NetworkRetain.cpp \
+	Pcap.h \
+	Pcap.cpp \
 	../util/IPv6PacketMatcher.cpp \
 	../util/IPv6Helpers.cpp \
 	../util/tunnel.c \

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -141,6 +141,15 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
+	virtual void pcap_to_fd(
+		int fd,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
+	virtual void pcap_terminate(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
 public:
 	// ========================================================================
 	// Scan-related Member Functions

--- a/src/wpantund/NCPInstanceBase-AsyncIO.cpp
+++ b/src/wpantund/NCPInstanceBase-AsyncIO.cpp
@@ -169,6 +169,10 @@ NCPInstanceBase::update_fd_set(fd_set *read_fd_set, fd_set *write_fd_set, fd_set
 
 	require_noerr(ret, bail);
 
+	ret = mPcapManager.update_fd_set(read_fd_set, write_fd_set, error_fd_set, max_fd, timeout);
+
+	require_noerr(ret, bail);
+
 	if (!ncp_state_is_detached_from_ncp(get_ncp_state())) {
 		nlpt_select_update_fd_set(&mDriverToNCPPumpPT, read_fd_set, write_fd_set, error_fd_set, max_fd);
 		nlpt_select_update_fd_set(&mNCPToDriverPumpPT, read_fd_set, write_fd_set, error_fd_set, max_fd);
@@ -197,6 +201,8 @@ NCPInstanceBase::process(void)
 	mRunawayResetBackoffManager.update();
 
 	mFirmwareUpgrade.process();
+
+	mPcapManager.process();
 
 	if (get_upgrade_status() != EINPROGRESS) {
 		refresh_global_addresses();

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -29,6 +29,7 @@
 #include "StatCollector.h"
 #include "NetworkRetain.h"
 #include "RunawayResetBackoffManager.h"
+#include "Pcap.h"
 
 namespace nl {
 namespace wpantund {
@@ -290,6 +291,7 @@ protected:
 	bool mLegacyInterfaceEnabled;
 	bool mNodeTypeSupportsLegacy;
 
+	PcapManager mPcapManager;
 
 private:
 	// ========================================================================

--- a/src/wpantund/Pcap.cpp
+++ b/src/wpantund/Pcap.cpp
@@ -1,0 +1,375 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+
+#include <string.h>
+#include <syslog.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "Pcap.h"
+
+using namespace nl;
+using namespace wpantund;
+
+
+PcapPacket::PcapPacket()
+	: mLen(sizeof(PcapFrameHeader)), mStatus(kWPANTUNDStatus_Ok)
+{
+	mHeader.mSeconds = 0;
+	mHeader.mMicroSeconds = 0;
+	mHeader.mRecordedPayloadSize = sizeof(PcapPpiHeader);
+	mHeader.mActualPayloadSize = sizeof(PcapPpiHeader);
+	mHeader.mPpiHeader.mVersion = 0;
+	mHeader.mPpiHeader.mFlags = 0;
+	mHeader.mPpiHeader.mSize = sizeof(PcapPpiHeader);
+	mHeader.mPpiHeader.mDLT = 0;
+}
+
+wpantund_status_t
+PcapPacket::get_status(void)const
+{
+	return mStatus;
+}
+
+const uint8_t*
+PcapPacket::get_data_ptr(void)const
+{
+	return mData;
+}
+
+int
+PcapPacket::get_data_len(void)const
+{
+	return mLen;
+}
+
+PcapPacket&
+PcapPacket::set_timestamp(struct timeval* tv)
+{
+	if (tv == NULL) {
+		struct timeval x;
+		gettimeofday(&x, NULL);
+
+		mHeader.mSeconds = static_cast<uint32_t>(x.tv_sec);
+		mHeader.mMicroSeconds = x.tv_usec;
+
+	} else {
+		mHeader.mSeconds = static_cast<uint32_t>(tv->tv_sec);
+		mHeader.mMicroSeconds = tv->tv_usec;
+	}
+
+	return *this;
+}
+
+PcapPacket&
+PcapPacket::set_dlt(uint32_t i)
+{
+	mHeader.mPpiHeader.mDLT = i;
+	return *this;
+}
+
+PcapPacket&
+PcapPacket::append_ppi_field(uint16_t type, const uint8_t* field_ptr, int field_len)
+{
+	PcapPpiFieldHeader field_header;
+
+	assert(mLen <= sizeof(mData));
+
+	if (field_len < 0) {
+		mStatus = kWPANTUNDStatus_InvalidArgument;
+
+	} else if (mLen + field_len + sizeof(PcapPpiFieldHeader) > sizeof(mData)) {
+		mStatus = kWPANTUNDStatus_InvalidArgument;
+
+	} else {
+		field_header.mType = type;
+		field_header.mSize = field_len;
+		memcpy(mData + mLen, &field_header, sizeof(PcapPpiFieldHeader));
+		memcpy(mData + mLen + sizeof(PcapPpiFieldHeader), field_ptr, field_len);
+		mLen += field_len + sizeof(PcapPpiFieldHeader);
+		mHeader.mRecordedPayloadSize += field_len + sizeof(PcapPpiFieldHeader);
+		mHeader.mPpiHeader.mSize += field_len + sizeof(PcapPpiFieldHeader);
+	}
+
+	mHeader.mActualPayloadSize += field_len + sizeof(PcapPpiFieldHeader);
+
+	return *this;
+}
+
+PcapPacket&
+PcapPacket::append_payload(const uint8_t* payload_ptr, int payload_len)
+{
+	assert(mLen <= sizeof(mData));
+
+	if (payload_len < 0) {
+		mStatus = kWPANTUNDStatus_InvalidArgument;
+
+	} else if (mLen + payload_len > sizeof(mData)) {
+		memcpy(mData + mLen, payload_ptr, sizeof(mData) - mLen);
+		mLen = sizeof(mData);
+		mHeader.mRecordedPayloadSize += sizeof(mData) - mLen;
+
+	} else {
+		memcpy(mData + mLen, payload_ptr, payload_len);
+		mLen += payload_len;
+		mHeader.mRecordedPayloadSize += payload_len;
+	}
+
+	mHeader.mActualPayloadSize += payload_len;
+
+	return *this;
+}
+
+
+PcapManager::PcapManager()
+{
+}
+
+PcapManager::~PcapManager()
+{
+}
+
+bool
+PcapManager::is_enabled(void)
+{
+	return !mFDSet.empty();
+}
+
+const std::set<int>&
+PcapManager::get_fd_set(void)
+{
+	return mFDSet;
+}
+
+int
+PcapManager::insert_fd(int fd)
+{
+	int ret = -1;
+	int save_errno;
+	int set = 1;
+	PcapGlobalHeader header;
+
+	// Prepare the PCAP header.
+	header.mMagic = PCAP_MAGIC;
+	header.mVerMaj = PCAP_VERSION_MAJOR;
+	header.mVerMin = PCAP_VERSION_MINOR;
+	header.mGMTOffset = 0;
+	header.mAccuracy = 0;
+	header.mSnapshotLengthField = PCAP_PACKET_MAX_SIZE;
+	header.mDLT = PCAP_DLT_PPI;
+
+#ifdef SO_NOSIGPIPE
+	setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&set, sizeof(int));
+#endif
+
+	// Send the PCAP header.
+	ret = static_cast<int>(write(fd, &header, sizeof(header)));
+
+	if (ret < 0) {
+		save_errno = errno;
+		syslog(LOG_ERR, "PcapManager::insert_fd: Call to send() on fd %d failed: %s (%d)", fd, strerror(errno), errno);
+		goto bail;
+	}
+
+	mFDSet.insert(fd);
+
+	ret = 0;
+
+bail:
+	if (ret < 0) {
+		errno = save_errno;
+	}
+
+	return ret;
+}
+
+int
+PcapManager::new_fd(void)
+{
+	int ret = -1;
+	int save_errno;
+	int fd[2] = { -1, -1 };
+
+	ret = socketpair(PF_UNIX, SOCK_DGRAM, 0, fd);
+
+	if (ret < 0) {
+		save_errno = errno;
+		syslog(LOG_ERR, "PcapManager::new_fd: Call to socketpair() failed: %s (%d)", strerror(errno), errno);
+		goto bail;
+	}
+
+	ret = insert_fd(fd[1]);
+
+	if (ret < 0) {
+		save_errno = errno;
+		goto bail;
+	}
+
+	ret = fd[0];
+
+bail:
+
+	if (ret < 0) {
+		close(fd[0]);
+		close(fd[1]);
+
+		errno = save_errno;
+	}
+
+	return ret;
+}
+
+void
+PcapManager::close_fd_set(const std::set<int>& x)
+{
+	if (&x == &mFDSet) {
+		// Special case where we are asked to close everything.
+		std::set<int> copy(x);
+
+		close_fd_set(copy);
+	} else {
+		std::set<int>::const_iterator iter;
+
+		for ( iter  = x.begin()
+			; iter != x.end()
+			; ++iter
+		) {
+			const int fd = *iter;
+			close(fd);
+			mFDSet.erase(fd);
+		}
+	}
+}
+
+void
+PcapManager::push_packet(const PcapPacket& packet)
+{
+	std::set<int>::const_iterator iter;
+	std::set<int> remove_set;
+
+	require_noerr(packet.get_status(), bail);
+
+	for ( iter  = mFDSet.begin()
+	    ; iter != mFDSet.end()
+		; ++iter
+	) {
+		int ret;
+
+		// Send the PCAP frame.
+		ret = static_cast<int>(write(
+			*iter,
+			packet.get_data_ptr(),
+			packet.get_data_len()
+		));
+
+		__ASSERT_MACROS_check(ret >= 0);
+
+		if (ret < 0) {
+			// Since we can't remove this file descriptor
+			// from the set while we are iterating through it,
+			// we add it to the remove set for later removal.
+			remove_set.insert(*iter);
+		}
+	}
+
+	close_fd_set(remove_set);
+
+bail:
+	return;
+}
+
+int
+PcapManager::update_fd_set(fd_set *read_fd_set, fd_set *write_fd_set, fd_set *error_fd_set, int *max_fd, cms_t *timeout)
+{
+	std::set<int>::const_iterator iter;
+
+	for ( iter  = mFDSet.begin()
+	    ; iter != mFDSet.end()
+		; ++iter
+	) {
+		const int fd = *iter;
+
+		if (read_fd_set) {
+			FD_SET(fd, read_fd_set);
+		}
+
+		if (error_fd_set) {
+			FD_SET(fd, read_fd_set);
+		}
+
+		if (max_fd && (*max_fd < fd)) {
+			*max_fd = fd;
+		}
+	}
+
+	return 0;
+}
+
+void
+PcapManager::process(void)
+{
+	if (is_enabled()) {
+		fd_set fds;
+		int max_fd(-1);
+		int fds_ready;
+		struct timeval timeout = {};
+
+		FD_ZERO(&fds);
+
+		update_fd_set(&fds, NULL, &fds, &max_fd, NULL);
+
+		fds_ready = select(
+			max_fd + 1,
+			&fds,
+			NULL,
+			&fds,
+			&timeout
+		);
+
+		if (fds_ready > 0) {
+			// Tear down bad file descriptors.
+			std::set<int> remove_set;
+			std::set<int>::const_iterator iter;
+
+			for ( iter  = mFDSet.begin()
+				; (fds_ready > 0) && (iter != mFDSet.end())
+				; ++iter
+			) {
+				int fd = *iter;
+				if (!FD_ISSET(fd, &fds)) {
+					continue;
+				}
+				fds_ready--;
+				remove_set.insert(fd);
+			}
+
+			close_fd_set(remove_set);
+		}
+	}
+}

--- a/src/wpantund/Pcap.h
+++ b/src/wpantund/Pcap.h
@@ -1,0 +1,144 @@
+/*
+ *
+ * Copyright (c) 2016 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __wpantund__Pcap__
+#define __wpantund__Pcap__
+
+#include <set>
+#include "wpan-error.h"
+#include "time-utils.h"
+
+namespace nl {
+namespace wpantund {
+
+#define PCAP_PACKET_MAX_SIZE        512
+
+#define PCAP_DLT_PPI                192
+#define PCAP_DLT_IEEE802_15_4       195
+#define PCAP_DLT_IEEE802_15_4_NOFCS 230
+
+#define PCAP_MAGIC                  0xa1b2c3d4
+#define PCAP_VERSION_MAJOR          2
+#define PCAP_VERSION_MINOR          4
+
+#define PCAP_PPI_VERSION            0
+
+#define PCAP_PPI_TYPE_SPINEL        61616
+
+/* Additional reading:
+ *
+ * * DLT list: http://www.tcpdump.org/linktypes.html
+ * * Info on PPI: http://www.cacetech.com/documents/PPI%20Header%20format%201.0.7.pdf
+ */
+
+struct PcapGlobalHeader {
+	uint32_t mMagic;
+	uint16_t mVerMaj;
+	uint16_t mVerMin;
+	int32_t  mGMTOffset;
+	uint32_t mAccuracy;
+	uint32_t mSnapshotLengthField;
+	uint32_t mDLT;
+};
+
+struct PcapPpiHeader {
+	uint8_t mVersion;
+	uint8_t mFlags;
+	uint16_t mSize;
+	uint32_t mDLT;
+	uint8_t  mPayloadData[0];
+};
+
+struct PcapPpiFieldHeader {
+	uint16_t mType;
+	uint16_t mSize;
+	uint8_t  mData[0];
+};
+
+struct PcapFrameHeader {
+	uint32_t mSeconds;
+	uint32_t mMicroSeconds;
+	uint32_t mRecordedPayloadSize;
+	uint32_t mActualPayloadSize;
+	union {
+		struct PcapPpiHeader mPpiHeader;
+		uint8_t  mPayloadData[0];
+	};
+};
+
+class PcapPacket
+{
+public:
+	PcapPacket();
+
+	wpantund_status_t get_status(void)const;
+
+	const uint8_t* get_data_ptr(void)const;
+
+	int get_data_len(void)const;
+
+	PcapPacket& set_timestamp(struct timeval* tv = NULL);
+
+	PcapPacket& set_dlt(uint32_t i);
+
+	PcapPacket& append_ppi_field(uint16_t type, const uint8_t* field_ptr, int field_len);
+
+	PcapPacket& append_payload(const uint8_t* payload_ptr, int payload_len);
+
+	PcapPacket& finish(void);
+
+private:
+	union {
+		uint8_t         mData[PCAP_PACKET_MAX_SIZE];
+		PcapFrameHeader mHeader;
+	};
+	int               mLen;
+	wpantund_status_t mStatus;
+};
+
+class PcapManager
+{
+public:
+	PcapManager();
+	~PcapManager();
+
+	bool is_enabled(void);
+
+	const std::set<int>& get_fd_set(void);
+
+	int new_fd(void);
+
+	int insert_fd(int fd);
+
+	void push_packet(const PcapPacket& packet);
+
+	void process(void);
+
+	int update_fd_set(fd_set *read_fd_set, fd_set *write_fd_set, fd_set *error_fd_set, int *max_fd, cms_t *timeout);
+
+	void close_fd_set(const std::set<int>& x);
+
+private:
+	std::set<int> mFDSet;
+};
+
+}; // namespace wpantund
+}; // namespace nl
+
+#endif /* defined(__wpantund__NetworkRetain__) */

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -506,6 +506,9 @@ main(int argc, char * argv[])
 	gPreviousHandlerForSIGTERM = signal(SIGTERM, &signal_SIGTERM);
 	signal(SIGHUP, &signal_SIGHUP);
 
+	// Always ignore SIGPIPE.
+	signal(SIGPIPE, SIG_IGN);
+
 	{
 		struct sigaction sigact;
 		sigact.sa_sigaction = &signal_critical;


### PR DESCRIPTION
This pull request adds support for the capture and logging of raw packets from the radio, assuming the underlying NCP supports it.

Note that this feature captures raw packets from the radio, which will currently always be 802.15.4 frames (but that may not always be the case in the future). If you just want to sniff IP traffic, you can simply use Wireshark or tcpdump directly.

Packets are captured in the PCAP format, which is the same format used by Wireshark and tcpdump. You can start a packet capture using the `pcap` command in `wpanctl`:

    Syntax:
       pcap [args] <capture-file>
    Options:
       -h/--help                 Print Help
       -t/--timeout              Set timeout period [ms]
       -f                        Force use of stdout, even if it is a tty

If you to not specify a file, `stdout` is used. If `stdout` is a TTY, it will refuse unless you also specify `-f`.

For real-time monitoring in Wireshark, you can capture to a named pipe (created using `mkfifo`) and have Wireshark capture from that.

Note that support for promiscuous sniffing is not yet supported. That feature will be added in a subsequent pull request.

Raw packet capture is being added to OpenThread NCPs via [PR #644][1].

[1]: https://github.com/openthread/openthread/pull/644