### PR TITLE
Add support for new property "JamDetection:Debug:HistoryBitmap"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -49,28 +49,28 @@ WPANTUND_DEFINE_NCPINSTANCE_PLUGIN(spinel, SpinelNCPInstance);
 void
 SpinelNCPInstance::handle_ncp_log(const uint8_t* data_ptr, int data_len)
 {
-    static char linebuffer[NCP_DEBUG_LINE_LENGTH_MAX + 1];
-    static int linepos = 0;
-    while (data_len--) {
-        char nextchar = *data_ptr++;
+	static char linebuffer[NCP_DEBUG_LINE_LENGTH_MAX + 1];
+	static int linepos = 0;
+	while (data_len--) {
+		char nextchar = *data_ptr++;
 
-        if ((nextchar == '\t') || (nextchar >= 32)) {
-            linebuffer[linepos++] = nextchar;
-        }
+		if ((nextchar == '\t') || (nextchar >= 32)) {
+			linebuffer[linepos++] = nextchar;
+		}
 
-        if ( (linepos != 0)
-          && ( (nextchar == '\n')
-            || (nextchar == '\r')
-            || (linepos >= (sizeof(linebuffer) - 1))
-          )
-        )
-        {
-            // flush.
-            linebuffer[linepos] = 0;
-            syslog(LOG_WARNING, "NCP => %s\n", linebuffer);
-            linepos = 0;
-        }
-    }
+		if ( (linepos != 0)
+		  && ( (nextchar == '\n')
+			|| (nextchar == '\r')
+			|| (linepos >= (sizeof(linebuffer) - 1))
+		  )
+		)
+		{
+			// flush.
+			linebuffer[linepos] = 0;
+			syslog(LOG_WARNING, "NCP => %s\n", linebuffer);
+			linepos = 0;
+		}
+	}
 }
 
 void
@@ -271,6 +271,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 		properties.insert(kWPANTUNDProperty_JamDetectionRssiThreshold);
 		properties.insert(kWPANTUNDProperty_JamDetectionWindow);
 		properties.insert(kWPANTUNDProperty_JamDetectionBusyPeriod);
+		properties.insert(kWPANTUNDProperty_JamDetectionDebugHistoryBitmap);
 	}
 
 	return properties;
@@ -313,6 +314,30 @@ static void convert_rloc16_to_router_id(CallbackWithStatusArg1 cb, int status, c
 		router_id = rloc16 >> 10;
 	}
 	cb(status, router_id);
+}
+
+static int unpack_jam_detect_history_bitmap(const uint8_t *data_in, spinel_size_t data_len, boost::any& value)
+{
+	spinel_ssize_t len;
+	uint32_t lower, higher;
+	uint64_t val;
+	int ret = kWPANTUNDStatus_Failure;
+
+	len = spinel_datatype_unpack(
+		data_in,
+		data_len,
+		SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S,
+		&lower,
+		&higher
+	);
+
+	if (len > 0)
+	{
+		ret = kWPANTUNDStatus_Ok;
+		value = (static_cast<uint64_t>(higher) << 32) + static_cast<uint64_t>(lower);
+	}
+
+	return ret;
 }
 
 void
@@ -425,6 +450,20 @@ SpinelNCPInstance::get_property(
 			cb(kWPANTUNDStatus_FeatureNotSupported, boost::any(std::string("Jam Detection Feature Not Supported")));
 		} else {
 			SIMPLE_SPINEL_GET(SPINEL_PROP_JAM_DETECT_BUSY, SPINEL_DATATYPE_UINT8_S);
+		}
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionDebugHistoryBitmap)) {
+		if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT)) {
+			cb(kWPANTUNDStatus_FeatureNotSupported, boost::any(std::string("Jam Detection Feature Not Supported")));
+		} else {
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP)
+				)
+				.set_reply_unpacker(unpack_jam_detect_history_bitmap)
+				.finish()
+			);
 		}
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadChildTable)) {
@@ -1030,7 +1069,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_STREAM_DEBUG) {
-        handle_ncp_log(value_data_ptr, value_data_len);
+		handle_ncp_log(value_data_ptr, value_data_len);
 
 	} else if (key == SPINEL_PROP_NET_ROLE) {
 		uint8_t value;
@@ -1459,7 +1498,7 @@ SpinelNCPInstance::address_was_added(const struct in6_addr& addr, int prefix_len
 		SpinelNCPTaskSendCommand::Factory factory(this);
 		uint8_t flags = SPINEL_NET_FLAG_SLAAC
 					  | SPINEL_NET_FLAG_ON_MESH
-		              | SPINEL_NET_FLAG_PREFERRED;
+					  | SPINEL_NET_FLAG_PREFERRED;
 		std::list<Data> commands;
 
 		NCPInstanceBase::address_was_added(addr, prefix_len);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -100,6 +100,7 @@
 #define kWPANTUNDProperty_JamDetectionRssiThreshold            "JamDetection:RssiThreshold"
 #define kWPANTUNDProperty_JamDetectionWindow                   "JamDetection:Window"
 #define kWPANTUNDProperty_JamDetectionBusyPeriod               "JamDetection:BusyPeriod"
+#define kWPANTUNDProperty_JamDetectionDebugHistoryBitmap       "JamDetection:Debug:HistoryBitmap"
 
 #define kWPANTUNDProperty_NestLabs_NetworkAllowingJoin         "com.nestlabs.internal:Network:AllowingJoin"
 #define kWPANTUNDProperty_NestLabs_NetworkPassthruPort         "com.nestlabs.internal:Network:PassthruPort"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1203,6 +1203,11 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_JAM_DETECT_BUSY";
         break;
 
+    case SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP:
+        ret = "SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP";
+        break;
+
+
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -403,6 +403,23 @@ typedef enum
      */
     SPINEL_PROP_JAM_DETECT_BUSY         = SPINEL_PROP_PHY_EXT__BEGIN + 4,
 
+    /// Jamming detection history bitmap (for debugging)
+    /** Format: `LL` (read-only)
+     *
+     * This value provides information about current state of jamming detection
+     * module for monitoring/debugging purpose. It returns a 64-bit value where
+     * each bit corresponds to one second interval starting with bit 0 for the
+     * most recent interval and bit 63 for the oldest intervals (63 sec earlier).
+     * The bit is set to 1 if the jamming detection module observed/detected
+     * high signal level during the corresponding one second interval.
+     *
+     * The value is read-only and is encoded as two uint32 values in
+     * little-endian format (first uint32 gives the lower bits corresponding to
+     * more recent history).
+     */
+    SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 5,
+
     SPINEL_PROP_PHY_EXT__END            = 0x1300,
 
     SPINEL_PROP_MAC__BEGIN             = 0x30,


### PR DESCRIPTION
This commit adds a new wpan property to get the jam detection history bitmap. This value provides information about current state of jamming detection module for monitoring/debugging purpose. It returns a 64-bit value where each bit corresponds to one second interval starting with bit 0 for the most recent interval and bit 63 for the oldest intervals (63 sec earlier). The bit is set to 1 if the jamming detection module observed/detected high signal level during the corresponding one second interval.

(This commit also fixes some of the indention in `SpinelNCPInstance.cpp` to use tabs everywhere). 

The counter-part of this change in OpenThread: https://github.com/openthread/openthread/pull/1033
