### PR TITLE
ncp-spinel: Add support for promiscuous packet capture

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -443,6 +443,7 @@ on_error:
 		mFailureCount++;
 	} while (true);
 
+	mIsPcapInProgress = false;
 	mFailureCount = 0;
 	mResetIsExpected = false;
 	set_initializing_ncp(false);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -268,7 +268,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 cms_t
 SpinelNCPInstance::get_ms_to_next_event(void)
 {
-	cms_t cms = EventHandler::get_ms_to_next_event();
+	cms_t cms = NCPInstanceBase::get_ms_to_next_event();
 
 	if (ncp_state_is_detached_from_ncp(get_ncp_state())) {
 		return CMS_DISTANT_FUTURE;
@@ -1345,6 +1345,14 @@ SpinelNCPInstance::address_was_removed(const struct in6_addr& addr, int prefix_l
 		start_new_task(factory.finish());
 	}
 }
+
+bool
+SpinelNCPInstance::is_busy(void)
+{
+	return NCPInstanceBase::is_busy()
+		|| !mTaskQueue.empty();
+}
+
 
 void
 SpinelNCPInstance::process(void)

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -122,6 +122,8 @@ protected:
 
 	void start_new_task(const boost::shared_ptr<SpinelNCPTask> &task);
 
+	virtual bool is_busy(void);
+
 protected:
 
 	int vprocess_init(int event, va_list args);

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -320,7 +320,7 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 
 	ret = mNextCommandRet;
 
-	require_noerr(ret, on_error);
+	require(ret == kWPANTUNDStatus_Ok || ret == kWPANTUNDStatus_Already, on_error);
 
 	mNextCommand = SpinelPackData(
 		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -191,6 +191,17 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 	}
 
+	// Turn off promiscuous mode, if it happens to be on
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
+		SPINEL_PROP_MAC_PROMISCUOUS_MODE,
+		SPINEL_MAC_PROMISCUOUS_MODE_OFF
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	check_noerr(ret);
+
 	if (mOptions.count(kWPANTUNDProperty_NetworkPANID)) {
 		mNextCommand = SpinelPackData(
 			SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT16_S),

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -139,6 +139,16 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 	}
 
+	// Turn off promiscuous mode, if it happens to be on
+	mNextCommand = SpinelPackData(
+		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
+		SPINEL_PROP_MAC_PROMISCUOUS_MODE,
+		SPINEL_MAC_PROMISCUOUS_MODE_OFF
+	);
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	check_noerr(ret);
+
 	if (mOptions.count(kWPANTUNDProperty_NCPChannel)) {
 		mNextCommand = SpinelPackData(
 			SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),

--- a/src/wpantund/NCPInstanceBase-AsyncIO.cpp
+++ b/src/wpantund/NCPInstanceBase-AsyncIO.cpp
@@ -147,6 +147,10 @@ NCPInstanceBase::get_ms_to_next_event(void)
 		if (temp_cms < ret) {
 			ret = temp_cms;
 		}
+
+		if (ret > BUSY_DEBOUNCE_TIME_IN_MS && !is_busy()) {
+			ret = BUSY_DEBOUNCE_TIME_IN_MS;
+		}
 	}
 
 	if (ret < 0) {

--- a/src/wpantund/Pcap.cpp
+++ b/src/wpantund/Pcap.cpp
@@ -253,7 +253,8 @@ PcapManager::close_fd_set(const std::set<int>& x)
 		std::set<int> copy(x);
 
 		close_fd_set(copy);
-	} else {
+
+	} else if (!x.empty()) {
 		std::set<int>::const_iterator iter;
 
 		for ( iter  = x.begin()
@@ -261,9 +262,11 @@ PcapManager::close_fd_set(const std::set<int>& x)
 			; ++iter
 		) {
 			const int fd = *iter;
+			syslog(LOG_INFO, "PcapManager::close_fd_set: Closing FD %d", fd);
 			close(fd);
 			mFDSet.erase(fd);
 		}
+		syslog(LOG_INFO, "PcapManager: %d pcap streams remaining", static_cast<int>(mFDSet.size()));
 	}
 }
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -962,8 +962,8 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_MAC_RAW_STREAM_ENABLED";
         break;
 
