### PR TITLE
Erase saved network info before `form`, `join` and after `leave`

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -379,6 +379,10 @@ SpinelNCPInstance::driver_to_ncp_pump()
 				syslog(LOG_INFO, "[->NCP] CMD_NOOP tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
 			} else if (mOutboundBuffer[1] == SPINEL_CMD_RESET) {
 				syslog(LOG_INFO, "[->NCP] CMD_RESET tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
+			} else if (mOutboundBuffer[1] == SPINEL_CMD_NET_CLEAR) {
+				syslog(LOG_INFO, "[->NCP] CMD_NET_CLEAR tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
+			} else {
+				syslog(LOG_INFO, "[->NCP] Spinel command 0x%02X tid:%d", mOutboundBuffer[1], SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
 			}
 		} else {
 			// There is an IPv6 packet waiting on one of the tunnel interfaces.

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -149,6 +149,12 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 	mLastState = mInstance->get_ncp_state();
 	mInstance->change_ncp_state(ASSOCIATING);
 
+	// Clear any previously saved network settings
+	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	require_noerr(ret, on_error);
+
 	// TODO: We should do a scan to make sure we pick a good channel
 	//       and don't have a panid collision.
 

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -51,7 +51,6 @@ nl::wpantund::SpinelNCPTaskJoin::finish(int status, const boost::any& value)
 	}
 }
 
-
 int
 nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 {
@@ -93,6 +92,13 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 	// will only be received by that task once it is that task's turn
 	// to execute.
 	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
+
+	// Clear any previously saved network settings
+	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	require_noerr(ret, on_error);
+
 
 	mLastState = mInstance->get_ncp_state();
 	mInstance->change_ncp_state(ASSOCIATING);

--- a/src/ncp-spinel/SpinelNCPTaskLeave.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskLeave.cpp
@@ -90,13 +90,11 @@ nl::wpantund::SpinelNCPTaskLeave::vprocess_event(int event, va_list args)
 	ret = mNextCommandRet;
 	require_noerr(ret, on_error);
 
-
-	if (mInstance->mCapabilities.count(SPINEL_CAP_NET_SAVE)) {
-		mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
-		EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
-		ret = mNextCommandRet;
-		require_noerr(ret, on_error);
-	}
+	// Clear any saved network settings.
+	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+	ret = mNextCommandRet;
+	require_noerr(ret, on_error);
 
 	ret = kWPANTUNDStatus_Ok;
 


### PR DESCRIPTION
This commit changes the code to issue a spinel `CMD_NET_CLEAR`command before "form", "join" or after "leave" operations (in their corresponding `SpinelNCTTask`s) . This ensures that any saved network settings are erased.

https://github.com/openthread/openthread/pull/1123 is the counterpart of this change in OpenThread 