### PR TITLE
Add support for MLE discover scan

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -163,6 +163,16 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_discover_scan_start_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_discover_scan_stop_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 	DBusHandlerResult interface_energy_scan_start_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -66,6 +66,8 @@
 
 #define WPANTUND_IF_CMD_NET_SCAN_START        "NetScanStart"
 #define WPANTUND_IF_CMD_NET_SCAN_STOP         "NetScanStop"
+#define WPANTUND_IF_CMD_DISCOVER_SCAN_START   "DiscoverScanStart"
+#define WPANTUND_IF_CMD_DISCOVER_SCAN_STOP    "DiscoverScanStop"
 #define WPANTUND_IF_SIGNAL_NET_SCAN_BEACON    "NetScanBeacon"
 
 #define WPANTUND_IF_CMD_ENERGY_SCAN_START     "EnergyScanStart"

--- a/src/ncp-spinel/SpinelNCPTaskScan.h
+++ b/src/ncp-spinel/SpinelNCPTaskScan.h
@@ -35,6 +35,7 @@ public:
 	enum ScanType {
 		kScanTypeNet = 0,
 		kScanTypeEnergy,
+		kScanTypeDiscover,
 	};
 
 	enum {
@@ -46,7 +47,10 @@ public:
 		CallbackWithStatusArg1 cb,
 		uint32_t channel_mask,
 		uint16_t channel_scan_period = kDefaultScanPeriod,   // per channel in ms
-		ScanType scan_type = kScanTypeNet
+		ScanType scan_type = kScanTypeNet,
+		bool joiner_flag = false,          // Scan for joiner only devices (used in discover scan).
+		bool enable_filtering = false,     // Enable scan result filtering (used in discover scan).
+		uint16_t pan_id_filter = 0xffff    // PANID used for filtering, 0xFFFF to disable (used in discover scan).
 	);
 	virtual int vprocess_event(int event, va_list args);
 	virtual void finish(int status, const boost::any& value = boost::any());
@@ -56,6 +60,11 @@ private:
 	uint8_t mChannelMaskLen;
 	uint16_t mScanPeriod;  // per channel
 	ScanType mScanType;
+	bool mJoinerFlag;
+	bool mEnablerFiltering;
+	uint16_t mPanId;
+	bool mShouldInterfaceDown;
+
 };
 
 }; // namespace wpantund

--- a/src/wpanctl/tool-cmd-scan.c
+++ b/src/wpanctl/tool-cmd-scan.c
@@ -36,6 +36,10 @@ static const arg_list_item_t scan_option_list[] = {
 	{'t', "timeout", "ms", "Set timeout period"},
 	{'c', "channel", "channel", "Set the desired channel"},
 	{'e', "energy", NULL, "Perform an energy scan"},
+	{'d', "discover", NULL, "Perform a MLE discover scan"},
+	{'j', "joiner-only", NULL, "Scan for joiner only devices (used in discover scan)"},
+	{'f', "enable-filtering", NULL, "Enable scan result filtering (used in discover scan)"},
+	{'p', "panid-filtering", NULL, "PANID used for filtering, 0xFFFF to disable (used in discover scan)"},
 	{0}
 };
 
@@ -172,6 +176,7 @@ int tool_cmd_scan(int argc, char *argv[])
 	int ret = 0;
 	int c;
 	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	const char *method_name;
 	DBusConnection* connection = NULL;
 	DBusMessage *message = NULL;
 	DBusMessage *reply = NULL;
@@ -179,6 +184,10 @@ int tool_cmd_scan(int argc, char *argv[])
 	DBusError error;
 	int32_t scan_period = 0;
 	uint32_t channel_mask = 0;
+	bool discover_scan = false;
+	dbus_bool_t joiner_flag = FALSE;
+	dbus_bool_t enable_filtering = FALSE;
+	uint16_t pan_id_filter = 0xffff;
 
 	dbus_error_init(&error);
 
@@ -190,11 +199,15 @@ int tool_cmd_scan(int argc, char *argv[])
 			{"timeout", required_argument, 0, 't'},
 			{"channel", required_argument, 0, 'c'},
 			{"energy", no_argument, 0, 'e'},
