### PR TITLE
improve the config-gateway function

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v0.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v0.cpp
@@ -633,6 +633,11 @@ DBusIPCAPI_v0::interface_config_gateway_handler(
 	dbus_message_ref(message);
 
 	dbus_bool_t defaultRoute = FALSE;
+	dbus_bool_t preferred = TRUE;
+	dbus_bool_t slaac = TRUE;
+	dbus_bool_t onMesh = TRUE;
+	int16_t priority_raw;
+	NCPControlInterface::OnMeshPrefixPriority priority;
 	uint32_t preferredLifetime = 0;
 	uint32_t validLifetime = 0;
 	uint8_t *prefix = NULL;
@@ -655,6 +660,8 @@ DBusIPCAPI_v0::interface_config_gateway_handler(
 
 	memcpy(addr.s6_addr, prefix, prefixLen);
 
+	priority = NCPControlInterface::PREFIX_MEDIUM_PREFERENCE;
+
 	if (validLifetime == 0) {
 		interface->remove_on_mesh_prefix(
 			&addr,
@@ -664,6 +671,10 @@ DBusIPCAPI_v0::interface_config_gateway_handler(
 		interface->add_on_mesh_prefix(
 			&addr,
 			defaultRoute,
+			preferred,
+			slaac,
+			onMesh,
+			priority,
 			boost::bind(&DBusIPCAPI_v0::CallbackWithStatus_Helper,this, _1, message)
 		);
 	}

--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -1192,7 +1192,7 @@ DBusIPCAPI_v1::interface_config_gateway_handler(
 	int prefix_len_in_bytes(0);
 	struct in6_addr address = {};
 	bool did_succeed(false);
-	int16_t priority_raw;
+	int16_t priority_raw(0);
 	NCPControlInterface::OnMeshPrefixPriority priority(NCPControlInterface::PREFIX_MEDIUM_PREFERENCE);
 
 	did_succeed = dbus_message_get_args(
@@ -1208,17 +1208,29 @@ DBusIPCAPI_v1::interface_config_gateway_handler(
 		DBUS_TYPE_INVALID
 	);
 
+	if (!did_succeed)
+	{
+		did_succeed = dbus_message_get_args(
+			message, NULL,
+			DBUS_TYPE_BOOLEAN, &default_route,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &prefix, &prefix_len_in_bytes,
+			DBUS_TYPE_UINT32, &preferred_lifetime,
+			DBUS_TYPE_UINT32, &valid_lifetime,
+			DBUS_TYPE_INVALID
+		);
+	} else {
+		if (priority_raw > 0) {
+			priority = NCPControlInterface::PREFIX_HIGH_PREFERENCE;
+		} else if (priority_raw < 0) {
+			priority = NCPControlInterface::PREFIX_LOW_PREFRENCE;
+		}
+	}
+
 	require(did_succeed, bail);
 	require(prefix_len_in_bytes <= sizeof(address), bail);
 	require(prefix_len_in_bytes >= 0, bail);
 
 	memcpy(address.s6_addr, prefix, prefix_len_in_bytes);
-
-	if  (priority_raw > 0) {
-		priority = NCPControlInterface::PREFIX_HIGH_PREFERENCE;
-	} else if (priority_raw < 0) {
-		priority = NCPControlInterface::PREFIX_LOW_PREFRENCE;
-	}
 
 	dbus_message_ref(message);
 

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -134,6 +134,10 @@ void
 DummyNCPControlInterface::add_on_mesh_prefix(
 	const struct in6_addr *prefix,
 	bool defaultRoute,
+	bool preferred,
+	bool slaac,
+	bool onMesh,
+	OnMeshPrefixPriority priority,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -133,6 +133,10 @@ public:
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,
+		bool preferred,
+		bool slaac,
+		bool onMesh,
+		OnMeshPrefixPriority priority,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -134,6 +134,10 @@ public:
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,
+		bool preferred,
+		bool slaac,
+		bool onMesh,
+		OnMeshPrefixPriority priority,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1767,29 +1767,31 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_THREAD_ON_MESH_NETS) {
-		mLocalPrefixes.clear();
+		mOnMeshPrefixes.clear();
 		while (value_data_len > 0) {
 			spinel_ssize_t len = 0;
 			struct in6_addr *addr = NULL;
 			uint8_t prefix_len = 0;
 			bool stable;
 			uint8_t flags = 0;
+			bool isLocal;
 
 			len = spinel_datatype_unpack(
 				value_data_ptr,
 				value_data_len,
-				"t(6CbC)",
+				"t(6CbCb)",
 				&addr,
 				&prefix_len,
 				&stable,
-				&flags
+				&flags,
+				&isLocal
 			);
 
 			if (len < 1) {
 				break;
 			}
 
-			refresh_on_mesh_prefix(addr, prefix_len, stable, flags);
+			refresh_on_mesh_prefix(addr, prefix_len, stable, flags, isLocal);
 
 			value_data_ptr += len;
 			value_data_len -= len;
@@ -1973,11 +1975,13 @@ bail:
 }
 
 void
-SpinelNCPInstance::refresh_on_mesh_prefix(struct in6_addr *prefix, uint8_t prefix_len, bool stable, uint8_t flags)
+SpinelNCPInstance::refresh_on_mesh_prefix(struct in6_addr *prefix, uint8_t prefix_len, bool stable, uint8_t flags, bool isLocal)
 {
-	struct in6_addr addr;
-	memcpy(&addr, prefix, sizeof(in6_addr));
-	add_prefix(addr, UINT32_MAX, UINT32_MAX, flags);
+	if (!isLocal) {
+		struct in6_addr addr;
+		memcpy(&addr, prefix, sizeof(in6_addr));
+		add_prefix(addr, UINT32_MAX, UINT32_MAX, flags);
+	}
 	if ( ((flags & (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC)) == (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC))
 	  && !lookup_address_for_prefix(NULL, *prefix, prefix_len)
 	) {
@@ -2047,16 +2051,17 @@ SpinelNCPInstance::handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const
 		spinel_datatype_unpack(
 			value_data_ptr,
 			value_data_len,
-			"6CbC",
+			"6CbCb",
 			&addr,
 			&prefix_len,
 			&stable,
-			&flags
+			&flags,
+			&isLocal
 		);
 
 		syslog(LOG_NOTICE, "On-Mesh Network Added: %s/%d flags:%s", in6_addr_to_string(*addr).c_str(), prefix_len, flags_to_string(flags, flag_lookup).c_str());
 
-		refresh_on_mesh_prefix(addr, prefix_len, stable, flags);
+		refresh_on_mesh_prefix(addr, prefix_len, stable, flags, isLocal);
 	}
 
 	process_event(EVENT_NCP_PROP_VALUE_INSERTED, key, value_data_ptr, value_data_len);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1767,6 +1767,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_THREAD_ON_MESH_NETS) {
+		mLocalPrefixes.clear();
 		while (value_data_len > 0) {
 			spinel_ssize_t len = 0;
 			struct in6_addr *addr = NULL;
@@ -1974,6 +1975,9 @@ bail:
 void
 SpinelNCPInstance::refresh_on_mesh_prefix(struct in6_addr *prefix, uint8_t prefix_len, bool stable, uint8_t flags)
 {
+	struct in6_addr addr;
+	memcpy(&addr, prefix, sizeof(in6_addr));
+	add_prefix(addr, UINT32_MAX, UINT32_MAX, flags);
 	if ( ((flags & (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC)) == (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC))
 	  && !lookup_address_for_prefix(NULL, *prefix, prefix_len)
 	) {
@@ -2037,6 +2041,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const
 		uint8_t prefix_len = 0;
 		bool stable;
 		uint8_t flags = 0;
+		bool isLocal;
 		static const char flag_lookup[] = "ppPSDCRM";
 
 		spinel_datatype_unpack(

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -148,7 +148,7 @@ protected:
 
 private:
 
-	void refresh_on_mesh_prefix(struct in6_addr *addr, uint8_t prefix_len, bool stable, uint8_t flags);
+	void refresh_on_mesh_prefix(struct in6_addr *addr, uint8_t prefix_len, bool stable, uint8_t flags, bool isLocal);
 
 public:
 	static bool setup_property_supported_by_class(const std::string& prop_name);

--- a/src/wpanctl/tool-cmd-config-gateway.c
+++ b/src/wpanctl/tool-cmd-config-gateway.c
@@ -44,6 +44,7 @@ static const arg_list_item_t config_gateway_option_list[] = {
 	{'v', "valid-lifetime", "seconds",
 	 "Set the valid lifetime (Default: infinite)"},
 	{'d', "default", NULL, "Indicates that we can be a default route"},
+	{'P', "priority", NULL, "(>0 for high, 0 for medium, <0 for low) Assign route priority"},
 	{0}
 };
 
@@ -57,6 +58,10 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 	DBusMessage *reply = NULL;
 	DBusError error;
 	dbus_bool_t defaultRoute = FALSE;
+	dbus_bool_t preferred = TRUE;
+	dbus_bool_t slaac = TRUE;
+	dbus_bool_t onMesh = TRUE;
+	int16_t priority = 0;
 	uint32_t preferredLifetime = 0xFFFFFFFF;
 	uint32_t validLifetime = 0xFFFFFFFF;
 	const char* prefix = NULL;
@@ -74,11 +79,12 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 			{"preferred-lifetime", required_argument, 0, 'p'},
 			{"valid-lifetime", required_argument, 0, 'v'},
 			{"default", no_argument, 0, 'd'},
+			{"priority", required_argument, 0, 'P'},
 			{0, 0, 0, 0}
 		};
 
 		int option_index = 0;
-		c = getopt_long(argc, argv, "ht:p:v:d", long_options,
+		c = getopt_long(argc, argv, "ht:p:v:dP:", long_options,
 				&option_index);
 
 		if (c == -1)
@@ -107,6 +113,9 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 			validLifetime = (uint32_t) strtol(optarg, NULL, 0);
 			break;
 
+		case 'P':
+			priority = (int16_t) strtol(optarg, NULL, 0);
+			break;
 		}
 	}
 
@@ -217,6 +226,10 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 16,
 		    DBUS_TYPE_UINT32, &preferredLifetime,
 		    DBUS_TYPE_UINT32, &validLifetime,
+			DBUS_TYPE_BOOLEAN, &preferred,
+			DBUS_TYPE_BOOLEAN, &slaac,
+			DBUS_TYPE_BOOLEAN, &onMesh,
+			DBUS_TYPE_INT16, &priority,
 		    DBUS_TYPE_INVALID
 		);
 

--- a/src/wpantund/Makefile.am
+++ b/src/wpantund/Makefile.am
@@ -67,6 +67,7 @@ wpantund_SOURCES = \
 	RunawayResetBackoffManager.h \
 	NCPInstanceBase-NetInterface.cpp \
 	NCPInstanceBase-Addresses.cpp \
+	NCPInstanceBase-Prefixes.cpp \
 	NCPInstanceBase-AsyncIO.cpp \
 	NCPTypes.h \
 	NCPTypes.cpp \

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -73,6 +73,12 @@ public:
 		ROUTE_HIGH_PREFERENCE = 1,
 	};
 
+	enum OnMeshPrefixPriority {
+		PREFIX_LOW_PREFRENCE = -1,
+		PREFIX_MEDIUM_PREFERENCE = 0,
+		PREFIX_HIGH_PREFERENCE = 1,
+	};
+
 public:
 	// ========================================================================
 	// Static Functions
@@ -143,6 +149,10 @@ public:
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,
+		bool preferred,
+		bool slaac,
+		bool onMesh,
+		OnMeshPrefixPriority priority,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 

--- a/src/wpantund/NCPInstanceBase-Prefixes.cpp
+++ b/src/wpantund/NCPInstanceBase-Prefixes.cpp
@@ -1,0 +1,62 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+#include "NCPInstanceBase.h"
+#include "tunnel.h"
+#include <syslog.h>
+#include <errno.h>
+#include "nlpt.h"
+#include <algorithm>
+#include "socket-utils.h"
+#include "SuperSocket.h"
+
+using namespace nl;
+using namespace wpantund;
+
+void
+NCPInstanceBase::add_prefix(const struct in6_addr &address, uint32_t valid_lifetime, uint32_t preferred_lifetime, uint8_t flags)
+{
+	GlobalAddressEntry entry = GlobalAddressEntry();
+
+	if (mLocalPrefixes.count(address)) {
+		syslog(LOG_INFO, "Updating IPv6 prefix...");
+		entry = mLocalPrefixes[address];
+	} else {
+		syslog(LOG_INFO, "Adding IPv6 prefix...");
+		mLocalPrefixes.insert(std::pair<struct in6_addr, GlobalAddressEntry>(address, entry));
+	}
+
+	entry.mValidLifetime = valid_lifetime;
+	entry.mPreferredLifetime = preferred_lifetime;
+	entry.mValidLifetimeExpiration = ((valid_lifetime == UINT32_MAX)
+		? TIME_DISTANT_FUTURE
+		: time_get_monotonic() + valid_lifetime
+	);
+	entry.mPreferredLifetimeExpiration = ((valid_lifetime == UINT32_MAX)
+		? TIME_DISTANT_FUTURE
+		: time_get_monotonic() + preferred_lifetime
+	);
+    entry.mFlags = flags;
+	mLocalPrefixes[address] = entry;
+}

--- a/src/wpantund/NCPInstanceBase-Prefixes.cpp
+++ b/src/wpantund/NCPInstanceBase-Prefixes.cpp
@@ -39,12 +39,12 @@ NCPInstanceBase::add_prefix(const struct in6_addr &address, uint32_t valid_lifet
 {
 	GlobalAddressEntry entry = GlobalAddressEntry();
 
-	if (mLocalPrefixes.count(address)) {
+	if (mOnMeshPrefixes.count(address)) {
 		syslog(LOG_INFO, "Updating IPv6 prefix...");
-		entry = mLocalPrefixes[address];
+		entry = mOnMeshPrefixes[address];
 	} else {
 		syslog(LOG_INFO, "Adding IPv6 prefix...");
-		mLocalPrefixes.insert(std::pair<struct in6_addr, GlobalAddressEntry>(address, entry));
+		mOnMeshPrefixes.insert(std::pair<struct in6_addr, GlobalAddressEntry>(address, entry));
 	}
 
 	entry.mValidLifetime = valid_lifetime;
@@ -57,6 +57,6 @@ NCPInstanceBase::add_prefix(const struct in6_addr &address, uint32_t valid_lifet
 		? TIME_DISTANT_FUTURE
 		: time_get_monotonic() + preferred_lifetime
 	);
-    entry.mFlags = flags;
-	mLocalPrefixes[address] = entry;
+	entry.mFlags = flags;
+	mOnMeshPrefixes[address] = entry;
 }

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -444,8 +444,9 @@ NCPInstanceBase::property_get_value(
 		std::map<struct in6_addr, GlobalAddressEntry>::const_iterator it;
 		static const char flag_lookup[] = "ppPSDCRM";
 		char address_string[INET6_ADDRSTRLEN];
-		for ( it = mLocalPrefixes.begin();
-			  it != mLocalPrefixes.end();
+
+		for ( it = mOnMeshPrefixes.begin();
+			  it != mOnMeshPrefixes.end();
 			  it++ ) {
 			inet_ntop(AF_INET6,	&it->first,	address_string, sizeof(address_string));
 			result.push_back(std::string(address_string) + "  " + flags_to_string(it->second.mFlags, flag_lookup).c_str());

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -266,6 +266,8 @@ NCPInstanceBase::get_supported_property_keys(void) const
 	properties.insert(kWPANTUNDProperty_IPv6LinkLocalAddress);
 	properties.insert(kWPANTUNDProperty_IPv6AllAddresses);
 
+	properties.insert(kWPANTUNDProperty_ThreadOnMeshPrefixes);
+
 	properties.insert(kWPANTUNDProperty_DaemonAutoAssociateAfterReset);
 	properties.insert(kWPANTUNDProperty_DaemonAutoDeepSleep);
 	properties.insert(kWPANTUNDProperty_DaemonReadyForHostSleep);
@@ -436,6 +438,19 @@ NCPInstanceBase::property_get_value(
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NetworkNodeType)) {
 		cb(0, boost::any(node_type_to_string(mNodeType)));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadOnMeshPrefixes)) {
+		std::list<std::string> result;
+		std::map<struct in6_addr, GlobalAddressEntry>::const_iterator it;
+		static const char flag_lookup[] = "ppPSDCRM";
+		char address_string[INET6_ADDRSTRLEN];
+		for ( it = mLocalPrefixes.begin();
+			  it != mLocalPrefixes.end();
+			  it++ ) {
+			inet_ntop(AF_INET6,	&it->first,	address_string, sizeof(address_string));
+			result.push_back(std::string(address_string) + "  " + flags_to_string(it->second.mFlags, flag_lookup).c_str());
+		}
+		cb(0, boost::any(result));
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6AllAddresses)
 		|| strcaseequal(key.c_str(), kWPANTUNDProperty_DebugIPv6GlobalIPAddressList)

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -136,10 +136,17 @@ public:
 
 public:
 	// ========================================================================
+	// MARK: On Mesh Prefix Management
+
+	void add_prefix(const struct in6_addr &address, uint32_t valid_lifetime = UINT32_MAX, uint32_t preferred_lifetime = UINT32_MAX, uint8_t flags = 0);
+
+public:
+	// ========================================================================
 	// MARK: Global Address Management
 
 
 	void add_address(const struct in6_addr &address, uint8_t prefix = 64, uint32_t valid_lifetime = UINT32_MAX, uint32_t preferred_lifetime = UINT32_MAX);
+
 	void remove_address(const struct in6_addr &address);
 
 	void refresh_global_addresses(void);
@@ -154,6 +161,7 @@ public:
 	bool lookup_address_for_prefix(struct in6_addr *address, const struct in6_addr &prefix, int prefix_len_in_bits = 64);
 
 	int join_multicast_group(const std::string &group_name);
+
 
 public:
 	// ========================================================================
@@ -238,6 +246,7 @@ protected:
 	struct nlpt mDriverToNCPPumpPT;
 
 	std::map<struct in6_addr, GlobalAddressEntry> mGlobalAddresses;
+	std::map<struct in6_addr, GlobalAddressEntry> mLocalPrefixes;
 
 	IPv6PacketMatcherRule mCommissioningRule;
 	IPv6PacketMatcher mInsecureFirewall;

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -146,7 +146,6 @@ public:
 
 
 	void add_address(const struct in6_addr &address, uint8_t prefix = 64, uint32_t valid_lifetime = UINT32_MAX, uint32_t preferred_lifetime = UINT32_MAX);
-
 	void remove_address(const struct in6_addr &address);
 
 	void refresh_global_addresses(void);
@@ -161,7 +160,6 @@ public:
 	bool lookup_address_for_prefix(struct in6_addr *address, const struct in6_addr &prefix, int prefix_len_in_bits = 64);
 
 	int join_multicast_group(const std::string &group_name);
-
 
 public:
 	// ========================================================================
@@ -246,7 +244,7 @@ protected:
 	struct nlpt mDriverToNCPPumpPT;
 
 	std::map<struct in6_addr, GlobalAddressEntry> mGlobalAddresses;
-	std::map<struct in6_addr, GlobalAddressEntry> mLocalPrefixes;
+	std::map<struct in6_addr, GlobalAddressEntry> mOnMeshPrefixes;
 
 	IPv6PacketMatcherRule mCommissioningRule;
 	IPv6PacketMatcher mInsecureFirewall;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -101,6 +101,7 @@
 #define kWPANTUNDProperty_ThreadCommissionerEnabled             "Thread:Commissioner:Enabled"
 #define kWPANTUNDProperty_ThreadDeviceMode                      "Thread:DeviceMode"
 #define kWPANTUNDProperty_ThreadOffMeshRoutes                   "Thread:OffMeshRoutes"
+#define kWPANTUNDProperty_ThreadOnMeshPrefixes                  "Thread:OnMeshPrefixes"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"


### PR DESCRIPTION
- add a property named "Thread:OnMeshPrefixes" which indicates the information about gateway (prefix, flags, and priority).
- add "priority" for configured prefix.
- provide "flags" (preferred, slaac, onMesh) for OT border router setting