### PR TITLE
Fix typo that prevented setting unsigned 64-bit properties

### DIFF
--- a/src/util/DBUSHelpers.cpp
+++ b/src/util/DBUSHelpers.cpp
@@ -139,7 +139,7 @@ DBUSHelpers::any_from_dbus_iter(DBusMessageIter *iter)
 		ret = v;
 	} break;
 	case DBUS_TYPE_UINT64: {
-		uint16_t v;
+		uint64_t v;
 		dbus_message_iter_get_basic(iter, &v);
 		ret = v;
 	} break;


### PR DESCRIPTION
Notably, this typo prevented setting XPANID as a 64-bit unsigned integer
instead of a byte array.