### PR TITLE
Support for dynamic control of OpenThread NCP log level.

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -574,6 +574,9 @@ SpinelNCPInstance::get_property(
 			)
 		));
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadLogLevel)) {
+		SIMPLE_SPINEL_GET(SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, SPINEL_DATATYPE_UINT8_S);
+
 	} else if (strncaseequal(key.c_str(), kWPANTUNDProperty_Spinel_CounterPrefix, sizeof(kWPANTUNDProperty_Spinel_CounterPrefix)-1)) {
 		int cntr_key = 0;
 
@@ -908,6 +911,18 @@ SpinelNCPInstance::set_property(
 					.finish()
 				);
 			}
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadLogLevel)) {
+			uint8_t logLevel = static_cast<uint8_t>(any_to_int(value));
+			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S), SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, logLevel);
+
+			mSettings[kWPANTUNDProperty_OpenThreadLogLevel] = SettingsEntry(command);
+
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(command)
+				.finish()
+			);
 
 		} else {
 			NCPInstanceBase::set_property(key, value, cb);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -94,6 +94,7 @@
 #define kWPANTUNDProperty_ThreadStableNetworkDataVersion "Thread:StableNetworkDataVersion"
 #define kWPANTUNDProperty_ThreadPreferredRouterID        "Thread:PreferredRouterID"
 
+#define kWPANTUNDProperty_OpenThreadLogLevel                   "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCounters          "OpenThread:MsgBufferCounters"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCountersAsString  "OpenThread:MsgBufferCounters:AsString"
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1268,6 +1268,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "SPINEL_PROP_DEBUG_TEST_ASSERT";
         break;
 
+    case SPINEL_PROP_DEBUG_NCP_LOG_LEVEL:
+        ret = "SPINEL_PROP_DEBUG_NCP_LOG_LEVEL";
+        break;
+
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -227,6 +227,18 @@ enum
     SPINEL_MAC_PROMISCUOUS_MODE_FULL     = 2, ///< All decoded MAC packets are passed up the stack.
 };
 
+enum
+{
+    SPINEL_NCP_LOG_LEVEL_EMERG  = 0,
+    SPINEL_NCP_LOG_LEVEL_ALERT  = 1,
+    SPINEL_NCP_LOG_LEVEL_CRIT   = 2,
+    SPINEL_NCP_LOG_LEVEL_ERR    = 3,
+    SPINEL_NCP_LOG_LEVEL_WARN   = 4,
+    SPINEL_NCP_LOG_LEVEL_NOTICE = 5,
+    SPINEL_NCP_LOG_LEVEL_INFO   = 6,
+    SPINEL_NCP_LOG_LEVEL_DEBUG  = 7,
+};
+
 typedef struct
 {
     uint8_t bytes[8];
@@ -1103,6 +1115,10 @@ typedef enum
     /** Format: 'b' (read-only) */
     SPINEL_PROP_DEBUG_TEST_ASSERT
                                     = SPINEL_PROP_DEBUG__BEGIN + 0,
+
+    /// The NCP log level.
+    /** Format: `C` */
+    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL  = SPINEL_PROP_DEBUG__BEGIN + 1,
 
     SPINEL_PROP_DEBUG__END          = 17408,
 


### PR DESCRIPTION
This commit adds support for getting/setting a new wpan property
"OpenThread:LogLevel" tied to `SPINEL_PROP_DEBUG_NCP_LOG_LEVEL`
property. This property can be used to control the OpenThread NCP
log level dynamically.

By including this property in the `mSettings` hash table, it is
ensured that the user-selected log-level persists over NCP resets.