-    case SPINEL_PROP_MAC_FILTER_MODE:
-        ret = "PROP_MAC_FILTER_MODE";
+    case SPINEL_PROP_MAC_PROMISCUOUS_MODE:
+        ret = "PROP_MAC_PROMISCUOUS_MODE";
         break;
 
     case SPINEL_PROP_MAC_SCAN_STATE:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -204,19 +204,9 @@ enum
 
 enum
 {
-    SPINEL_MAC_FILTER_MODE_NORMAL      = 0, ///< Normal MAC filtering is in place.
-    SPINEL_MAC_FILTER_MODE_PROMISCUOUS = 1, ///< All MAC packets matching network are passed up the stack.
-    SPINEL_MAC_FILTER_MODE_MONITOR     = 2, ///< All decoded MAC packets are passed up the stack.
-
-    /// 802.15.4's definition of "Promiscuous" mode.
-    /** 802.15.4 defines promiscuous mode to be what
-     *  is generally considered to be "Monitor" mode.
-     *  This definition will hopefully help people who
-     *  are familiar with the 802.15.4 spec from being
-     *  confused about what they need to set this
-     *  property to in order to get the desired behavior.
-     */
-    SPINEL_MAC_FILTER_MODE_15_4_PROMISCUOUS = SPINEL_MAC_FILTER_MODE_MONITOR,
+    SPINEL_MAC_PROMISCUOUS_MODE_OFF      = 0, ///< Normal MAC filtering is in place.
+    SPINEL_MAC_PROMISCUOUS_MODE_NETWORK  = 1, ///< All MAC packets matching network are passed up the stack.
+    SPINEL_MAC_PROMISCUOUS_MODE_FULL     = 2, ///< All decoded MAC packets are passed up the stack.
 };
 
 typedef struct
@@ -246,10 +236,10 @@ typedef unsigned int spinel_cid_t;
 
 enum
 {
-    SPINEL_MD_FLAG_TX               = 0x0001,
-    SPINEL_MD_FLAG_BAD_FCS          = 0x0004,
-    SPINEL_MD_FLAG_DUPE             = 0x0008,
-    SPINEL_MD_FLAG_RESERVED         = 0xFFF2,
+    SPINEL_MD_FLAG_TX               = 0x0001, //!< Packet was transmitted, not received.
+    SPINEL_MD_FLAG_BAD_FCS          = 0x0004, //!< Packet was received with bad FCS
+    SPINEL_MD_FLAG_DUPE             = 0x0008, //!< Packet seems to be a duplicate
+    SPINEL_MD_FLAG_RESERVED         = 0xFFF2, //!< Flags reserved for future use.
 };
 
 enum
@@ -368,7 +358,7 @@ typedef enum
     SPINEL_PROP_MAC_15_4_SADDR         = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
     SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
     SPINEL_PROP_MAC_RAW_STREAM_ENABLED = SPINEL_PROP_MAC__BEGIN + 7, ///< [C]
-    SPINEL_PROP_MAC_FILTER_MODE        = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
+    SPINEL_PROP_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_MAC__BEGIN + 8, ///< [C]
     SPINEL_PROP_MAC_ENERGY_SCAN_RESULT = SPINEL_PROP_MAC__BEGIN + 9, ///< chan,maxRssi [Cc]
     SPINEL_PROP_MAC__END               = 0x40,
 
@@ -533,6 +523,12 @@ typedef enum
      */
     SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID
                                         = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
+
+    /// Thread Neighbor Table
+    /** Format: `A(T(ESLCcCbLL))`
+     *  eui64, rloc16, age, inLqi ,aveRSS, mode, isChild. linkFrameCounter, mleCounter
+     */
+    SPINEL_PROP_THREAD_NEIGHBOR_TABLE  = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
 
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 


### PR DESCRIPTION
This change allows the `wpanctl pcap` command to work when in an `offline` state. When started while `offline`, it puts the NCP into a promiscuous sniffing mode.

If you subsequently associate with a network while sniffing promiscuously, promiscuous mode is turned off and behavior reverts to the same as if you had started `wpanctl pcap` while associated.

This change also restores packet capture state properly after a NCP reset.

This pull request also includes the following other changes:

* 36d2dbf: Fix for incorrectly calculating time for next event
* 5547790: ncp-spinel: Join: Allow `ALREADY` error when setting `PROP_NET_IF_UP`