### PR TITLE
Add new properties to get leader network data

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -242,7 +242,10 @@ SpinelNCPInstance::get_supported_property_keys()const
 		properties.insert(kWPANTUNDProperty_ThreadLeaderLocalWeight);
 		properties.insert(kWPANTUNDProperty_ThreadNetworkData);
 		properties.insert(kWPANTUNDProperty_ThreadNetworkDataVersion);
+		properties.insert(kWPANTUNDProperty_ThreadStableNetworkData);
 		properties.insert(kWPANTUNDProperty_ThreadStableNetworkDataVersion);
+		properties.insert(kWPANTUNDProperty_ThreadLeaderNetworkData);
+		properties.insert(kWPANTUNDProperty_ThreadStableLeaderNetworkData);
 		properties.insert(kWPANTUNDProperty_ThreadChildTable);
 		properties.insert(kWPANTUNDProperty_ThreadNeighborTable);
 	}
@@ -431,6 +434,12 @@ SpinelNCPInstance::get_property(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadStableNetworkData)) {
 		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_STABLE_NETWORK_DATA, SPINEL_DATATYPE_DATA_S);
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadLeaderNetworkData)) {
+		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_LEADER_NETWORK_DATA, SPINEL_DATATYPE_DATA_S);
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadStableLeaderNetworkData)) {
+		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA, SPINEL_DATATYPE_DATA_S);
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadStableNetworkDataVersion)) {
 		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION, SPINEL_DATATYPE_UINT8_S);
 
@@ -510,7 +519,7 @@ SpinelNCPInstance::get_property(
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
-		
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadNeighborTable)) {
 		start_new_task(boost::shared_ptr<SpinelNCPTask>(
 			new SpinelNCPTaskGetNetworkTopology(
@@ -530,7 +539,7 @@ SpinelNCPInstance::get_property(
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
-		
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadMsgBufferCounters)) {
 		start_new_task(boost::shared_ptr<SpinelNCPTask>(
 			new SpinelNCPTaskGetMsgBufferCounters(
@@ -1370,6 +1379,10 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		{
 			syslog(LOG_INFO, "[-NCP-] Child: %s", it->get_as_string().c_str());
 		}
+	} else if (key == SPINEL_PROP_THREAD_LEADER_NETWORK_DATA) {
+		char net_data_cstr_buf[540];
+		encode_data_into_string(value_data_ptr, value_data_len, net_data_cstr_buf, sizeof(net_data_cstr_buf), 0);
+		syslog(LOG_INFO, "[-NCP-] Leader network data: %s", net_data_cstr_buf);
 	}
 
 bail:

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -82,6 +82,8 @@
 #define kWPANTUNDProperty_ThreadLeaderRouterID           "Thread:Leader:RouterID"
 #define kWPANTUNDProperty_ThreadLeaderWeight             "Thread:Leader:Weight"
 #define kWPANTUNDProperty_ThreadLeaderLocalWeight        "Thread:Leader:LocalWeight"
+#define kWPANTUNDProperty_ThreadLeaderNetworkData        "Thread:Leader:NetworkData"
+#define kWPANTUNDProperty_ThreadStableLeaderNetworkData  "Thread:Leader:StableNetworkData"
 #define kWPANTUNDProperty_ThreadNetworkData              "Thread:NetworkData"
 #define kWPANTUNDProperty_ThreadChildTable               "Thread:ChildTable"
 #define kWPANTUNDProperty_ThreadChildTableAsValMap       "Thread:ChildTable:AsValMap"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1119,6 +1119,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_THREAD_STABLE_NETWORK_DATA";
         break;
 
+    case SPINEL_PROP_THREAD_LEADER_NETWORK_DATA:
+        ret = "SPINEL_PROP_THREAD_LEADER_NETWORK_DATA";
+        break;
+
+    case SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA:
+        ret = "SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA";
+        break;
+
     case SPINEL_PROP_THREAD_ON_MESH_NETS:
         ret = "SPINEL_PROP_THREAD_ON_MESH_NETS";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -762,6 +762,18 @@ typedef enum
      */
     SPINEL_PROP_THREAD_CHILD_COUNT_MAX = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
 
+    /// Leader network data
+    /** Format: `D` - Read only
+     */
+    SPINEL_PROP_THREAD_LEADER_NETWORK_DATA
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
+
+    /// Stable leader network data
+    /** Format: `D` - Read only
+     */
+    SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA
+                                       = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
+
     SPINEL_PROP_THREAD_EXT__END        = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN          = 0x60,


### PR DESCRIPTION
- Adds two new properties to wpantund "Thread:LeaderNetworkData" and
  "Thread:StableLeaderNetworkData" to get the full/stable leader
  network data from the NCP.

- Adds corresponding spinel properties `THREAD_LEADER_NETWORK_DATA`
  and `THREAD_STABLE_LEADER_NETWORK_DATA`.

- In `handle_ncp_spinel_value_is()` we now print the leader network
  data in the logs whenever we get an event from NCP notifying us of
  a change in network data.