### PR TITLE
Add property Network PSKc

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -241,6 +241,7 @@ private:
 
 	int mSubPTIndex;
 
+	Data mNetworkPSKc;
 	Data mNetworkKey;
 	uint32_t mNetworkKeyIndex;
 

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -259,6 +259,7 @@ NCPInstanceBase::get_supported_property_keys() const
 	properties.insert(kWPANTUNDProperty_NetworkPANID);
 	properties.insert(kWPANTUNDProperty_NetworkXPANID);
 	properties.insert(kWPANTUNDProperty_NetworkKey);
+	properties.insert(kWPANTUNDProperty_NetworkPSKc);
 	properties.insert(kWPANTUNDProperty_NetworkKeyIndex);
 	properties.insert(kWPANTUNDProperty_NetworkNodeType);
 	properties.insert(kWPANTUNDProperty_NCPState);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -72,7 +72,8 @@
 #define kWPANTUNDProperty_NetworkKey             "Network:Key"
 #define kWPANTUNDProperty_NetworkKeyIndex        "Network:KeyIndex"
 #define kWPANTUNDProperty_NetworkIsCommissioned  "Network:IsCommissioned"
-#define kWPANTUNDProperty_NetworkIsConnected  "Network:IsConnected"
+#define kWPANTUNDProperty_NetworkIsConnected     "Network:IsConnected"
+#define kWPANTUNDProperty_NetworkPSKc            "Network:PSKc"
 
 #define kWPANTUNDProperty_IPv6LinkLocalAddress   "IPv6:LinkLocalAddress"
 #define kWPANTUNDProperty_IPv6MeshLocalAddress   "IPv6:MeshLocalAddress"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1075,6 +1075,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_NET_KEY_SWITCH_GUARDTIME";
         break;
 
+    case SPINEL_PROP_NET_PSKC:
+        ret = "PROP_NET_PSKC";
+        break;
+
     case SPINEL_PROP_THREAD_LEADER_ADDR:
         ret = "PROP_THREAD_LEADER_ADDR";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -251,6 +251,11 @@ typedef struct
 
 typedef struct
 {
+    uint8_t bytes[16];
+} spinel_net_pskc_t;
+
+typedef struct
+{
     uint8_t bytes[6];
 } spinel_eui48_t;
 
@@ -680,6 +685,8 @@ typedef enum
 
     SPINEL_PROP_NET_KEY_SWITCH_GUARDTIME
                                      = SPINEL_PROP_NET__BEGIN + 10, ///< [L]
+
+    SPINEL_PROP_NET_PSKC             = SPINEL_PROP_NET__BEGIN + 11, ///< [D]
 
     SPINEL_PROP_NET__END             = 0x50,
 


### PR DESCRIPTION
This PR adds a property to access the PSKc of Thread network. All implementation detail follows the way for Network Master Key.