### PR TITLE
`TaskLeave`: Issue a "reset" at the end of "leave"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -120,7 +120,6 @@ do_deep_sleep_tickle:
 			timeout_error
 		);
 
-		mResetIsExpected = false;
 		continue;
 
 timeout_error:

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -124,6 +124,7 @@ nl::wpantund::spinel_status_to_wpantund_status(int spinel_status)
 	case SPINEL_STATUS_INVALID_STATE:
 		ret = kWPANTUNDStatus_InvalidForCurrentState;
 		break;
+
 	default:
 		ret = WPANTUND_NCPERROR_TO_STATUS(spinel_status);
 		break;
@@ -960,10 +961,15 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 				default:
 					break;
 				}
-				reinitialize_ncp();
 				reset_tasks(wstatus);
 			}
+
+			if (mDriverState == NORMAL_OPERATION) {
+				reinitialize_ncp();
+			}
+			mResetIsExpected = false;
 			return;
+
 		} else if (status == SPINEL_STATUS_NOMEM) {
 			cms_t now = time_ms();
 			if (now - mLastTimeNoMemStatus > kMaxTimeBetweenNoMemStatus) {

--- a/src/ncp-spinel/SpinelNCPTask.cpp
+++ b/src/ncp-spinel/SpinelNCPTask.cpp
@@ -79,12 +79,12 @@ SpinelNCPTask::vprocess_send_command(int event, va_list args)
 			  ),
 			on_error
 		);
-		mInstance->mResetIsExpected = false;
+		mNextCommandRet = kWPANTUNDStatus_Ok;
+
 	} else {
 		CONTROL_REQUIRE_COMMAND_RESPONSE_WITHIN(mNextCommandTimeout, on_error);
+		mNextCommandRet = peek_ncp_callback_status(event, args);
 	}
-
-	mNextCommandRet = peek_ncp_callback_status(event, args);
 
 	if (mNextCommandRet) {
 		mNextCommandRet = spinel_status_to_wpantund_status(mNextCommandRet);


### PR DESCRIPTION
This ensures that all the volatile memory on the NCP is wiped after
a network "leave" command.