### PR TITLE
Measure prefix length in bits, not bytes

### DIFF
--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -131,22 +131,41 @@ DummyNCPControlInterface::data_poll(CallbackWithStatus cb)
 }
 
 void
-DummyNCPControlInterface::config_gateway(bool defaultRoute, const uint8_t prefix[8], uint32_t preferredLifetime, uint32_t validLifetime, CallbackWithStatus cb)
-{
-	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Send config gateway command
+DummyNCPControlInterface::add_on_mesh_prefix(
+	const struct in6_addr *prefix,
+	bool defaultRoute,
+	CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
 }
 
 void
-DummyNCPControlInterface::add_external_route(const uint8_t *route, int route_prefix_len, int domain_id,
-	ExternalRoutePriority priority, CallbackWithStatus cb)
-{
-	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Send add external route command
+DummyNCPControlInterface::remove_on_mesh_prefix(
+	const struct in6_addr *prefix,
+	CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
 }
 
 void
-DummyNCPControlInterface::remove_external_route(const uint8_t *route, int route_prefix_len, int domain_id, CallbackWithStatus cb)
-{
-	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Send remove external route command
+DummyNCPControlInterface::add_external_route(
+	const struct in6_addr *prefix,
+	int prefix_len_in_bits,
+	int domain_id,
+	ExternalRoutePriority priority,
+	CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
+void
+DummyNCPControlInterface::remove_external_route(
+	const struct in6_addr *prefix,
+	int prefix_len_in_bits,
+	int domain_id,
+	CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
 }
 
 void

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -84,9 +84,31 @@ public:
 	    const std::string&                      key,
 	    const boost::any&                       value,
 	    CallbackWithStatus      cb);
-	virtual void config_gateway(bool defaultRoute, const uint8_t prefix[8], uint32_t preferredLifetime, uint32_t validLifetime, CallbackWithStatus cb = NilReturn());
-	virtual void add_external_route(const uint8_t route[], int route_prefix_len, int domain_id, ExternalRoutePriority priority, CallbackWithStatus);
-	virtual void remove_external_route(const uint8_t route[], int route_prefix_len, int domain_id, CallbackWithStatus cb);
+	virtual void add_on_mesh_prefix(
+		const struct in6_addr *prefix,
+		bool defaultRoute,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void remove_on_mesh_prefix(
+		const struct in6_addr *prefix,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void add_external_route(
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
+		int domain_id,
+		ExternalRoutePriority priority,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void remove_external_route(
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
+		int domain_id,
+		CallbackWithStatus cb = NilReturn()
+	);
 
 	virtual void data_poll(CallbackWithStatus cb = NilReturn());
 	virtual void host_did_wake(CallbackWithStatus cb = NilReturn());

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -83,9 +83,31 @@ public:
 	    const std::string&                      key,
 	    const boost::any&                       value,
 	    CallbackWithStatus      cb);
-	virtual void config_gateway(bool defaultRoute, const uint8_t prefix[8], uint32_t preferredLifetime, uint32_t validLifetime, CallbackWithStatus cb = NilReturn());
-	virtual void add_external_route(const uint8_t route[], int route_prefix_len, int domain_id, ExternalRoutePriority priority, CallbackWithStatus);
-	virtual void remove_external_route(const uint8_t route[], int route_prefix_len, int domain_id, CallbackWithStatus cb);
+	virtual void add_on_mesh_prefix(
+		const struct in6_addr *prefix,
+		bool defaultRoute,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void remove_on_mesh_prefix(
+		const struct in6_addr *prefix,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void add_external_route(
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
+		int domain_id,
+		ExternalRoutePriority priority,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void remove_external_route(
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
+		int domain_id,
+		CallbackWithStatus cb = NilReturn()
+	);
 
 	virtual void data_poll(CallbackWithStatus cb = NilReturn());
 	virtual void host_did_wake(CallbackWithStatus cb = NilReturn());

--- a/src/util/IPv6Helpers.h
+++ b/src/util/IPv6Helpers.h
@@ -30,6 +30,14 @@
 
 #define MINIMUM_IPV6_PACKET_SIZE	40
 
+#define IPV6_MAX_PREFIX_LENGTH                  128
+#define IPV6_NETWORK_PREFIX_LENGTH              64
+
+#define IPV6_PREFIX_BITS_TO_BYTES(x)		((static_cast<uint8_t>(x)+7)/8)
+#define IPV6_PREFIX_BYTES_TO_BITS(x)		(static_cast<uint8_t>(x)*8)
+
+#define IPV6_MAX_LIFETIME					UINT32_MAX
+
 static inline bool
 operator==(const struct in6_addr &lhs, const struct in6_addr &rhs)
 {
@@ -59,5 +67,6 @@ std::string in6_addr_to_string(const struct in6_addr &addr);
 struct in6_addr make_slaac_addr_from_eui64(const uint8_t prefix[8], const uint8_t eui64[8]);
 
 void in6_addr_apply_mask(struct in6_addr &address, uint8_t mask);
+
 
 #endif

--- a/src/wpanctl/tool-cmd-config-gateway.c
+++ b/src/wpanctl/tool-cmd-config-gateway.c
@@ -60,6 +60,10 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 	uint32_t preferredLifetime = 0xFFFFFFFF;
 	uint32_t validLifetime = 0xFFFFFFFF;
 	const char* prefix = NULL;
+	uint8_t prefix_length = 64;
+	char address_string[INET6_ADDRSTRLEN] = "::";
+	uint8_t prefix_bytes[16] = {};
+	uint8_t *addr = prefix_bytes;
 
 	dbus_error_init(&error);
 
@@ -168,7 +172,6 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 		);
 
 		if(prefix) {
-			uint8_t prefix_bytes[16] = {};
 
 			// So the prefix could either be
 			// specified like an IPv6 address, or
@@ -201,24 +204,17 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 				}
 			}
 
-			fprintf(stderr, "Using prefix \"%s\"\n", prefix);
+			inet_ntop(AF_INET6, (const void *)&prefix_bytes, address_string, sizeof(address_string));
 
-			uint8_t *addr = prefix_bytes;
-			dbus_message_append_args(
-			    message,
-			    DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 8,
-			    DBUS_TYPE_INVALID
-			);
-		} else {
-			dbus_message_append_args(
-			    message,
-			    DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, "", 0,
-			    DBUS_TYPE_INVALID
-			);
+			fprintf(stderr, "Using prefix \"%s\"\n", address_string);
+
 		}
+
+		addr = prefix_bytes;
 
 		dbus_message_append_args(
 		    message,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 16,
 		    DBUS_TYPE_UINT32, &preferredLifetime,
 		    DBUS_TYPE_UINT32, &validLifetime,
 		    DBUS_TYPE_INVALID

--- a/src/wpanctl/tool-cmd-pcap.c
+++ b/src/wpanctl/tool-cmd-pcap.c
@@ -109,13 +109,8 @@ static int do_pcap_to_fd(int fd, int timeout, DBusError *error)
 		DBUS_TYPE_INVALID
 	);
 
-	if (ret) {
-		fprintf(stderr, "pcap: failed with error %d. %s\n", ret, wpantund_status_to_cstr(ret));
-		print_error_diagnosis(ret);
-		goto bail;
-	}
-
 bail:
+
 	if (connection) {
 		dbus_connection_unref(connection);
 	}
@@ -285,6 +280,11 @@ tool_cmd_pcap(int argc, char *argv[])
 	fprintf(stderr, "%s: Capture terminated\n", argv[0]);
 
 bail:
+
+	if (ret) {
+		fprintf(stderr, "pcap: failed with error %d. %s\n", ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
+	}
 
 	// Clean up.
 

--- a/src/wpanctl/tool-cmd-reset.c
+++ b/src/wpanctl/tool-cmd-reset.c
@@ -107,6 +107,7 @@ int tool_cmd_reset(int argc, char *argv[])
 		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
 		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
 		if (ret != 0) {
+			print_error_diagnosis(ret);
 			goto bail;
 		}
 		snprintf(path,

--- a/src/wpanctl/tool-cmd-resume.c
+++ b/src/wpanctl/tool-cmd-resume.c
@@ -107,6 +107,7 @@ int tool_cmd_resume(int argc, char *argv[])
 		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
 		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
 		if (ret != 0) {
+			print_error_diagnosis(ret);
 			goto bail;
 		}
 		snprintf(path,

--- a/src/wpanctl/tool-cmd-scan.c
+++ b/src/wpanctl/tool-cmd-scan.c
@@ -267,6 +267,7 @@ int tool_cmd_scan(int argc, char *argv[])
 		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
 
 		if (ret != 0) {
+			print_error_diagnosis(ret);
 			goto bail;
 		}
 

--- a/src/wpanctl/tool-cmd-setprop.c
+++ b/src/wpanctl/tool-cmd-setprop.c
@@ -161,6 +161,7 @@ int tool_cmd_setprop(int argc, char* argv[])
 		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
 		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
 		if (ret != 0) {
+			print_error_diagnosis(ret);
 			goto bail;
 		}
 		snprintf(path,

--- a/src/wpanctl/tool-cmd-status.c
+++ b/src/wpanctl/tool-cmd-status.c
@@ -107,6 +107,7 @@ int tool_cmd_status(int argc, char *argv[])
 		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
 		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
 		if (ret != 0) {
+			print_error_diagnosis(ret);
 			goto bail;
 		}
 		snprintf(path,

--- a/src/wpanctl/wpanctl-utils.c
+++ b/src/wpanctl/wpanctl-utils.c
@@ -323,7 +323,7 @@ bail:
 int
 lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name)
 {
-	int ret = ERRORCODE_NOTFOUND;
+	int ret = kWPANTUNDStatus_InterfaceNotFound;
 	int i;
 	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
 	DBusConnection* connection = NULL;
@@ -454,6 +454,7 @@ wpantund_status_to_cstr(int status)
 	case kWPANTUNDStatus_TryAgainLater: return "TryAgainLater";
 	case kWPANTUNDStatus_InvalidRange: return "InvalidRange";
 	case kWPANTUNDStatus_MissingXPANID: return "MissingXPANID";
+	case kWPANTUNDStatus_InterfaceNotFound: return "InterfaceNotFound";
 	default: break;
 	}
 	return "";
@@ -462,6 +463,16 @@ wpantund_status_to_cstr(int status)
 void print_error_diagnosis(int error)
 {
 	switch(error) {
+	case kWPANTUNDStatus_InterfaceNotFound:
+		fprintf(stderr, "\nDIAGNOSIS: The requested operation can't be completed because the given\n"
+						"network interface doesn't exist or it isn't managed by wpantund. If you are\n"
+						"using wpanctl in interactive mode, you can use the `ls` command to get a list\n"
+						"of valid interfaces and use the `cd` command to select a valid interface.\n"
+						"Otherwise, use the `-I` argument to wpanctl to select a valid interface.\n"
+						"\n"
+		);
+		break;
+
 	case kWPANTUNDStatus_Busy:
 	case -EBUSY:
 		fprintf(stderr, "\nDIAGNOSIS: The requested operation can't be completed because the NCP\n"

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -118,25 +118,28 @@ public:
 	    CallbackWithStatus cb
 	) = 0;
 
-	virtual void config_gateway(
+	virtual void add_on_mesh_prefix(
+		const struct in6_addr *prefix,
 		bool defaultRoute,
-		const uint8_t prefix[8],
-		uint32_t preferredLifetime,
-		uint32_t validLifetime,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
+	virtual void remove_on_mesh_prefix(
+		const struct in6_addr *prefix,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 	virtual void add_external_route(
-		const uint8_t route[],
-		int route_prefix_len,
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
 		int domain_id,
 		ExternalRoutePriority priority,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 	virtual void remove_external_route(
-		const uint8_t route[],
-		int route_prefix_len,
+		const struct in6_addr *prefix,
+		int prefix_len_in_bits,
 		int domain_id,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;

--- a/src/wpantund/wpan-error.h
+++ b/src/wpantund/wpan-error.h
@@ -61,6 +61,8 @@ typedef enum {
 
 	kWPANTUNDStatus_NCP_Reset                     = 27,
 
+	kWPANTUNDStatus_InterfaceNotFound             = 28,
+
 	kWPANTUNDStatus_NCPError_First = 0xEA0000,
 	kWPANTUNDStatus_NCPError_Last = 0xEAFFFF,
 } wpantund_status_t;


### PR DESCRIPTION
As a carry-over from days long gone, several code paths in `wpantund` measure the prefix length in bytes, not bits. This change addresses this issue.

Also includes improvements for a common error condition (interface not found) in `wpanctl`.