### PR TITLE
Recovery mechanism for back-to-back NOMEM status from NCP

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -247,6 +247,15 @@ private:
 	// Task management
 	std::list<boost::shared_ptr<SpinelNCPTask> > mTaskQueue;
 
+	enum
+	{
+		kMaxTimeBetweenNoMemStatus = 60000, // (in ms) time between NOMEM status to consider it back-to-back.
+		kMaxNonMemCountToReset = 15,        // Number of back-to-back NOMEM status to reset
+	};
+
+	cms_t mLastTimeNoMemStatus;
+	uint16_t mNoMemStatusCounter;
+
 }; // class SpinelNCPInstance
 
 extern class SpinelNCPInstance* gNCPInstance;


### PR DESCRIPTION
This commit adds a recovery mechanism for the case where we get back-to-back NOMEM status from NCP so that after some number (set to 15) of NOMEM status the NCP is reset.

This should help address possible memory leak or issues where radio may be getting stuck.