+			{"discover", no_argument, 0, 'd'},
+			{"joiner-only", no_argument, 0, 'j'},
+			{"enable-filtering", no_argument, 0, 'f'},
+			{"panid-filtering", required_argument, 0, 'p'},
 			{0, 0, 0, 0}
 		};
 
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hc:t:e", long_options,
+		c = getopt_long(argc, argv, "hc:t:edjfp:", long_options,
 				&option_index);
 
 		if (c == -1)
@@ -217,6 +230,22 @@ int tool_cmd_scan(int argc, char *argv[])
 
 		case 'e':
 			sEnergyScan = true;
+			break;
+
+		case 'd':
+			discover_scan = true;
+			break;
+
+		case 'j':
+			joiner_flag = TRUE;
+			break;
+
+		case 'f':
+			enable_filtering = TRUE;
+			break;
+
+		case 'p':
+			pan_id_filter = strtol(optarg, NULL, 0);
 			break;
 		}
 	}
@@ -279,11 +308,21 @@ int tool_cmd_scan(int argc, char *argv[])
 			gInterfaceName
 		);
 
+		if (sEnergyScan) {
+			method_name = WPANTUND_IF_CMD_ENERGY_SCAN_START;
+		} else {
+			if (discover_scan) {
+				method_name = WPANTUND_IF_CMD_DISCOVER_SCAN_START;
+			} else {
+				method_name = WPANTUND_IF_CMD_NET_SCAN_START;
+			}
+		}
+
 		message = dbus_message_new_method_call(
 			interface_dbus_name,
 			path,
 			WPANTUND_DBUS_APIv1_INTERFACE,
-			sEnergyScan? WPANTUND_IF_CMD_ENERGY_SCAN_START : WPANTUND_IF_CMD_NET_SCAN_START
+			method_name
 		);
 
 		dbus_message_append_args(
@@ -291,6 +330,16 @@ int tool_cmd_scan(int argc, char *argv[])
 			DBUS_TYPE_UINT32, &channel_mask,
 			DBUS_TYPE_INVALID
 		);
+
+		if (discover_scan) {
+			dbus_message_append_args(
+				message,
+				DBUS_TYPE_BOOLEAN, &joiner_flag,
+				DBUS_TYPE_BOOLEAN, &enable_filtering,
+				DBUS_TYPE_UINT16, &pan_id_filter,
+				DBUS_TYPE_INVALID
+			);
+		}
 
 		print_scan_header();
 
@@ -318,7 +367,7 @@ int tool_cmd_scan(int argc, char *argv[])
 
 		reply = dbus_pending_call_steal_reply(pending);
 
-		require(reply!=NULL, bail);
+		require(reply != NULL, bail);
 
 
 		dbus_message_iter_init(reply, &iter);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -212,4 +212,11 @@
 #define kWPANTUNDValueMapKey_NetworkTopology_MleFrameCounter    "MleFrameCounter"
 #define kWPANTUNDValueMapKey_NetworkTopology_IsChild            "IsChild"
 
+#define kWPANTUNDValueMapKey_Scan_Period                        "Scan:Period"
+#define kWPANTUNDValueMapKey_Scan_ChannelMask                   "Scan:ChannelMask"
+#define kWPANTUNDValueMapKey_Scan_Discover                      "Scan:Discover"
+#define kWPANTUNDValueMapKey_Scan_JoinerFalg                    "Scan:JoinerFlag"
+#define kWPANTUNDValueMapKey_Scan_EnableFiltering               "Scan:EnableFiltering"
+#define kWPANTUNDValueMapKey_Scan_PANIDFilter                   "Scan:PANID"
+
 #endif


### PR DESCRIPTION
This commit includes the following changes: It updates the `TaskScan`
implementation to add support for the discovery scan in addition
energy and network scan operations It also adds a new dbus method for
MLE discovery scan. The wpanctl "scan" command is  updated to add
options for the new discover scan ("scan -d" to start a discovery
scan).