### PR TITLE
NCPInstanceBase: Don't allow host sleep while NCP is being initialized

### DIFF
--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -837,6 +837,10 @@ NCPInstanceBase::is_busy(void)
 	const NCPState ncp_state = get_ncp_state();
 	bool is_busy = ncp_state_is_busy(ncp_state);
 
+	if (is_initializing_ncp()) {
+		return true;
+	}
+
 	if (ncp_state == FAULT) {
 		return false;
 	}


### PR DESCRIPTION
This commit changes the `NCPInstanceBase::is_busy()` to ensure that it returns `true` while NCP is being initialized.