### PR TITLE
Modify the "Tickle" logic

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -166,7 +166,7 @@ SpinelNCPInstance::vprocess_associated(int event, va_list args)
 	// very similar, it is not the same! DO NOT REMOVE!
 	EH_WAIT_UNTIL_WITH_TIMEOUT(
 		NCP_TICKLE_TIMEOUT,
-		should_exit || (IS_EVENT_FROM_NCP(event))
+		should_exit
 	);
 
 	if (eh_did_timeout) {


### PR DESCRIPTION
This commit changes the "Tickle" logic, so that it happens at certain intervals independent of us getting events from the NCP. This can help with cases where the Tx path may have an issue.