### PR TITLE
Adding support for legacy network to spinel code

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -319,6 +319,26 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 	}
 
+	if (mOptions.count(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix)) {
+		if (mInstance->mCapabilities.count(SPINEL_CAP_NEST_LEGACY_INTERFACE)) {
+			{
+				nl::Data data(any_to_data(mOptions[kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix]));
+				mNextCommand = SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
+					SPINEL_PROP_NEST_LEGACY_ULA_PREFIX,
+					data.data(),
+					data.size()
+				);
+			}
+
+			EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+			ret = mNextCommandRet;
+
+			require_noerr(ret, on_error);
+		}
+	}
+
 	// Now bring up the network by bringing up the interface and the stack.
 
 	mNextCommand = SpinelPackData(

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -121,6 +121,13 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 			}
 			isRouterRoleEnabled = false;
 
+		} else if (node_type == LURKER) {
+			if (!mInstance->mCapabilities.count(SPINEL_CAP_NEST_LEGACY_INTERFACE)) {
+				ret = kWPANTUNDStatus_FeatureNotSupported;
+				goto on_error;
+			}
+			isRouterRoleEnabled = true;
+
 		} else {
 			ret = kWPANTUNDStatus_InvalidArgument;
 			goto on_error;

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1155,6 +1155,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_NEST_STREAM_MFG";
         break;
 
+    case SPINEL_PROP_NEST_LEGACY_ULA_PREFIX:
+        ret = "SPINEL_PROP_NEST_LEGACY_ULA_PREFIX";
+        break;
+
+    case SPINEL_PROP_NEST_LEGACY_JOINED_NODE:
+        ret = "SPINEL_PROP_NEST_LEGACY_JOINED_NODE";
+        break;
+
     case SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT:
         ret = "SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -759,6 +759,17 @@ typedef enum
 
     SPINEL_PROP_NEST__BEGIN         = 15296,
     SPINEL_PROP_NEST_STREAM_MFG     = SPINEL_PROP_NEST__BEGIN + 0,
+
+    /// The legacy network ULA prefix (8 bytes)
+    /** Format: 'D' */
+    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX
+                                    = SPINEL_PROP_NEST__BEGIN + 1,
+
+    /// A (newly) joined legacy node (this is signaled from NCP)
+    /** Format: 'E' */
+    SPINEL_PROP_NEST_LEGACY_JOINED_NODE
+                                    = SPINEL_PROP_NEST__BEGIN + 2,
+
     SPINEL_PROP_NEST__END           = 15360,
 
     SPINEL_PROP_VENDOR__BEGIN       = 15360,


### PR DESCRIPTION
This PR adds the following 
- Support for passing the legacy prefix during "form" operation.
- Adds new legacy related spinel properties.
