### PR TITLE
Sync OpenThread files to latest versions and update plugin to match

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -517,14 +517,14 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 					syslog(LOG_WARNING,
 						"Spinel command for restoring property \"%s\" does not fit in outbound buffer (require %d bytes but only %u bytes available)",
 						mSettingsIter->first.c_str(),
-						mSettingsIter->second.mSpinelCommand.size(),
-						sizeof(GetInstance(this)->mOutboundBuffer)
+						(int)mSettingsIter->second.mSpinelCommand.size(),
+						(unsigned int)sizeof(GetInstance(this)->mOutboundBuffer)
 					);
 
 					continue;
 				}
 
-				GetInstance(this)->mOutboundBufferLen = mSettingsIter->second.mSpinelCommand.size();
+				GetInstance(this)->mOutboundBufferLen = (spinel_ssize_t)mSettingsIter->second.mSpinelCommand.size();
 				memcpy(GetInstance(this)->mOutboundBuffer, mSettingsIter->second.mSpinelCommand.data(), mSettingsIter->second.mSpinelCommand.size());
 
 				CONTROL_REQUIRE_OUTBOUND_BUFFER_FLUSHED_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -353,7 +353,6 @@ static int unpack_jam_detect_history_bitmap(const uint8_t *data_in, spinel_size_
 {
 	spinel_ssize_t len;
 	uint32_t lower, higher;
-	uint64_t val;
 	int ret = kWPANTUNDStatus_Failure;
 
 	len = spinel_datatype_unpack(
@@ -1278,7 +1277,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			len = spinel_datatype_unpack(
 				value_data_ptr,
 				value_data_len,
-				"T(6CbC).",
+				"t(6CbC)",
 				&addr,
 				&prefix_len,
 				&stable,
@@ -1348,7 +1347,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			ret = spinel_datatype_unpack(
 				value_data_ptr,
 				value_data_len,
-				SPINEL_DATATYPE_DATA_S SPINEL_DATATYPE_DATA_S,
+				SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_S,
 				&frame_ptr,
 				&frame_len,
 				&meta_ptr,

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -169,6 +169,7 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 			// Make sure the channel is the supported channel set.
 			if (mInstance->mSupprotedChannels.find(channel) == mInstance->mSupprotedChannels.end()) {
 				syslog(LOG_ERR, "Channel %d is not supported by NCP. Supported channels mask is %08x",
+					channel,
 					mInstance->get_default_channel_mask()
 				);
 				ret = kWPANTUNDStatus_InvalidArgument;

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
@@ -62,7 +62,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::prase_child_table(const uint8_t *
 		len = spinel_datatype_unpack(
 			data_in,
 			data_len,
-			"T("
+			"t("
 				SPINEL_DATATYPE_EUI64_S         // EUI64 Address
 				SPINEL_DATATYPE_UINT16_S        // Rloc16
 				SPINEL_DATATYPE_UINT32_S        // Timeout
@@ -127,7 +127,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::prase_neighbor_table(const uint8_
 		len = spinel_datatype_unpack(
 			data_in,
 			data_len,
-			"T("
+			"t("
 				SPINEL_DATATYPE_EUI64_S         // EUI64 Address
 				SPINEL_DATATYPE_UINT16_S        // Rloc16
 				SPINEL_DATATYPE_UINT32_S        // Age

--- a/src/ncp-spinel/SpinelNCPTaskScan.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskScan.cpp
@@ -156,7 +156,7 @@ nl::wpantund::SpinelNCPTaskScan::vprocess_event(int event, va_list args)
 			spinel_datatype_unpack(
 				data_ptr,
 				data_len,
-				"CcT(ESSC.)T(iCUD.).",
+				"Cct(ESSC)t(iCUd)",
 				&chan,
 				&rssi,
 

--- a/third_party/openthread/README.google
+++ b/third_party/openthread/README.google
@@ -1,5 +1,5 @@
-URL: https://github.com/openthread/openthread/tree/b1c19ed091b3faec71d4382a8edbec20b25086d9
-Version: b1c19ed091b3faec71d4382a8edbec20b25086d9
+URL: https://github.com/openthread/openthread/tree/5298a515c374ec31518ed176d1a9dd6033370c32
+Version: 5298a515c374ec31518ed176d1a9dd6033370c32
 License: BSD-3
 License File: LICENSE
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -385,6 +385,9 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             unsigned int *arg_ptr = va_arg(args->obj, unsigned int *);
             spinel_ssize_t pui_len = spinel_packed_uint_decode(data_ptr, data_len, arg_ptr);
 
+            // Range check
+            require_action(NULL == arg_ptr || (*arg_ptr < SPINEL_MAX_UINT_PACKED), bail, {ret = -1; errno = ERANGE;});
+
             require(pui_len > 0, bail);
 
             require(pui_len <= (spinel_ssize_t)data_len, bail);
@@ -414,6 +417,7 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
         }
 
         case SPINEL_DATATYPE_DATA_C:
+        case SPINEL_DATATYPE_DATA_WLEN_C:
         {
             spinel_ssize_t pui_len = 0;
             uint16_t block_len = 0;
@@ -422,10 +426,10 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             unsigned int *block_len_ptr = va_arg(args->obj, unsigned int *);
             char nextformat = *spinel_next_packed_datatype(pack_format);
 
-            if ((nextformat != 0) && (nextformat != ')'))
-            {
+            if ( (pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C)
+              || ( (nextformat != 0) && (nextformat != ')') )
+            ) {
                 pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
-                //pui_len = spinel_packed_uint_decode(data_ptr, data_len, &block_len);
                 block_ptr += pui_len;
 
                 require(pui_len > 0, bail);
@@ -456,6 +460,8 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             break;
         }
 
+
+        case 'T':
         case SPINEL_DATATYPE_STRUCT_C:
         {
             spinel_ssize_t pui_len = 0;
@@ -464,8 +470,9 @@ spinel_datatype_vunpack_(const uint8_t *data_ptr, spinel_size_t data_len, const 
             const uint8_t *block_ptr = data_ptr;
             char nextformat = *spinel_next_packed_datatype(pack_format);
 
-            if ((nextformat != 0) && (nextformat != ')'))
-            {
+            if ( (pack_format[0] == SPINEL_DATATYPE_STRUCT_C)
+              || ( (nextformat != 0) && (nextformat != ')') )
+            ) {
                 pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
                 block_ptr += pui_len;
 
@@ -703,7 +710,12 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
         case SPINEL_DATATYPE_UINT_PACKED_C:
         {
             uint32_t arg = va_arg(args->obj, uint32_t);
-            spinel_ssize_t encoded_size = spinel_packed_uint_encode(data_ptr, data_len_max, arg);
+            spinel_ssize_t encoded_size;
+
+            // Range Check
+            require_action(arg < SPINEL_MAX_UINT_PACKED, bail, {ret = -1; errno = EINVAL;});
+
+            encoded_size = spinel_packed_uint_encode(data_ptr, data_len_max, arg);
             ret += encoded_size;
 
             if ((spinel_ssize_t)data_len_max >= encoded_size)
@@ -751,6 +763,7 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             break;
         }
 
+        case SPINEL_DATATYPE_DATA_WLEN_C:
         case SPINEL_DATATYPE_DATA_C:
         {
             const uint8_t *arg = va_arg(args->obj, const uint8_t *);
@@ -758,8 +771,9 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             spinel_ssize_t size_len = 0;
             char nextformat = *spinel_next_packed_datatype(pack_format);
 
-            if (nextformat != 0 && nextformat != ')')
-            {
+            if ( (pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C)
+              || ( (nextformat != 0) && (nextformat != ')') )
+            ) {
                 size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, data_size_arg);
                 require_action(size_len > 0, bail, {ret = -1; errno = EINVAL;});
             }
@@ -784,6 +798,7 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             break;
         }
 
+        case 'T':
         case SPINEL_DATATYPE_STRUCT_C:
         {
             spinel_ssize_t struct_len = 0;
@@ -800,8 +815,9 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
                 va_end(subargs.obj);
             }
 
-            if (nextformat != 0 && nextformat != ')')
-            {
+            if ( (pack_format[0] == SPINEL_DATATYPE_STRUCT_C)
+              || ( (nextformat != 0) && (nextformat != ')') )
+            ) {
                 size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, struct_len);
                 require_action(size_len > 0, bail, {ret = -1; errno = EINVAL;});
             }
@@ -975,6 +991,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_PHY_RSSI";
         break;
 
+    case SPINEL_PROP_MAC_EXTENDED_ADDR:
+        ret = "PROP_MAC_EXTENDED_ADDR";
+        break;
+
     case SPINEL_PROP_MAC_RAW_STREAM_ENABLED:
         ret = "PROP_MAC_RAW_STREAM_ENABLED";
         break;
@@ -1108,27 +1128,27 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         break;
 
     case SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD:
-        ret = "SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD";
+        ret = "PROP_IPV6_ICMP_PING_OFFLOAD";
         break;
 
     case SPINEL_PROP_THREAD_PARENT:
-        ret = "SPINEL_PROP_THREAD_PARENT";
+        ret = "PROP_THREAD_PARENT";
         break;
 
     case SPINEL_PROP_THREAD_STABLE_NETWORK_DATA:
-        ret = "SPINEL_PROP_THREAD_STABLE_NETWORK_DATA";
+        ret = "PROP_THREAD_STABLE_NETWORK_DATA";
         break;
 
     case SPINEL_PROP_THREAD_LEADER_NETWORK_DATA:
-        ret = "SPINEL_PROP_THREAD_LEADER_NETWORK_DATA";
+        ret = "PROP_THREAD_LEADER_NETWORK_DATA";
         break;
 
     case SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA:
-        ret = "SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA";
+        ret = "PROP_THREAD_STABLE_LEADER_NETWORK_DATA";
         break;
 
     case SPINEL_PROP_THREAD_ON_MESH_NETS:
-        ret = "SPINEL_PROP_THREAD_ON_MESH_NETS";
+        ret = "PROP_THREAD_ON_MESH_NETS";
         break;
 
     case SPINEL_PROP_THREAD_LOCAL_ROUTES:
@@ -1140,15 +1160,15 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         break;
 
     case SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE:
-        ret = "SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
+        ret = "PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE";
         break;
 
     case SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU:
-        ret = "SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
+        ret = "PROP_THREAD_RLOC16_DEBUG_PASSTHRU";
         break;
 
     case SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED:
-        ret = "SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED";
+        ret = "PROP_THREAD_ROUTER_ROLE_ENABLED";
         break;
 
     case SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD:
@@ -1225,7 +1245,7 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         break;
 
     case SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP:
-        ret = "SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP";
+        ret = "PROP_JAM_DETECT_HISTORY_BITMAP";
         break;
 
     case SPINEL_PROP_GPIO_CONFIG:
@@ -1242,6 +1262,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 
     case SPINEL_PROP_GPIO_STATE_CLEAR:
         ret = "PROP_GPIO_STATE_CLEAR";
+        break;
+
+    case SPINEL_PROP_DEBUG_TEST_ASSERT:
+        ret = "SPINEL_PROP_DEBUG_TEST_ASSERT";
         break;
 
     default:
@@ -1368,6 +1392,10 @@ const char *spinel_status_to_cstr(spinel_status_t status)
 
     case SPINEL_STATUS_ITEM_NOT_FOUND:
         ret = "STATUS_ITEM_NOT_FOUND";
+        break;
+
+    case SPINEL_STATUS_INVALID_COMMAND_FOR_PROP:
+        ret = "STATUS_INVALID_COMMAND_FOR_PROP";
         break;
 
     case SPINEL_STATUS_JOIN_FAILURE:
@@ -1506,7 +1534,7 @@ main(void)
 
     memset(buffer, 0xAA, sizeof(buffer));
 
-    len = spinel_datatype_pack(buffer, sizeof(buffer), "CiT(iL)U", 0x88, 9, 0xA3, 0xDEADBEEF, static_string);
+    len = spinel_datatype_pack(buffer, sizeof(buffer), "Cit(iL)U", 0x88, 9, 0xA3, 0xDEADBEEF, static_string);
 
     if (len != 24)
     {
@@ -1523,7 +1551,7 @@ main(void)
         uint32_t l = 0;
         const char *str = NULL;
 
-        len = spinel_datatype_unpack(buffer, (spinel_size_t)len, "CiT(iL)U", &c, &i1, &i2, &l, &str);
+        len = spinel_datatype_unpack(buffer, (spinel_size_t)len, "Cit(iL)U", &c, &i1, &i2, &l, &str);
 
         if (len != 24)
         {

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -69,7 +69,7 @@
 // ----------------------------------------------------------------------------
 
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    2
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    3
 
 #define SPINEL_FRAME_MAX_SIZE                   1300
 
@@ -105,6 +105,7 @@ typedef enum
     SPINEL_STATUS_CCA_FAILURE       = 18, ///< The packet was not sent due to a CCA failure.
     SPINEL_STATUS_ALREADY           = 19, ///< The operation is already in progress.
     SPINEL_STATUS_ITEM_NOT_FOUND    = 20, ///< The given item could not be found.
+    SPINEL_STATUS_INVALID_COMMAND_FOR_PROP = 21, ///< The given command cannot be performed on this property.
 
     SPINEL_STATUS_JOIN__BEGIN       = 104,
 
@@ -286,6 +287,10 @@ enum
     SPINEL_CMD_PEEK_RET             = 19,
     SPINEL_CMD_POKE                 = 20,
 
+    SPINEL_CMD_PROP_VALUE_MULTI_GET = 21,
+    SPINEL_CMD_PROP_VALUE_MULTI_SET = 22,
+    SPINEL_CMD_PROP_VALUES_ARE      = 23,
+
     SPINEL_CMD_NEST__BEGIN          = 15296,
     SPINEL_CMD_NEST__END            = 15360,
 
@@ -311,6 +316,7 @@ enum
     SPINEL_CAP_WRITABLE_RAW_STREAM   = 8,
     SPINEL_CAP_GPIO                  = 9,
     SPINEL_CAP_TRNG                  = 10,
+    SPINEL_CAP_CMD_MULTI             = 11,
 
     SPINEL_CAP_802_15_4__BEGIN        = 16,
     SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
@@ -337,6 +343,7 @@ enum
 
     SPINEL_CAP_OPENTHREAD__BEGIN     = 512,
     SPINEL_CAP_MAC_WHITELIST         = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
+    SPINEL_CAP_MAC_RAW               = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
     SPINEL_CAP_OPENTHREAD__END       = 640,
 
     SPINEL_CAP_NEST__BEGIN           = 15296,
@@ -576,7 +583,7 @@ typedef enum
     SPINEL_PROP_MAC_SCAN_STATE         = SPINEL_PROP_MAC__BEGIN + 0, ///< [C]
     SPINEL_PROP_MAC_SCAN_MASK          = SPINEL_PROP_MAC__BEGIN + 1, ///< [A(C)]
     SPINEL_PROP_MAC_SCAN_PERIOD        = SPINEL_PROP_MAC__BEGIN + 2, ///< ms-per-channel [S]
-    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,(laddr,saddr,panid,lqi),(proto,xtra) [CcT(ESSC.)T(i).]
+    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3, ///< chan,rssi,mac_data,net_data [CcdD]
     SPINEL_PROP_MAC_15_4_LADDR         = SPINEL_PROP_MAC__BEGIN + 4, ///< [E]
     SPINEL_PROP_MAC_15_4_SADDR         = SPINEL_PROP_MAC__BEGIN + 5, ///< [S]
     SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6, ///< [S]
@@ -587,7 +594,7 @@ typedef enum
 
     SPINEL_PROP_MAC_EXT__BEGIN         = 0x1300,
     /// MAC Whitelist
-    /** Format: `A(T(Ec))`
+    /** Format: `A(t(Ec))`
      *
      * Structure Parameters:
      *
@@ -607,6 +614,23 @@ typedef enum
      *  Specified by Thread. Randomly-chosen, but non-volatile EUI-64.
      */
     SPINEL_PROP_MAC_EXTENDED_ADDR      = SPINEL_PROP_MAC_EXT__BEGIN + 2,
+
+    /// MAC Source Match Enabled Flag
+    /** Format: `b`
+     */
+    SPINEL_PROP_MAC_SRC_MATCH_ENABLED  = SPINEL_PROP_MAC_EXT__BEGIN + 3,
+
+    /// MAC Source Match Short Address List
+    /** Format: `A(S)`
+     */
+    SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES
+                                       = SPINEL_PROP_MAC_EXT__BEGIN + 4,
+
+    /// MAC Source Match Extended Address List
+    /** Format: `A(E)`
+     */
+    SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES
+                                       = SPINEL_PROP_MAC_EXT__BEGIN + 5,
     SPINEL_PROP_MAC_EXT__END           = 0x1400,
 
     SPINEL_PROP_NET__BEGIN           = 0x40,
@@ -650,7 +674,7 @@ typedef enum
     SPINEL_PROP_THREAD__BEGIN          = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR     = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
     SPINEL_PROP_THREAD_PARENT          = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
-    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(T(ESLLCCcC))]
+    SPINEL_PROP_THREAD_CHILD_TABLE     = SPINEL_PROP_THREAD__BEGIN + 2, ///< array(EUI64,rloc16,timeout,age,netDataVer,inLqi,aveRSS,mode) [A(t(ESLLCCcC))]
     SPINEL_PROP_THREAD_LEADER_RID      = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
     SPINEL_PROP_THREAD_LEADER_WEIGHT   = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
     SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
@@ -662,8 +686,8 @@ typedef enum
                                        = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
                                        = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
-    SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(T(6CbC))]
+    SPINEL_PROP_THREAD_ON_MESH_NETS    = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_LOCAL_ROUTES    = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
     SPINEL_PROP_THREAD_ASSISTING_PORTS = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
@@ -752,7 +776,7 @@ typedef enum
                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
 
     /// Thread Neighbor Table
-    /** Format: `A(T(ESLCcCbLL))`
+    /** Format: `A(t(ESLCcCbLL))`
      *  eui64, rloc16, age, inLqi ,aveRSS, mode, isChild. linkFrameCounter, mleCounter
      */
     SPINEL_PROP_THREAD_NEIGHBOR_TABLE  = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
@@ -780,8 +804,8 @@ typedef enum
     SPINEL_PROP_IPV6_LL_ADDR         = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
     SPINEL_PROP_IPV6_ML_ADDR         = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
     SPINEL_PROP_IPV6_ML_PREFIX       = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
-    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(T(6CLLC))]
-    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(T(6CCC))]
+    SPINEL_PROP_IPV6_ADDRESS_TABLE   = SPINEL_PROP_IPV6__BEGIN + 3, ///< array(ipv6addr,prefixlen,valid,preferred,flags) [A(t(6CLLC))]
+    SPINEL_PROP_IPV6_ROUTE_TABLE     = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
 
 
     /// IPv6 ICMP Ping Offload
@@ -798,9 +822,9 @@ typedef enum
 
     SPINEL_PROP_STREAM__BEGIN       = 0x70,
     SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
-    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [D]
-    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [D]
-    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [D]
+    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
+    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
+    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
     SPINEL_PROP_STREAM__END         = 0x80,
 
 
@@ -1023,11 +1047,13 @@ typedef enum
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_SPINEL_ERR     = SPINEL_PROP_CNTR__BEGIN + 302,
 
-
+    /// Number of out of order received spinel frames (tid increase by more than 1).
+    /** Format: `L` (Read-only) */
+    SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID
+                                       = SPINEL_PROP_CNTR__BEGIN + 303,
 
     /// The message buffer counter info
-    /** Format: `T(SSSSSSSSSSSSSSSS)` (Read-only)
-     *  `T(`
+    /** Format: `SSSSSSSSSSSSSSSS` (Read-only)
      *      `S`, (TotalBuffers)           The number of buffers in the pool.
      *      `S`, (FreeBuffers)            The number of free message buffers.
      *      `S`, (6loSendMessages)        The number of messages in the 6lo send queue.
@@ -1044,7 +1070,6 @@ typedef enum
      *      `S`, (ArpBuffers)             The number of buffers in the ARP send queue.
      *      `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
      *      `S`, (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
-     *  `)`
      */
     SPINEL_PROP_MSG_BUFFER_COUNTERS    = SPINEL_PROP_CNTR__BEGIN + 400,
 
@@ -1067,6 +1092,19 @@ typedef enum
 
     SPINEL_PROP_VENDOR__BEGIN       = 15360,
     SPINEL_PROP_VENDOR__END         = 16384,
+
+    SPINEL_PROP_DEBUG__BEGIN        = 16384,
+
+    /// Reading this property will cause an assert on the NCP.
+    /// This is intended for testing the assert functionality of
+    /// underlying platform/NCP. Assert should ideally cause the
+    /// NCP to reset, but if this is not supported a `false` boolean
+    /// is returned in response.
+    /** Format: 'b' (read-only) */
+    SPINEL_PROP_DEBUG_TEST_ASSERT
+                                    = SPINEL_PROP_DEBUG__BEGIN + 0,
+
+    SPINEL_PROP_DEBUG__END          = 17408,
 
     SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_PROP_EXPERIMENTAL__END   = 2097152,
@@ -1114,9 +1152,10 @@ enum
     SPINEL_DATATYPE_IPv6ADDR_C    = '6',
     SPINEL_DATATYPE_EUI64_C       = 'E',
     SPINEL_DATATYPE_EUI48_C       = 'e',
+    SPINEL_DATATYPE_DATA_WLEN_C   = 'd',
     SPINEL_DATATYPE_DATA_C        = 'D',
     SPINEL_DATATYPE_UTF8_C        = 'U', //!< Zero-Terminated UTF8-Encoded String
-    SPINEL_DATATYPE_STRUCT_C      = 'T',
+    SPINEL_DATATYPE_STRUCT_C      = 't',
     SPINEL_DATATYPE_ARRAY_C       = 'A',
 };
 
@@ -1135,10 +1174,43 @@ typedef char spinel_datatype_t;
 #define SPINEL_DATATYPE_IPv6ADDR_S    "6"
 #define SPINEL_DATATYPE_EUI64_S       "E"
 #define SPINEL_DATATYPE_EUI48_S       "e"
+#define SPINEL_DATATYPE_DATA_WLEN_S   "d"
 #define SPINEL_DATATYPE_DATA_S        "D"
 #define SPINEL_DATATYPE_UTF8_S        "U" //!< Zero-Terminated UTF8-Encoded String
-#define SPINEL_DATATYPE_STRUCT_S      "T"
-#define SPINEL_DATATYPE_ARRAY_S       "A"
+
+#define SPINEL_DATATYPE_ARRAY_S(x)        "A(" x ")"
+#define SPINEL_DATATYPE_STRUCT_S(x)       "t(" x ")"
+
+#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x)                                     \
+        SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
+
+#define SPINEL_DATATYPE_COMMAND_S                                             \
+        SPINEL_DATATYPE_UINT8_S       /* header  */                           \
+        SPINEL_DATATYPE_UINT_PACKED_S /* command */
+
+#define SPINEL_DATATYPE_COMMAND_PROP_S                                        \
+        SPINEL_DATATYPE_COMMAND_S     /* prop command  */                     \
+        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
+
+#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str)     \
+        SPINEL_DATATYPE_UINT8_S /* Channel */                                 \
+        SPINEL_DATATYPE_INT8_S  /* RSSI */                                    \
+        SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */         \
+        SPINEL_DATATYPE_STRUCT_S(net_format_str) /* net-layer data */
+
+#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S                         \
+        SPINEL_DATATYPE_EUI64_S  /* laddr */                                  \
+        SPINEL_DATATYPE_UINT16_S /* saddr */                                  \
+        SPINEL_DATATYPE_UINT16_S /* panid */                                  \
+        SPINEL_DATATYPE_UINT8_S  /* lqi   */
+
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                              \
+        SPINEL_DATATYPE_UINT_PACKED_S /* type */                              \
+        SPINEL_DATATYPE_UINT8_S /* flags */                                   \
+        SPINEL_DATATYPE_UTF8_S /* network name */                             \
+        SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
+
+#define SPINEL_MAX_UINT_PACKED        2097151
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len,
                                                       const char *pack_format, ...);

--- a/third_party/openthread/tools/spi-hdlc-adapter/README.md
+++ b/third_party/openthread/tools/spi-hdlc-adapter/README.md
@@ -19,16 +19,31 @@ protocol document.
 *   `--pty`: Create a pseudo terminal for HDLC input/output. The path
     of the newly-created PTY will be written to `stdout`, followed by
     a newline.
+*   `--raw`: Do not encode/decode packets using HDLC. Instead, write
+    whole, raw frames to the specified input and output FDs. This is
+    useful for emulating a serial port, or when datagram-based sockets
+    are supplied for `stdin` and `stdout` (when used with `--stdio`).
+*   `--mtu=[MTU]`: Specify the MTU. Currently only used in raw mode.
+    Default and maximum value is 2043. Must be greater than zero.
 *   `--gpio-int[=gpio-path]`: Specify a path to the Linux
     sysfs-exported GPIO directory for the `I̅N̅T̅` pin. If not
     specified, `spi-hdlc-adapter` will fall back to polling, which is
     inefficient.
 *   `--gpio-reset[=gpio-path]`: Specify a path to the Linux
     sysfs-exported GPIO directory for the `R̅E̅S̅` pin.
-*   `--spi-mode[=mode]`: Specify the SPI mode to use (0-3).
-*   `--spi-speed[=hertz]`: Specify the SPI speed in hertz.
-*   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion, in
-    microseconds.
+*   `--spi-mode[=mode]`: Specify the SPI mode to use (0-3). Default
+    value is `0`.
+*   `--spi-speed[=hertz]`: Specify the SPI speed in hertz. Default
+    value is `1000000` (1MHz).
+*   `--spi-cs-delay[=usec]`: Specify the delay after C̅S̅ assertion,
+    in microseconds. Default is 20µs. Note that this may need to be
+    set to zero for spi-hdlc-adapter to work with some SPI drivers.
+*   `--spi-align-allowance[=n]`: Specify the the maximum number of 0xFF
+    bytes to clip from start of MISO frame. This makes this tool usable
+    with SPI slaves which have buggy SPI blocks that prepend up to
+    three 0xFF bytes to the start of MISO frame. Default value is `0`.
+    Maximum value is `3`. *This must be set to at least `2` for chips
+    in the SiLabs EM35x family.*
 *   `--verbose`: Increase debug verbosity.
 *   `--help`: Print out usage information to `stdout` and exit.
 
@@ -58,3 +73,18 @@ procedure:
 1.  Set `R̅E̅S̅/direction` to `low`.
 2.  Sleep for 30ms.
 3.  Set `R̅E̅S̅/direction` to `high`.
+
+## Statistics ##
+
+Some simple usage statistics are printed out to syslog at exit and
+whenever the `SIGUSR1` signal is received. The easiest way to send
+that signal to `spi-hdlc-adapter` is like this:
+
+    # killall -sigusr1 spi-hdlc-adapter
+
+At which point you will see something like this in the syslogs:
+
+    spi-hdlc-adapter[5215]: INFO: sSpiFrameCount=45660
+    spi-hdlc-adapter[5215]: INFO: sSpiValidFrameCount=45643
+    spi-hdlc-adapter[5215]: INFO: sSpiGarbageFrameCount=17
+    spi-hdlc-adapter[5215]: INFO: sSpiDuplexFrameCount=20931


### PR DESCRIPTION
This pull request includes two changes, one is the sync of files that have changed in OpenThread and the other updates various parts of the Spinel plug-in to reflect those changes.

The later commit is larger than expected due to the realization that `spinel-extra.c` was quite crufty. The code in question wasn't being used in the ways in which it was broken, which is why we haven't seen any problems so far. Nonetheless, it seemed prudent to fix the code.

This change also includes the latest updates ([#1441](https://github.com/openthread/openthread/pull/1441)) to `spi-hdlc-adapter`, previous versions of which had a nasty frame corruption bug.