### PR TITLE
Remove the mechanism to detect for back-to-back NOMEM status from NCP

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -169,8 +169,6 @@ SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 	mSupprotedChannels.clear();
 
 	mIsPcapInProgress = false;
-	mNoMemStatusCounter = 0;
-	mLastTimeNoMemStatus = 0;
 	mSettings.clear();
 
 	if (!settings.empty()) {
@@ -1023,22 +1021,6 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			}
 			mResetIsExpected = false;
 			return;
-
-		} else if (status == SPINEL_STATUS_NOMEM) {
-			cms_t now = time_ms();
-			if (now - mLastTimeNoMemStatus > kMaxTimeBetweenNoMemStatus) {
-				mNoMemStatusCounter = 0;
-			}
-			mLastTimeNoMemStatus = now;
-			mNoMemStatusCounter++;
-
-			if (mNoMemStatusCounter == kMaxNonMemCountToReset)
-			{
-				mNoMemStatusCounter = 0;
-				syslog(LOG_WARNING, "NCP is out of memory for too long...Resetting the NCP!");
-				ncp_is_misbehaving();
-				return;
-			}
 		} else if (status == SPINEL_STATUS_INVALID_COMMAND) {
 			syslog(LOG_NOTICE, "[-NCP-]: COMMAND NOT RECOGNIZED");
 		}

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -251,15 +251,6 @@ private:
 	// Task management
 	std::list<boost::shared_ptr<SpinelNCPTask> > mTaskQueue;
 
-	enum
-	{
-		kMaxTimeBetweenNoMemStatus = 60000, // (in ms) time between NOMEM status to consider it back-to-back.
-		kMaxNonMemCountToReset = 15,        // Number of back-to-back NOMEM status to reset
-	};
-
-	cms_t mLastTimeNoMemStatus;
-	uint16_t mNoMemStatusCounter;
-
 }; // class SpinelNCPInstance
 
 extern class SpinelNCPInstance* gNCPInstance;


### PR DESCRIPTION
This commit removes the recovery mechanism which was  added in commit
f7e06585db for detecting back-to-back NOMEM status from NCP and
resetting the NCP. This was added to safe-guard against possible memory
leaks in NCP. It's recommend to instead add such a safe-guard in NCP.