### PR TITLE
NCPInstanceBase: Make sure we clear the global address table upon reset

### DIFF
--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -116,6 +116,9 @@ NCPInstanceBase::reset_interface(void)
 {
 	mPrimaryInterface->reset();
 
+	// The global address table must be cleared upon reset.
+	mGlobalAddresses.clear();
+
 	if (static_cast<bool>(mLegacyInterface)) {
 		mLegacyInterface->reset();
 	}


### PR DESCRIPTION
Upon leaving a network, we were not clearing `wpantund`'s global address
table. This would cause these old addresses to be re-added to the interface
when the same instance of `wpantund` associated with a new network.

This change fixes this issue by making sure that we clear the global
address table whenever we reset the interface.