### PR TITLE
Change to `ISOLATED` state upon receiving `NET_ROLE_DETACHED` event from NCP

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1086,6 +1086,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 	} else if (key == SPINEL_PROP_NET_ROLE) {
 		uint8_t value;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_UINT8_S, &value);
+		syslog(LOG_INFO,"[-NCP-]: Net Role \"%s\" (%d)", spinel_net_role_to_cstr(value), value);
 
 		if ( ncp_state_is_joining(get_ncp_state())
 		  && (value != SPINEL_NET_ROLE_DETACHED)
@@ -1109,6 +1110,11 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			if (mNodeType != LEADER) {
 				mNodeType = LEADER;
 				signal_property_changed(kWPANTUNDProperty_NetworkNodeType, node_type_to_string(mNodeType));
+			}
+
+		} else if (value == SPINEL_NET_ROLE_DETACHED) {
+			if (ncp_state_is_associated(get_ncp_state())) {
+				change_ncp_state(ISOLATED);
 			}
 		}
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1221,6 +1221,35 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
     return ret;
 }
 
+const char *spinel_net_role_to_cstr(uint8_t net_role)
+{
+    const char *ret = "NET_ROLE_UNKNONW";
+
+    switch (net_role)
+    {
+    case SPINEL_NET_ROLE_DETACHED:
+        ret = "NET_ROLE_DETACHED";
+        break;
+
+    case SPINEL_NET_ROLE_CHILD:
+        ret = "NET_ROLE_CHILD";
+        break;
+
+    case SPINEL_NET_ROLE_ROUTER:
+        ret = "NET_ROLE_ROUTER";
+        break;
+
+    case SPINEL_NET_ROLE_LEADER:
+        ret = "NET_ROLE_LEADER";
+        break;
+
+    default:
+        break;
+    }
+
+    return ret;
+}
+
 const char *spinel_status_to_cstr(spinel_status_t status)
 {
     const char *ret = "UNKNOWN";

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1000,6 +1000,8 @@ SPINEL_API_EXTERN const char *spinel_next_packed_datatype(const char *pack_forma
 
 SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key);
 
+SPINEL_API_EXTERN const char *spinel_net_role_to_cstr(uint8_t net_role);
+
 SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This commits contains the following changes:L

- A new check is added in `handle_ncp_spinel_value_is()` for
  handling `NET_ROLE` changes to `DETACHED`. When a `DETACHED`
  role change is received, and the state was previously in
  associated state, the NCP state is updated to `ISOLATED`.
  This addresses the case  where an end-device looses its parent
  after a successful join.

- A new `LOG_INFO` level message is added to print the value of
  `NET_ROLE` upon receiving it from NCP.

- It adds a new function in `spinel` to convert net_role values
  to C strings.