### PR TITLE
`netif-mgmt`: Fix the check for `SIOGIFINDEX` in `netif_mgmt_get_ifindex()`.

### DIFF
--- a/src/util/netif-mgmt.c
+++ b/src/util/netif-mgmt.c
@@ -195,7 +195,7 @@ int
 netif_mgmt_get_ifindex(int reqfd, const char* if_name) {
 	int ret = -1;
 
-#ifdef SIOIFINDEX
+#ifdef SIOGIFINDEX
 	struct ifreq ifr;
 
 	memset(&ifr, 0, sizeof(struct ifreq));


### PR DESCRIPTION
This should address https://github.com/openthread/openthread/issues/1536.