### PR TITLE
Ensure to user a random xpanid during "form" if none was set explicitly earlier

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -557,6 +557,7 @@ on_error:
 	mIsPcapInProgress = false;
 	mFailureCount = 0;
 	mResetIsExpected = false;
+	mXPANIDWasExplicitlySet = false;
 	set_initializing_ncp(false);
 	mDriverState = NORMAL_OPERATION;
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -170,6 +170,7 @@ SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 
 	mIsPcapInProgress = false;
 	mSettings.clear();
+	mXPANIDWasExplicitlySet = false;
 
 	if (!settings.empty()) {
 		int status;
@@ -844,6 +845,8 @@ SpinelNCPInstance::set_property(
 				)
 				.finish()
 			);
+
+			mXPANIDWasExplicitlySet = true;
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkKey)) {
 			Data network_key = any_to_data(value);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -244,6 +244,7 @@ private:
 	Data mNetworkPSKc;
 	Data mNetworkKey;
 	uint32_t mNetworkKeyIndex;
+	bool mXPANIDWasExplicitlySet;
 
 	bool mResetIsExpected;
 

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -43,8 +43,7 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 	if (!mOptions.count(kWPANTUNDProperty_NetworkPANID)) {
 		uint16_t panid = instance->mCurrentNetworkInstance.panid;
 
-		if (panid == 0xffff)
-		{
+		if (panid == 0xffff) {
 			sec_random_fill(reinterpret_cast<uint8_t*>(&panid), sizeof(panid));
 		}
 
@@ -52,10 +51,13 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 	}
 
 	if (!mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
-		uint64_t xpanid = instance->mCurrentNetworkInstance.get_xpanid_as_uint64();
+		uint64_t xpanid = 0;
 
-		if (xpanid == 0)
-		{
+		if (instance->mXPANIDWasExplicitlySet) {
+			xpanid = instance->mCurrentNetworkInstance.get_xpanid_as_uint64();
+		}
+
+		if (xpanid == 0) {
 			sec_random_fill(reinterpret_cast<uint8_t*>(&xpanid), sizeof(xpanid));
 		}
 


### PR DESCRIPTION
This commits adds new flag `mXPANIDWasExplicitlySet` to track if the
XPANID is set explicitly after a NCP reset. This is then used to
ensure that a random xpanid is generated and used during "form"
opeation if non was set earlier.

This change addresses an issue where newly formed network always end
up using the default OpenThread XPANID value of `0xDEAD00BEEF00CAFE`.