### PR TITLE
Add supported channels set and use it during `form` if none is given

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -400,7 +400,7 @@ SpinelNCPControlInterface::netscan_start(
     const ValueMap& options,
     CallbackWithStatus cb
 ) {
-	ChannelMask channel_mask(mNCPInstance->mDefaultChannelMask);
+	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
 
 	if (options.count(kWPANTUNDProperty_NCPChannelMask)) {
 		channel_mask = any_to_int(options.at(kWPANTUNDProperty_NCPChannelMask));
@@ -426,7 +426,7 @@ SpinelNCPControlInterface::energyscan_start(
     const ValueMap& options,
     CallbackWithStatus cb
 ) {
-	ChannelMask channel_mask(mNCPInstance->mDefaultChannelMask);
+	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
 
 	if (options.count(kWPANTUNDProperty_NCPChannelMask)) {
 		channel_mask = any_to_int(options.at(kWPANTUNDProperty_NCPChannelMask));

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -142,6 +142,8 @@ protected:
 	virtual void address_was_added(const struct in6_addr& addr, int prefix_len);
 	virtual void address_was_removed(const struct in6_addr& addr, int prefix_len);
 
+	uint32_t get_default_channel_mask(void);
+
 private:
 
 	void refresh_on_mesh_prefix(struct in6_addr *addr, uint8_t prefix_len, bool stable, uint8_t flags);

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -21,6 +21,7 @@
 #define __wpantund__NCPInstanceBase__
 
 #include "NCPInstance.h"
+#include <set>
 #include <map>
 #include <string>
 #include "FirmwareUpgrade.h"
@@ -164,7 +165,7 @@ public:
 
 public:
 	// ========================================================================
-	// MARK: Firware Upgrade
+	// MARK: Firmware Upgrade
 
 	virtual bool is_firmware_upgrade_required(const std::string& version);
 
@@ -273,6 +274,8 @@ protected:
 	struct in6_addr mNCPLinkLocalAddress;
 
 	WPAN::NetworkInstance mCurrentNetworkInstance;
+
+	std::set<unsigned int> mSupprotedChannels;
 
 	NodeType mNodeType;
 


### PR DESCRIPTION
This commit contains the following changes:

- It parses the `SPINEL_PROP_PHY_CHAN_SUPPORTED` message and stores a set of supported channels.

- It adds new methods to get default channel mask.

- It modifies the `FormTask` to use the default channel mask if none   is given and ensures the selected channel is supported by NCP.