### PR TITLE
Ensure stable flag is true for on-mesh-prefix added from `address_was_added()`

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1387,7 +1387,7 @@ SpinelNCPInstance::address_was_added(const struct in6_addr& addr, int prefix_len
 				SPINEL_PROP_THREAD_ON_MESH_NETS,
 				&addr,
 				prefix_len,
-				false,
+				true,
 				flags
 			)
 		);


### PR DESCRIPTION
This commit changes the `SpinelNCPInstance::address_was_added()` so that when an `ON_MESH_PREFIX` added the stable flag is set to `true`.