### PR TITLE
Add support to save and restore certain radio properties during initialization

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -167,6 +167,7 @@ SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 	mInboundHeader = 0;
 	mDefaultChannelMask = 0x07FFF800;
 	mIsPcapInProgress = false;
+	mSettings.clear();
 
 	if (!settings.empty()) {
 		int status;
@@ -544,12 +545,13 @@ SpinelNCPInstance::set_property(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPCCAThreshold)) {
 			int cca = any_to_int(value);
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_INT8_S), SPINEL_PROP_PHY_CCA_THRESHOLD, cca);
+
+			mSettings[kWPANTUNDProperty_NCPCCAThreshold] = SettingsEntry(command);
 
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
-				.add_command(
-					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_INT8_S), SPINEL_PROP_PHY_CCA_THRESHOLD, cca)
-				)
+				.add_command(command)
 				.finish()
 			);
 
@@ -689,6 +691,9 @@ SpinelNCPInstance::set_property(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionEnable)) {
 			bool isEnabled = any_to_bool(value);
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S), SPINEL_PROP_JAM_DETECT_ENABLE, isEnabled);
+
+			mSettings[kWPANTUNDProperty_JamDetectionEnable] = SettingsEntry(command, SPINEL_CAP_JAM_DETECT);
 
 			if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT))
 			{
@@ -696,15 +701,16 @@ SpinelNCPInstance::set_property(
 			} else {
 				start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 					.set_callback(cb)
-					.add_command(
-						SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S), SPINEL_PROP_JAM_DETECT_ENABLE, isEnabled)
-					)
+					.add_command(command)
 					.finish()
 				);
 			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionRssiThreshold)) {
 			int8_t rssiThreshold = static_cast<int8_t>(any_to_int(value));
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_INT8_S), SPINEL_PROP_JAM_DETECT_RSSI_THRESHOLD, rssiThreshold);
+
+			mSettings[kWPANTUNDProperty_JamDetectionRssiThreshold] = SettingsEntry(command, SPINEL_CAP_JAM_DETECT);
 
 			if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT))
 			{
@@ -712,15 +718,16 @@ SpinelNCPInstance::set_property(
 			} else {
 				start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 					.set_callback(cb)
-					.add_command(
-						SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_INT8_S), SPINEL_PROP_JAM_DETECT_RSSI_THRESHOLD, rssiThreshold)
-					)
+					.add_command(command)
 					.finish()
 				);
 			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionWindow)) {
 			uint8_t window = static_cast<uint8_t>(any_to_int(value));
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_JAM_DETECT_WINDOW, window);
+
+			mSettings[kWPANTUNDProperty_JamDetectionWindow] = SettingsEntry(command, SPINEL_CAP_JAM_DETECT);
 
 			if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT))
 			{
@@ -728,15 +735,16 @@ SpinelNCPInstance::set_property(
 			} else {
 				start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 					.set_callback(cb)
-					.add_command(
-						SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_JAM_DETECT_WINDOW, window)
-					)
+					.add_command(command)
 					.finish()
 				);
 			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionBusyPeriod)) {
 			uint8_t busyPeriod = static_cast<uint8_t>(any_to_int(value));
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_JAM_DETECT_BUSY, busyPeriod);
+
+			mSettings[kWPANTUNDProperty_JamDetectionBusyPeriod] = SettingsEntry(command, SPINEL_CAP_JAM_DETECT);
 
 			if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT))
 			{
@@ -744,13 +752,10 @@ SpinelNCPInstance::set_property(
 			} else {
 				start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 					.set_callback(cb)
-					.add_command(
-						SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_JAM_DETECT_BUSY, busyPeriod)
-					)
+					.add_command(command)
 					.finish()
 				);
 			}
-
 
 		} else {
 			NCPInstanceBase::set_property(key, value, cb);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -171,6 +171,33 @@ public:
 	virtual void process(void);
 
 private:
+	struct SettingsEntry
+	{
+	public:
+		SettingsEntry(const Data &command = Data(), unsigned int capability = 0) :
+			mSpinelCommand(command),
+			mCapability(capability)
+		{
+		}
+
+		Data mSpinelCommand;
+		unsigned int mCapability;
+	};
+
+	/* Map from property key to setting entry
+	 *
+	 * The map contains all parameters/properties that are retained and
+	 * restored when NCP gets initialized.
+	 *
+	 * `Setting entry` contains an optional capability value and an associated
+	 * spinel command.
+	 *
+	 * If the `capability` is present in the list of NCP capabilities , then
+	 * the associated spinel command is sent to NCP after initialization.
+	 */
+	typedef std::map<std::string, SettingsEntry> SettingsMap;
+
+private:
 	SpinelNCPControlInterface mControlInterface;
 
 	uint8_t mLastTID;
@@ -199,6 +226,8 @@ private:
 	std::set<unsigned int> mCapabilities;
 	uint32_t mDefaultChannelMask;
 
+	SettingsMap mSettings;
+	SettingsMap::iterator mSettingsIter;
 
 	DriverState mDriverState;
 


### PR DESCRIPTION
This commit adds support in `SpinelNcpInstance` to save and restore certain settings/properties. This is currently used to remember the jamming detection related parameters.

The settings are stored in a hash table which maps the property name (as `std::string`) to a `SettingsEntry` struct.  The `SettingsEntry` contains the spinel command to set the value of the property, along with an optional capability value. At the end of NCP initialization, if the `capability` value is given and it is present in the list of NCP capabilities, the associated spinel command is sent to NCP to set/restore the value of the the property.