### PR TITLE
Fix loop in SpinelPackData

### DIFF
--- a/src/ncp-spinel/SpinelNCPTask.cpp
+++ b/src/ncp-spinel/SpinelNCPTask.cpp
@@ -111,7 +111,6 @@ nl::wpantund::SpinelPackData(const char* pack_format, ...)
 
 		if (packed_size < 0) {
 			ret.clear();
-			break;
 		} else if (packed_size > ret.size()) {
 			ret.resize(packed_size);
 			continue;

--- a/src/ncp-spinel/SpinelNCPTask.cpp
+++ b/src/ncp-spinel/SpinelNCPTask.cpp
@@ -118,7 +118,8 @@ nl::wpantund::SpinelPackData(const char* pack_format, ...)
 		} else {
 			ret.resize(packed_size);
 		}
-	} while(false);
+		break;
+	} while(true);
 
 	va_end(args);
 	return ret;


### PR DESCRIPTION
The do-while loop in SpinelPackData would never run for a second time due to the fact it was a while(false), instead of a while(true) 