### PR TITLE
Check for time out error when adding address/on-mesh-prefix

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -510,7 +510,7 @@ SpinelNCPInstance::get_property(
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
-		
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadNeighborTable)) {
 		start_new_task(boost::shared_ptr<SpinelNCPTask>(
 			new SpinelNCPTaskGetNetworkTopology(
@@ -530,7 +530,7 @@ SpinelNCPInstance::get_property(
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
-		
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadMsgBufferCounters)) {
 		start_new_task(boost::shared_ptr<SpinelNCPTask>(
 			new SpinelNCPTaskGetMsgBufferCounters(
@@ -1589,11 +1589,14 @@ SpinelNCPInstance::address_was_added(const struct in6_addr& addr, int prefix_len
 		uint8_t flags = SPINEL_NET_FLAG_SLAAC
 					  | SPINEL_NET_FLAG_ON_MESH
 					  | SPINEL_NET_FLAG_PREFERRED;
-		std::list<Data> commands;
+		CallbackWithStatus callback;
 
 		NCPInstanceBase::address_was_added(addr, prefix_len);
 
 		factory.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
+
+		callback = boost::bind(&SpinelNCPInstance::check_operation_status, this, "address_was_added()", _1);
+		factory.set_callback(callback);
 
 		factory.add_command(
 			SpinelPackData(
@@ -1655,6 +1658,16 @@ SpinelNCPInstance::address_was_removed(const struct in6_addr& addr, int prefix_l
 	}
 
 	NCPInstanceBase::address_was_removed(addr, prefix_len);
+}
+
+void
+SpinelNCPInstance::check_operation_status(std::string operation, int status)
+{
+	if (status == kWPANTUNDStatus_Timeout)
+	{
+		syslog(LOG_ERR, "Timed out while performing \"%s\" - Resetting NCP.", operation.c_str());
+		ncp_is_misbehaving();
+	}
 }
 
 bool

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -142,6 +142,8 @@ protected:
 	virtual void address_was_added(const struct in6_addr& addr, int prefix_len);
 	virtual void address_was_removed(const struct in6_addr& addr, int prefix_len);
 
+	void check_operation_status(std::string operation, int status);
+
 	uint32_t get_default_channel_mask(void);
 
 private:

--- a/src/ncp-spinel/SpinelNCPTaskSendCommand.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskSendCommand.cpp
@@ -355,6 +355,11 @@ on_error:
 
 		EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
 
+		if (mNextCommandRet != kWPANTUNDStatus_Ok)
+		{
+			mRetVal = mNextCommandRet;
+		}
+
 		check_noerr(mNextCommandRet);
 	}
 


### PR DESCRIPTION
This commit adds a callback in `address_was_added()` when issuing
the set the spinel commands to check for timeout error of the whole
operation.