### PR TITLE
Make form/join/resume/leave less fragile.

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -144,7 +144,7 @@ int
 SpinelNCPInstance::vprocess_resume(int event, va_list args)
 {
 	Data command;
-	bool is_commissioned;
+	bool is_commissioned = false;
 	int ret;
 
 	EH_BEGIN_SUB(&mSubPT);
@@ -157,13 +157,15 @@ SpinelNCPInstance::vprocess_resume(int event, va_list args)
 	require(command.size() < sizeof(mOutboundBuffer), on_error);
 	memcpy(mOutboundBuffer, command.data(), command.size());
 	mOutboundBufferLen = static_cast<spinel_ssize_t>(command.size());
+
 	CONTROL_REQUIRE_OUTBOUND_BUFFER_FLUSHED_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
 	CONTROL_REQUIRE_COMMAND_RESPONSE_WITHIN(NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT, on_error);
 
 	ret = peek_ncp_callback_status(event, args);
-	require_noerr(ret, on_error);
 
-	{
+	check_noerr(ret);
+
+	if (ret == 0) {
 		unsigned int key = va_arg(args, unsigned int);
 		const uint8_t* data_in = va_arg(args, const uint8_t*);
 		spinel_size_t data_len = va_arg_small(args, spinel_size_t);

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -154,7 +154,8 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
 	ret = mNextCommandRet;
-	require_noerr(ret, on_error);
+
+	check_noerr(ret);
 
 	// TODO: We should do a scan to make sure we pick a good channel
 	//       and don't have a panid collision.

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -97,8 +97,8 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
 	ret = mNextCommandRet;
-	require_noerr(ret, on_error);
 
+	check_noerr(ret);
 
 	mLastState = mInstance->get_ncp_state();
 	mInstance->change_ncp_state(ASSOCIATING);

--- a/src/ncp-spinel/SpinelNCPTaskLeave.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskLeave.cpp
@@ -94,6 +94,7 @@ nl::wpantund::SpinelNCPTaskLeave::vprocess_event(int event, va_list args)
 	mNextCommand = SpinelPackData(SPINEL_FRAME_PACK_CMD_NET_CLEAR);
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
 	ret = mNextCommandRet;
+
 	require_noerr(ret, on_error);
 
 	mInstance->mNetworkKey = Data();


### PR DESCRIPTION
One of the core cornerstones of Spinel is to not treat the failure of largely unrelated commands to be fatal. Currently, the absence of the net save commands is going to cause forming, joining, resuming, and leaving to fail. This is entirely unnecessary, since the failure of the net-clear command is not at all fatal.