### PR TITLE
NCPInstanceBase-NetInterface: Add mesh-local address (if non-zero) in `set_online()`

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -967,7 +967,9 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		 && buffer_is_nonzero(addr->s6_addr, 8)
 		 && (0 != memcmp(mNCPMeshLocalAddress.s6_addr, addr->s6_addr, sizeof(mNCPMeshLocalAddress)))
 		) {
-			remove_address(mNCPMeshLocalAddress);
+			if (buffer_is_nonzero(mNCPMeshLocalAddress.s6_addr, sizeof(mNCPMeshLocalAddress))) {
+				remove_address(mNCPMeshLocalAddress);
+			}
 			memcpy(mNCPMeshLocalAddress.s6_addr, addr->s6_addr, sizeof(mNCPMeshLocalAddress));
 			signal_property_changed(kWPANTUNDProperty_IPv6MeshLocalAddress, in6_addr_to_string(*addr));
 			add_address(mNCPMeshLocalAddress);
@@ -980,7 +982,9 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		 && buffer_is_nonzero(addr->s6_addr, 8)
 		 && (0 != memcmp(mNCPV6Prefix, addr, sizeof(mNCPV6Prefix)))
 		) {
-			remove_address(mNCPMeshLocalAddress);
+			if (buffer_is_nonzero(mNCPMeshLocalAddress.s6_addr, sizeof(mNCPMeshLocalAddress))) {
+				remove_address(mNCPMeshLocalAddress);
+			}
 			memcpy(mNCPV6Prefix, addr, sizeof(mNCPV6Prefix));
 			struct in6_addr prefix_addr (mNCPMeshLocalAddress);
 			// Zero out the lower 64 bits.

--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -48,6 +48,10 @@ NCPInstanceBase::set_online(bool x)
 		add_address(mNCPLinkLocalAddress);
 	}
 
+	if (buffer_is_nonzero(mNCPMeshLocalAddress.s6_addr, sizeof(mNCPMeshLocalAddress)))	{
+		add_address(mNCPMeshLocalAddress);
+	}
+
 	if ((ret == 0) && static_cast<bool>(mLegacyInterface)) {
 		if (x && mNodeTypeSupportsLegacy) {
 			ret = mLegacyInterface->set_online(true);


### PR DESCRIPTION
This commit makes the following changes:

- In `NCPInstanceBase::set_online()` new code is added to add mesh-local address (in non-zero) when the interface is brought online. This helps address an issue where the mesh-local address was not added after a reset.

- In `SpinelNCPInstance::handle_ncp_spinel_value_is()` when processing the receiving of new mesh-local address, the codechecks that the old value of `mNCPMeshLocalAddress` to ensure it is non-zero before trying to remove it (this helps remove an unnecessary `require` failure message from the logs).