### PR TITLE
wpanctl getprop --all infinite recursion

### DIFF
--- a/src/wpanctl/tool-cmd-getprop.c
+++ b/src/wpanctl/tool-cmd-getprop.c
@@ -54,6 +54,8 @@ int tool_cmd_getprop(int argc, char *argv[])
 
 	dbus_error_init(&error);
 
+	optind = 0;
+
 	while (1) {
 		static struct option long_options[] = {
 			{"help", no_argument, 0, 'h'},


### PR DESCRIPTION
Reset optind to 0 in tool_cmd_getprop. 

Without this zeroing, when getprop is used with the --all or -a options, it will end up in infinite recursion.  This is because the value of optind is persistent across function calls, and since getprop --all results in an optind of 2 and the recursive calls of getprop {property} will always have an argc of 2, optind == argc will be true, causing every recursive call to be treated like a new call to getprop --all.
