### PR TITLE
Add child table and last status logs

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -662,6 +662,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 	if (key == SPINEL_PROP_LAST_STATUS) {
 		spinel_status_t status = SPINEL_STATUS_OK;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, "i", &status);
+		syslog(LOG_INFO,"[-NCP-]: Last status (%s, %d)", spinel_status_to_cstr(status), status);
 		if ((status >= SPINEL_STATUS_RESET__BEGIN) && (status <= SPINEL_STATUS_RESET__END)) {
 			syslog(LOG_NOTICE, "[-NCP-]: NCP was reset (%s, %d)", spinel_status_to_cstr(status), status);
 			process_event(EVENT_NCP_RESET, status);
@@ -1070,6 +1071,16 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			} else {
 				handle_normal_ipv6_from_ncp(frame_ptr, frame_len);
 			}
+		}
+	} else if (key == SPINEL_PROP_THREAD_CHILD_TABLE) {
+		SpinelNCPTaskGetChildTable::ChildTable child_table;
+		SpinelNCPTaskGetChildTable::ChildTable::iterator it;
+
+		SpinelNCPTaskGetChildTable::prase_child_table(value_data_ptr, value_data_len, child_table);
+
+		for (it = child_table.begin(); it != child_table.end(); it++)
+		{
+			syslog(LOG_INFO, "[-NCP-] Child: %s", it->get_as_string().c_str());
 		}
 	}
 

--- a/src/ncp-spinel/SpinelNCPTaskGetChildTable.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetChildTable.h
@@ -41,14 +41,6 @@ public:
 		kResultFormat_ValueMapArray,   // Returns the child table as an array of ValueMap dictionary.
 	};
 
-	SpinelNCPTaskGetChildTable(
-		SpinelNCPInstance* instance,
-		CallbackWithStatusArg1 cb,
-		ResultFormat result_format = kResultFormat_StringArray
-	);
-	virtual int vprocess_event(int event, va_list args);
-
-private:
 	enum
 	{
 		kThreadMode_RxOnWhenIdle        = (1 << 3),
@@ -75,8 +67,22 @@ private:
 		ValueMap get_as_valuemap(void) const;
 	};
 
+	typedef std::list<ChildInfoEntry> ChildTable;
+
+public:
+	SpinelNCPTaskGetChildTable(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		ResultFormat result_format = kResultFormat_StringArray
+	);
+	virtual int vprocess_event(int event, va_list args);
+
+	// Parses the spinel child table property and updates the child_table
+	static int prase_child_table(const uint8_t *data_in, spinel_size_t data_len, ChildTable& child_table);
+
+private:
 	ResultFormat mResultFormat;
-	std::list<ChildInfoEntry> mChildTable;
+	ChildTable mChildTable;
 };
 
 


### PR DESCRIPTION
This commit changes the `TaskGetChildTable` to expose some new methods (to parse/get the child table from the corresponding spinel message). It also adds logs
- when `LAST_STATUS` is received (the status)
- when `CHILD_TABLE` property changes is received (prints the entire
  child table in the syslogs).