### PR TITLE
Form network based on existing PANID and XPANID

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -162,7 +162,7 @@ nl::wpantund::peek_ncp_callback_status(int event, va_list args)
 }
 
 SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
-	NCPInstanceBase(settings), mControlInterface(this)
+	NCPInstanceBase(settings), mControlInterface(this), mPanid(0xffff)
 {
 	mOutboundBufferLen = 0;
 	mInboundHeader = 0;

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -694,7 +694,6 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkPANID)) {
 			uint16_t panid = any_to_int(value);
 
-			mCurrentNetworkInstance.panid = panid;
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(
@@ -821,7 +820,6 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkXPANID)) {
 			Data xpanid = any_to_data(value);
 
-			memcpy(mCurrentNetworkInstance.hwaddr, xpanid.data(), xpanid.size());
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -162,7 +162,7 @@ nl::wpantund::peek_ncp_callback_status(int event, va_list args)
 }
 
 SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
-	NCPInstanceBase(settings), mControlInterface(this), mPanid(0xffff)
+	NCPInstanceBase(settings), mControlInterface(this)
 {
 	mOutboundBufferLen = 0;
 	mInboundHeader = 0;
@@ -694,7 +694,7 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkPANID)) {
 			uint16_t panid = any_to_int(value);
 
-			mPanid = panid;
+			mCurrentNetworkInstance.panid = panid;
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(
@@ -821,7 +821,7 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkXPANID)) {
 			Data xpanid = any_to_data(value);
 
-			mXPanid = any_to_uint64(value);
+			memcpy(mCurrentNetworkInstance.hwaddr, xpanid.data(), xpanid.size());
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -694,6 +694,7 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkPANID)) {
 			uint16_t panid = any_to_int(value);
 
+			mPanid = panid;
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(
@@ -820,6 +821,7 @@ SpinelNCPInstance::set_property(
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkXPANID)) {
 			Data xpanid = any_to_data(value);
 
+			mXPanid = any_to_uint64(value);
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -52,12 +52,7 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 	}
 
 	if (!mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
-		uint64_t xpanid;
-
-		memcpy(&xpanid, instance->mCurrentNetworkInstance.hwaddr, sizeof(xpanid));
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-		reverse_bytes((uint8_t *)xpanid, sizeof(xpanid));
-#endif
+		uint64_t xpanid = instance->mCurrentNetworkInstance.get_xpanid_as_uint64();
 
 		if (xpanid == 0)
 		{

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -41,7 +41,7 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 ):	SpinelNCPTask(instance, cb), mOptions(options), mLastState(instance->get_ncp_state())
 {
 	if (!mOptions.count(kWPANTUNDProperty_NetworkPANID)) {
-		uint16_t panid = instance->mPanid;
+		uint16_t panid = instance->mCurrentNetworkInstance.panid;
 
 		if (panid == 0xffff)
 		{
@@ -52,7 +52,12 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 	}
 
 	if (!mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
-		uint64_t xpanid = instance->mXPanid;
+		uint64_t xpanid;
+
+		memcpy(&xpanid, instance->mCurrentNetworkInstance.hwaddr, sizeof(xpanid));
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+		reverse_bytes((uint8_t *)xpanid, sizeof(xpanid));
+#endif
 
 		if (xpanid == 0)
 		{

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -41,17 +41,23 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 ):	SpinelNCPTask(instance, cb), mOptions(options), mLastState(instance->get_ncp_state())
 {
 	if (!mOptions.count(kWPANTUNDProperty_NetworkPANID)) {
-		uint16_t panid;
+		uint16_t panid = instance->mPanid;
 
-		sec_random_fill(reinterpret_cast<uint8_t*>(&panid), sizeof(panid));
+		if (panid == 0xffff)
+		{
+			sec_random_fill(reinterpret_cast<uint8_t*>(&panid), sizeof(panid));
+		}
 
 		mOptions[kWPANTUNDProperty_NetworkPANID] = panid;
 	}
 
 	if (!mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
-		uint64_t xpanid;
+		uint64_t xpanid = instance->mXPanid;
 
-		sec_random_fill(reinterpret_cast<uint8_t*>(&xpanid), sizeof(xpanid));
+		if (xpanid == 0)
+		{
+			sec_random_fill(reinterpret_cast<uint8_t*>(&xpanid), sizeof(xpanid));
+		}
 
 		mOptions[kWPANTUNDProperty_NetworkXPANID] = xpanid;
 	}


### PR DESCRIPTION
Setting PSKc relies on forming network with given XPANID. This PR fixes #138 .