### PR TITLE
Correct path of dbus plist

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ as:
     brew install ./etc/wpantund.rb
 
     # Start the D-Bus daemon
-    sudo cp "$(brew --repository)"/Cellar/d-bus/*/org.freedesktop.dbus-session.plist /Library/LaunchDaemons/
+    sudo cp "$(brew --repository)"/Cellar/dbus/*/org.freedesktop.dbus-session.plist /Library/LaunchDaemons/
     sudo launchctl load -w /Library/LaunchDaemons/org.freedesktop.dbus-session.plist
 
 (the last two commands are for setting D-Bus up to launch properly at


### PR DESCRIPTION
I did according to the installation guide, finding that the d-bus path is incorrect.