### PR TITLE
StatCollector: Add scan result info to the logs

### DIFF
--- a/src/wpantund/NetworkInstance.h
+++ b/src/wpantund/NetworkInstance.h
@@ -105,6 +105,7 @@ struct NetworkInstance : public NetworkId {
 	uint8_t type;
 	uint8_t hwaddr[8];
 	uint16_t saddr;
+	uint8_t version;
 
 public:
 	NetworkInstance(
@@ -119,7 +120,8 @@ public:
 		joinable(_joinable),
 		rssi(-128),
 		type(0),
-		hwaddr()
+		hwaddr(),
+		version(0)
 	{
 	}
 	NetworkInstance(
@@ -134,7 +136,8 @@ public:
 		joinable(_joinable),
 		rssi(-128),
 		type(0),
-		hwaddr()
+		hwaddr(),
+		version(0)
 	{
 	}
 

--- a/src/wpantund/StatCollector.h
+++ b/src/wpantund/StatCollector.h
@@ -287,6 +287,7 @@ private:
 	void did_get_rip_entry_value_map(int status, const boost::any& value);
 	int  record_rip_entry(const ValueMap& rip_entry);
 	void property_changed(const std::string& key, const boost::any& value);
+	void did_rx_net_scan_beacon(const WPAN::NetworkInstance& network);
 
 private:
 	NCPControlInterface *mControlInterface;


### PR DESCRIPTION
This commit makes two changes:

- `StatCollector` registers to receive the NetScan results and prints
  the scan result info (network name, panid, xpaindi, etc.) to syslog.

- A `version` field is added to `NetworkInstance` struct.