### PR TITLE
Add support for controlling steering data when joinable

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -168,6 +168,9 @@ SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 	mInboundHeader = 0;
 	mSupprotedChannels.clear();
 
+	mSetSteeringDataWhenJoinable = false;
+	memset(mSteeringDataAddress, 0xff, sizeof(mSteeringDataAddress));
+
 	mIsPcapInProgress = false;
 	mSettings.clear();
 
@@ -597,6 +600,12 @@ SpinelNCPInstance::get_property(
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadLogLevel)) {
 		SIMPLE_SPINEL_GET(SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, SPINEL_DATATYPE_UINT8_S);
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable)) {
+		cb(0, boost::any(mSetSteeringDataWhenJoinable));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadSteeringDataAddress)) {
+		cb(0, boost::any(nl::Data(mSteeringDataAddress, sizeof(mSteeringDataAddress))));
 
 	} else if (strncaseequal(key.c_str(), kWPANTUNDProperty_Spinel_CounterPrefix, sizeof(kWPANTUNDProperty_Spinel_CounterPrefix)-1)) {
 		int cntr_key = 0;
@@ -1035,6 +1044,22 @@ SpinelNCPInstance::set_property(
 				.add_command(command)
 				.finish()
 			);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable)) {
+			mSetSteeringDataWhenJoinable = any_to_bool(value);
+			cb(kWPANTUNDStatus_Ok);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadSteeringDataAddress)) {
+			Data address = any_to_data(value);
+			wpantund_status_t status = kWPANTUNDStatus_Ok;
+
+			if (address.size() != sizeof(mSteeringDataAddress)) {
+				status = kWPANTUNDStatus_InvalidArgument;
+			} else {
+				memcpy(mSteeringDataAddress, address.data(), sizeof(mSteeringDataAddress));
+			}
+
+			cb (status);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_BorderAgentProxyStream)) {
 			Data packet = any_to_data(value);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -230,6 +230,9 @@ private:
 	std::set<unsigned int> mCapabilities;
 	uint32_t mDefaultChannelMask;
 
+	bool mSetSteeringDataWhenJoinable;
+	uint8_t mSteeringDataAddress[8];
+
 	SettingsMap mSettings;
 	SettingsMap::iterator mSettingsIter;
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -101,6 +101,8 @@
 #define kWPANTUNDProperty_ThreadDeviceMode                      "Thread:DeviceMode"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
+#define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"
+#define kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable "OpenThread:SteeringData:SetWhenJoinable"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCounters           "OpenThread:MsgBufferCounters"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCountersAsString   "OpenThread:MsgBufferCounters:AsString"
 #define kWPANTUNDProperty_OpenThreadDebugTestAssert             "OpenThread:Debug:TestAssert"


### PR DESCRIPTION
This commit adds new feature to allow setting of the steering data
when the joinability status gets changed (through `permit_join()`).
This feature requires the NCP `SPINEL_CAP_OOB_STEERING_DATA`
capability.

This commit defines two new wpan properties:

1) `OpenThread:SteeringData:SetWhenJoinable` (boolean) which defines
whether or not when the device is joinable the steering data is set.
The default setting is `false`. It is recommended that this property
is changed using `wpantund.conf` during initialization.

2) `OpenThread:SteeringData:Address` (eui64 value) which specifies the
address used to set the steering data (out of band) using the spinel
property `SPINEL_PROP_THREAD_STEERING_DATA` (the given eui64 is used
to compute the bloom filter which is used as the steering data).
Default value is all `0xff`s which means set the steering data/bloom
filter to accept/allow all.