### PR TITLE
NCPInstanceBase: Fix for dissapearing addresses after NCP crash

### DIFF
--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -114,6 +114,12 @@ NCPInstanceBase::set_mac_hardware_address(const uint8_t x[8])
 void
 NCPInstanceBase::reset_interface(void)
 {
+	syslog(LOG_NOTICE, "Resetting interface(s). . .");
+
+	mCurrentNetworkInstance.joinable = false;
+
+	set_commissioniner(0, 0, 0);
+
 	mPrimaryInterface->reset();
 
 	// The global address table must be cleared upon reset.

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -778,10 +778,18 @@ NCPInstanceBase::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_nc
 	} else if (ncp_state_is_commissioned(old_ncp_state)
 		&& !ncp_state_is_commissioned(new_ncp_state)
 		&& !ncp_state_is_sleeping(new_ncp_state)
+		&& (new_ncp_state != UNINITIALIZED)
 	) {
-		syslog(LOG_NOTICE, "Resetting interface(s). . .");
-		mCurrentNetworkInstance.joinable = false;
-		set_commissioniner(0, 0, 0);
+		reset_interface();
+
+
+	// Uninitialized -> Offline
+	// If we are transitioning from uninitialized to offline,
+	// and we have global addresses, then need to clear them out.
+	} else if (old_ncp_state == UNINITIALIZED
+		&& new_ncp_state == OFFLINE
+		&& !mGlobalAddresses.empty()
+	) {
 		reset_interface();
 
 


### PR DESCRIPTION
This change adjusts the state change logic to ensure that
the global address table is only forcably cleared when we
have entered the offline state.