### PR TITLE
Adding support for prop insert/remove value 

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v0.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v0.cpp
@@ -277,7 +277,7 @@ DBusIPCAPI_v0::status_response_helper(
 			&dict
 		);
 
-		value = interface->get_property(kWPANTUNDProperty_NCPState);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPState);
 
 		if (!value.empty()) {
 			ncp_state_string = any_to_string(value);
@@ -292,78 +292,78 @@ DBusIPCAPI_v0::status_response_helper(
 
 		if (ncp_state_is_commissioned(ncp_state))
 		{
-			value = interface->get_property(kWPANTUNDProperty_NetworkName);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkName);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkName, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkXPANID);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkXPANID);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkXPANID, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkPANID);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkPANID);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkPANID, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NCPChannel);
+			value = interface->property_get_value(kWPANTUNDProperty_NCPChannel);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NCPChannel, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6LinkLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6LinkLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6LinkLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6MeshLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalPrefix);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalPrefix);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6MeshLocalPrefix, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_NetworkAllowingJoin);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_NetworkAllowingJoin);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_NetworkAllowingJoin, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkNodeType);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkNodeType);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkNodeType, value);
 			}
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_DaemonEnabled);
+		value = interface->property_get_value(kWPANTUNDProperty_DaemonEnabled);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_DaemonEnabled, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_NCPVersion);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPVersion);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_NCPVersion, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_DaemonVersion);
+		value = interface->property_get_value(kWPANTUNDProperty_DaemonVersion);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_DaemonVersion, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_NCPHardwareAddress);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPHardwareAddress);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_NCPHardwareAddress, value);
 		}
@@ -496,7 +496,7 @@ DBusIPCAPI_v0::interface_form_handler(
 
 	{	// The mesh local prefix can be set by setting it before forming.
 		boost::any value;
-		value = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalPrefix);
+		value = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalPrefix);
 		if (!value.empty()) {
 			options[kWPANTUNDProperty_IPv6MeshLocalPrefix] = value;
 		}
@@ -847,7 +847,7 @@ DBusIPCAPI_v0::interface_get_prop_handler(
 	}
 
 	dbus_message_ref(message);
-	interface->get_property(property_key,
+	interface->property_get_value(property_key,
 							boost::bind(&DBusIPCAPI_v0::CallbackWithStatusArg1_Helper, this,
 										_1, _2, message));
 
@@ -883,7 +883,7 @@ DBusIPCAPI_v0::interface_set_prop_handler(
 	}
 
 	dbus_message_ref(message);
-	interface->set_property(
+	interface->property_set_value(
 		property_key,
 		property_value,
 		boost::bind(&DBusIPCAPI_v0::CallbackWithStatus_Helper, this, _1,
@@ -921,7 +921,7 @@ DBusIPCAPI_v0::interface_status_handler(
 	dbus_message_ref(message);
 
 	NCPState ncp_state = UNINITIALIZED;
-	boost::any value(interface->get_property(kWPANTUNDProperty_NCPState));
+	boost::any value(interface->property_get_value(kWPANTUNDProperty_NCPState));
 
 	if (!value.empty()) {
 		ncp_state = string_to_ncp_state(any_to_string(value));
@@ -1344,7 +1344,7 @@ DBusIPCAPI_v0::ncp_state_changed(NCPControlInterface* interface)
 	std::string ncp_state_str;
 	const char* ncp_state_cstr = kWPANTUNDStateUninitialized;
 
-	value = interface->get_property(kWPANTUNDProperty_NCPState);
+	value = interface->property_get_value(kWPANTUNDProperty_NCPState);
 
 	if (!value.empty()) {
 		ncp_state_str = any_to_string(value);
@@ -1382,25 +1382,25 @@ DBusIPCAPI_v0::ncp_state_changed(NCPControlInterface* interface)
 	    &dict
 	    );
 
-	append_dict_entry(&dict, kWPANTUNDProperty_DaemonEnabled, interface->get_property(kWPANTUNDProperty_DaemonEnabled));
+	append_dict_entry(&dict, kWPANTUNDProperty_DaemonEnabled, interface->property_get_value(kWPANTUNDProperty_DaemonEnabled));
 
 	if (ncp_state_is_commissioned(ncp_state)) {
 		ipc_append_network_properties(&dict,
 	                              interface->get_current_network_instance());
-		boost::any prefix = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalPrefix);
+		boost::any prefix = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalPrefix);
 		if (!prefix.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_IPv6MeshLocalPrefix, prefix);
 		}
 
-		prefix = interface->get_property(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
+		prefix = interface->property_get_value(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
 		if (!prefix.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress, prefix);
 		}
 
-		append_dict_entry(&dict, kWPANTUNDProperty_NetworkNodeType, interface->get_property(kWPANTUNDProperty_NetworkNodeType));
+		append_dict_entry(&dict, kWPANTUNDProperty_NetworkNodeType, interface->property_get_value(kWPANTUNDProperty_NetworkNodeType));
 
 		if (ncp_state >= ASSOCIATED) {
-			boost::any networkKey = interface->get_property(kWPANTUNDProperty_NetworkKey);
+			boost::any networkKey = interface->property_get_value(kWPANTUNDProperty_NetworkKey);
 			if (!networkKey.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkKey, networkKey);
 			}
@@ -1503,7 +1503,7 @@ DBusIPCAPI_v0::property_changed(NCPControlInterface* interface,const std::string
 	}
 
 	if (key == kWPANTUNDProperty_NestLabs_NetworkWakeRemaining) {
-		uint8_t data = static_cast<uint8_t>(any_to_int(interface->get_property(kWPANTUNDProperty_NestLabs_NetworkWakeData)));
+		uint8_t data = static_cast<uint8_t>(any_to_int(interface->property_get_value(kWPANTUNDProperty_NestLabs_NetworkWakeData)));
 		net_wake_event(interface, data, any_to_int(value));
 	} else if (key == kWPANTUNDProperty_DaemonReadyForHostSleep) {
 		if (any_to_bool(value)) {

--- a/src/ipc-dbus/DBusIPCAPI_v0.h
+++ b/src/ipc-dbus/DBusIPCAPI_v0.h
@@ -142,6 +142,14 @@ private:
 		NCPControlInterface* interface,
 		DBusMessage *        message
 	);
+	DBusHandlerResult interface_insert_prop_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+	DBusHandlerResult interface_remove_prop_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
 	DBusHandlerResult interface_reset_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message

--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -426,7 +426,7 @@ DBusIPCAPI_v1::status_response_helper(
 			&dict
 		);
 
-		value = interface->get_property(kWPANTUNDProperty_NCPState);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPState);
 
 		if (!value.empty()) {
 			ncp_state_string = any_to_string(value);
@@ -439,84 +439,84 @@ DBusIPCAPI_v1::status_response_helper(
 						  DBUS_TYPE_STRING,
 						  &ncp_state_cstr);
 
-		value = interface->get_property(kWPANTUNDProperty_DaemonEnabled);
+		value = interface->property_get_value(kWPANTUNDProperty_DaemonEnabled);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_DaemonEnabled, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_NCPVersion);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPVersion);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_NCPVersion, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_DaemonVersion);
+		value = interface->property_get_value(kWPANTUNDProperty_DaemonVersion);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_DaemonVersion, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_ConfigNCPDriverName);
+		value = interface->property_get_value(kWPANTUNDProperty_ConfigNCPDriverName);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_ConfigNCPDriverName, value);
 		}
 
-		value = interface->get_property(kWPANTUNDProperty_NCPHardwareAddress);
+		value = interface->property_get_value(kWPANTUNDProperty_NCPHardwareAddress);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_NCPHardwareAddress, value);
 		}
 
 		if (ncp_state_is_commissioned(ncp_state))
 		{
-			value = interface->get_property(kWPANTUNDProperty_NCPChannel);
+			value = interface->property_get_value(kWPANTUNDProperty_NCPChannel);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NCPChannel, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkNodeType);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkNodeType);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkNodeType, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkName);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkName);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkName, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkXPANID);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkXPANID);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkXPANID, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NetworkPANID);
+			value = interface->property_get_value(kWPANTUNDProperty_NetworkPANID);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NetworkPANID, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6LinkLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6LinkLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6LinkLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6MeshLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_IPv6MeshLocalPrefix);
+			value = interface->property_get_value(kWPANTUNDProperty_IPv6MeshLocalPrefix);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_IPv6MeshLocalPrefix, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_LegacyMeshLocalAddress, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix, value);
 			}
 
-			value = interface->get_property(kWPANTUNDProperty_NestLabs_NetworkAllowingJoin);
+			value = interface->property_get_value(kWPANTUNDProperty_NestLabs_NetworkAllowingJoin);
 			if (!value.empty()) {
 				append_dict_entry(&dict, kWPANTUNDProperty_NestLabs_NetworkAllowingJoin, value);
 			}
@@ -584,7 +584,7 @@ DBusIPCAPI_v1::interface_status_handler(
 	dbus_message_ref(message);
 
 	NCPState ncp_state = UNINITIALIZED;
-	boost::any value(interface->get_property(kWPANTUNDProperty_NCPState));
+	boost::any value(interface->property_get_value(kWPANTUNDProperty_NCPState));
 
 	if (!value.empty()) {
 		ncp_state = string_to_ncp_state(any_to_string(value));
@@ -839,7 +839,7 @@ DBusIPCAPI_v1::interface_get_prop_handler(
 
 	dbus_message_ref(message);
 
-	interface->get_property(
+	interface->property_get_value(
 		property_key,
 		boost::bind(
 			&DBusIPCAPI_v1::CallbackWithStatusArg1_Helper,
@@ -882,7 +882,7 @@ DBusIPCAPI_v1::interface_set_prop_handler(
 
 	dbus_message_ref(message);
 
-	interface->set_property(
+	interface->property_set_value(
 		property_key,
 		property_value,
 		boost::bind(

--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -143,12 +143,23 @@ private:
 		DBusMessage *        message
 	);
 
-	DBusHandlerResult interface_get_prop_handler(
+	DBusHandlerResult interface_prop_get_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message
 	);
 
-	DBusHandlerResult interface_set_prop_handler(
+	DBusHandlerResult interface_prop_set_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_prop_insert_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+
+	DBusHandlerResult interface_prop_remove_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message
 	);

--- a/src/ipc-dbus/wpan-dbus-v0.h
+++ b/src/ipc-dbus/wpan-dbus-v0.h
@@ -84,6 +84,8 @@
 
 #define WPAN_IFACE_CMD_GET_PROP         "GetProp"
 #define WPAN_IFACE_CMD_SET_PROP         "SetProp"
+#define WPAN_IFACE_CMD_INSERT_PROP      "InsertProp"
+#define WPAN_IFACE_CMD_REMOVE_PROP      "RemoveProp"
 
 
 #define WPAN_IFACE_PROTOCOL_TCPUDP      0xFF

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -76,9 +76,11 @@
 
 #define WPANTUND_IF_CMD_PROP_GET              "PropGet"
 #define WPANTUND_IF_CMD_PROP_SET              "PropSet"
+#define WPANTUND_IF_CMD_PROP_INSERT           "PropInsert"
+#define WPANTUND_IF_CMD_PROP_REMOVE           "PropRemove"
 #define WPANTUND_IF_SIGNAL_PROP_CHANGED       "PropChanged"
 
-#define WPANTUND_IF_CMD_JOINER_ADD             "JoinerAdd"
+#define WPANTUND_IF_CMD_JOINER_ADD            "JoinerAdd"
 
 // ============================================================================
 // NestLabs Internal API Interface

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -59,7 +59,7 @@ DummyNCPControlInterface::DummyNCPControlInterface(DummyNCPInstance* instance_po
 void
 DummyNCPControlInterface::join(
 	const ValueMap& options,
-    CallbackWithStatus cb
+	CallbackWithStatus cb
 ) {
 	// TODO: Writeme!
 	cb(kWPANTUNDStatus_FeatureNotImplemented);
@@ -68,7 +68,7 @@ DummyNCPControlInterface::join(
 void
 DummyNCPControlInterface::form(
 	const ValueMap& options,
-    CallbackWithStatus cb
+	CallbackWithStatus cb
 ) {
 
 	// TODO: Writeme!
@@ -180,11 +180,11 @@ DummyNCPControlInterface::joiner_add(
 
 void
 DummyNCPControlInterface::permit_join(
-    int seconds,
-    uint8_t traffic_type,
-    in_port_t traffic_port,
-    bool network_wide,
-    CallbackWithStatus cb
+	int seconds,
+	uint8_t traffic_type,
+	in_port_t traffic_port,
+	bool network_wide,
+	CallbackWithStatus cb
 )
 {
 	// TODO: Writeme!
@@ -193,16 +193,16 @@ DummyNCPControlInterface::permit_join(
 
 void
 DummyNCPControlInterface::netscan_start(
-    const ValueMap& options,
-    CallbackWithStatus cb
+	const ValueMap& options,
+	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented); // TODO: Start network scan
 }
 
 void
 DummyNCPControlInterface::mfg(
-    const std::string& mfg_command,
-    CallbackWithStatusArg1 cb
+	const std::string& mfg_command,
+	CallbackWithStatusArg1 cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented, 0); // TODO: Start mfg run
 }
@@ -215,8 +215,8 @@ DummyNCPControlInterface::netscan_stop(CallbackWithStatus cb)
 
 void
 DummyNCPControlInterface::energyscan_start(
-    const ValueMap& options,
-    CallbackWithStatus cb
+	const ValueMap& options,
+	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);
 }
@@ -263,9 +263,9 @@ DummyNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
 
 void
 DummyNCPControlInterface::property_get_value(
-    const std::string& in_key, CallbackWithStatusArg1 cb
-    )
-{
+	const std::string& in_key,
+	CallbackWithStatusArg1 cb
+) {
 	if (!mNCPInstance->is_initializing_ncp()) {
 		syslog(LOG_INFO, "property_get_value: key: \"%s\"", in_key.c_str());
 	}
@@ -274,12 +274,10 @@ DummyNCPControlInterface::property_get_value(
 
 void
 DummyNCPControlInterface::property_set_value(
-    const std::string&                      key,
-    const boost::any&                       value,
-    CallbackWithStatus      cb
-    )
-{
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
 	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
 	mNCPInstance->property_set_value(key, value, cb);
-
 }

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -262,24 +262,24 @@ DummyNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
 // MARK: -
 
 void
-DummyNCPControlInterface::get_property(
+DummyNCPControlInterface::property_get_value(
     const std::string& in_key, CallbackWithStatusArg1 cb
     )
 {
 	if (!mNCPInstance->is_initializing_ncp()) {
-		syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+		syslog(LOG_INFO, "property_get_value: key: \"%s\"", in_key.c_str());
 	}
-	mNCPInstance->get_property(in_key, cb);
+	mNCPInstance->property_get_value(in_key, cb);
 }
 
 void
-DummyNCPControlInterface::set_property(
+DummyNCPControlInterface::property_set_value(
     const std::string&                      key,
     const boost::any&                       value,
     CallbackWithStatus      cb
     )
 {
-	syslog(LOG_INFO, "set_property: key: \"%s\"", key.c_str());
-	mNCPInstance->set_property(key, value, cb);
+	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
+	mNCPInstance->property_set_value(key, value, cb);
 
 }

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -281,3 +281,23 @@ DummyNCPControlInterface::property_set_value(
 	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
 	mNCPInstance->property_set_value(key, value, cb);
 }
+
+void
+DummyNCPControlInterface::property_insert_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_INFO, "property_insert_value: key: \"%s\"", key.c_str());
+	mNCPInstance->property_insert_value(key, value, cb);
+}
+
+void
+DummyNCPControlInterface::property_remove_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_INFO, "property_remove_value: key: \"%s\"", key.c_str());
+	mNCPInstance->property_remove_value(key, value, cb);
+}

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -47,43 +47,77 @@ public:
 
 	virtual void join(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	);
 
 	virtual void form(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	);
 
-	virtual void leave(CallbackWithStatus cb = NilReturn());
-	virtual void attach(CallbackWithStatus cb = NilReturn());
-	virtual void begin_low_power(CallbackWithStatus cb = NilReturn());
+	virtual void leave(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void netscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
-	virtual void netscan_stop(CallbackWithStatus cb = NilReturn());
+	virtual void attach(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
-	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn());
+	virtual void begin_low_power(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
+	virtual void netscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void begin_net_wake(uint8_t data, uint32_t flags, CallbackWithStatus cb = NilReturn());
-	virtual void reset(CallbackWithStatus cb = NilReturn());
+	virtual void netscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void energyscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void energyscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void begin_net_wake(
+		uint8_t data,
+		uint32_t flags,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void reset(
+		CallbackWithStatus cb = NilReturn()
+	);
+
 	virtual void permit_join(
-	    int seconds = 15 * 60,
-	    uint8_t commissioning_traffic_type = 0xFF,
-	    in_port_t commissioning_traffic_port = 0,
-	    bool network_wide = false,
-	    CallbackWithStatus      cb = NilReturn());
+		int seconds = 15 * 60,
+		uint8_t commissioning_traffic_type = 0xFF,
+		in_port_t commissioning_traffic_port = 0,
+		bool network_wide = false,
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void refresh_state(CallbackWithStatus cb = NilReturn());
+	virtual void refresh_state(
+		CallbackWithStatus cb = NilReturn()
+	);
 
 	virtual void property_get_value(
-	    const std::string& key, CallbackWithStatusArg1 cb);
+		const std::string& key,
+		CallbackWithStatusArg1 cb
+	);
+
 	virtual void property_set_value(
-	    const std::string&                      key,
-	    const boost::any&                       value,
-	    CallbackWithStatus      cb);
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,
@@ -117,16 +151,30 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
-	virtual void data_poll(CallbackWithStatus cb = NilReturn());
-	virtual void host_did_wake(CallbackWithStatus cb = NilReturn());
+	virtual void data_poll(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual std::string get_name();
+	virtual void host_did_wake(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual std::string get_name(void);
 
 	virtual NCPInstance& get_ncp_instance(void);
 
-	virtual void pcap_to_fd(int fd, CallbackWithStatus cb = NilReturn());
+	virtual void pcap_to_fd(int fd,
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void pcap_terminate(CallbackWithStatus cb = NilReturn());
+	virtual void pcap_terminate(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void mfg(
+		const std::string& mfg_command,
+		CallbackWithStatusArg1 cb = NilReturn()
+	);
 
 private:
 

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -118,6 +118,18 @@ public:
 		CallbackWithStatus cb
 	);
 
+	virtual void property_insert_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
+	virtual void property_remove_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -78,9 +78,9 @@ public:
 
 	virtual void refresh_state(CallbackWithStatus cb = NilReturn());
 
-	virtual void get_property(
+	virtual void property_get_value(
 	    const std::string& key, CallbackWithStatusArg1 cb);
-	virtual void set_property(
+	virtual void property_set_value(
 	    const std::string&                      key,
 	    const boost::any&                       value,
 	    CallbackWithStatus      cb);

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -622,25 +622,25 @@ SpinelNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
 // MARK: -
 
 void
-SpinelNCPControlInterface::get_property(
+SpinelNCPControlInterface::property_get_value(
     const std::string& in_key, CallbackWithStatusArg1 cb
     )
 {
 	if (!mNCPInstance->is_initializing_ncp()) {
-		syslog(LOG_INFO, "get_property: key: \"%s\"", in_key.c_str());
+		syslog(LOG_INFO, "property_get_value: key: \"%s\"", in_key.c_str());
 	}
-	mNCPInstance->get_property(in_key, cb);
+	mNCPInstance->property_get_value(in_key, cb);
 }
 
 void
-SpinelNCPControlInterface::set_property(
+SpinelNCPControlInterface::property_set_value(
     const std::string&                      key,
     const boost::any&                       value,
     CallbackWithStatus      cb
     )
 {
-	syslog(LOG_INFO, "set_property: key: \"%s\"", key.c_str());
-	mNCPInstance->set_property(key, value, cb);
+	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
+	mNCPInstance->property_set_value(key, value, cb);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -616,8 +616,6 @@ SpinelNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
 	cb(kWPANTUNDStatus_Ok);
 }
 
-
-
 // ----------------------------------------------------------------------------
 // MARK: -
 
@@ -638,7 +636,24 @@ SpinelNCPControlInterface::property_set_value(
 	mNCPInstance->property_set_value(key, value, cb);
 }
 
-<<<<<<< HEAD
+void
+SpinelNCPControlInterface::property_insert_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	mNCPInstance->property_insert_value(key, value, cb);
+}
+
+void
+SpinelNCPControlInterface::property_remove_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	mNCPInstance->property_remove_value(key, value, cb);
+}
+
 // ----------------------------------------------------------------------------
 // MARK: -
 
@@ -685,6 +700,3 @@ SpinelNCPControlInterface::convert_external_route_priority_to_flags(ExternalRout
 
 	return flags;
 }
-=======
-
->>>>>>> Fix spacing/alignment and use tab for indentation

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -70,7 +70,7 @@ SpinelNCPControlInterface::SpinelNCPControlInterface(SpinelNCPInstance* instance
 void
 SpinelNCPControlInterface::join(
 	const ValueMap& options,
-    CallbackWithStatus cb
+	CallbackWithStatus cb
 ) {
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
 		new SpinelNCPTaskJoin(
@@ -84,7 +84,7 @@ SpinelNCPControlInterface::join(
 void
 SpinelNCPControlInterface::form(
 	const ValueMap& options,
-    CallbackWithStatus cb
+	CallbackWithStatus cb
 ) {
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
 		new SpinelNCPTaskForm(
@@ -379,12 +379,12 @@ bail:
 
 void
 SpinelNCPControlInterface::permit_join(
-    int seconds,
-    uint8_t traffic_type,
-    in_port_t traffic_port,
-    bool network_wide,
-    CallbackWithStatus cb
-    )
+	int seconds,
+	uint8_t traffic_type,
+	in_port_t traffic_port,
+	bool network_wide,
+	CallbackWithStatus cb
+	)
 {
 	SpinelNCPTaskSendCommand::Factory factory(mNCPInstance);
 	bool should_update_steering_data = false;
@@ -466,8 +466,8 @@ bail:
 
 void
 SpinelNCPControlInterface::netscan_start(
-    const ValueMap& options,
-    CallbackWithStatus cb
+	const ValueMap& options,
+	CallbackWithStatus cb
 ) {
 	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
 	SpinelNCPTaskScan::ScanType scan_type;
@@ -532,8 +532,8 @@ SpinelNCPControlInterface::netscan_stop(CallbackWithStatus cb)
 
 void
 SpinelNCPControlInterface::energyscan_start(
-    const ValueMap& options,
-    CallbackWithStatus cb
+	const ValueMap& options,
+	CallbackWithStatus cb
 ) {
 	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
 
@@ -565,8 +565,8 @@ SpinelNCPControlInterface::get_name() {
 
 void
 SpinelNCPControlInterface::mfg(
-    const std::string& mfg_command,
-    CallbackWithStatusArg1 cb
+	const std::string& mfg_command,
+	CallbackWithStatusArg1 cb
 ) {
 	mNCPInstance->start_new_task(
 		SpinelNCPTaskSendCommand::Factory(mNCPInstance)
@@ -623,26 +623,22 @@ SpinelNCPControlInterface::pcap_terminate(CallbackWithStatus cb)
 
 void
 SpinelNCPControlInterface::property_get_value(
-    const std::string& in_key, CallbackWithStatusArg1 cb
-    )
-{
-	if (!mNCPInstance->is_initializing_ncp()) {
-		syslog(LOG_INFO, "property_get_value: key: \"%s\"", in_key.c_str());
-	}
+	const std::string& in_key,
+	CallbackWithStatusArg1 cb
+) {
 	mNCPInstance->property_get_value(in_key, cb);
 }
 
 void
 SpinelNCPControlInterface::property_set_value(
-    const std::string&                      key,
-    const boost::any&                       value,
-    CallbackWithStatus      cb
-    )
-{
-	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
 	mNCPInstance->property_set_value(key, value, cb);
 }
 
+<<<<<<< HEAD
 // ----------------------------------------------------------------------------
 // MARK: -
 
@@ -689,3 +685,6 @@ SpinelNCPControlInterface::convert_external_route_priority_to_flags(ExternalRout
 
 	return flags;
 }
+=======
+
+>>>>>>> Fix spacing/alignment and use tab for indentation

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -119,6 +119,18 @@ public:
 		CallbackWithStatus cb
 	);
 
+	virtual void property_insert_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
+	virtual void property_remove_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -77,9 +77,9 @@ public:
 
 	virtual void refresh_state(CallbackWithStatus cb = NilReturn());
 
-	virtual void get_property(
+	virtual void property_get_value(
 	    const std::string& key, CallbackWithStatusArg1 cb);
-	virtual void set_property(
+	virtual void property_set_value(
 	    const std::string&                      key,
 	    const boost::any&                       value,
 	    CallbackWithStatus      cb);

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -48,41 +48,77 @@ public:
 
 	virtual void join(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	);
 
 	virtual void form(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	);
 
-	virtual void leave(CallbackWithStatus cb = NilReturn());
-	virtual void attach(CallbackWithStatus cb = NilReturn());
-	virtual void begin_low_power(CallbackWithStatus cb = NilReturn());
+	virtual void leave(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void netscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
-	virtual void netscan_stop(CallbackWithStatus cb = NilReturn());
+	virtual void attach(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn());
-	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn());
+	virtual void begin_low_power(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void begin_net_wake(uint8_t data, uint32_t flags, CallbackWithStatus cb = NilReturn());
-	virtual void reset(CallbackWithStatus cb = NilReturn());
+	virtual void netscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void netscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void energyscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void energyscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void begin_net_wake(
+		uint8_t data,
+		uint32_t flags,
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual void reset(
+		CallbackWithStatus cb = NilReturn()
+	);
+
 	virtual void permit_join(
-	    int seconds = 15 * 60,
-	    uint8_t commissioning_traffic_type = 0xFF,
-	    in_port_t commissioning_traffic_port = 0,
-	    bool network_wide = false,
-	    CallbackWithStatus      cb = NilReturn());
+		int seconds = 15 * 60,
+		uint8_t commissioning_traffic_type = 0xFF,
+		in_port_t commissioning_traffic_port = 0,
+		bool network_wide = false,
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void refresh_state(CallbackWithStatus cb = NilReturn());
+	virtual void refresh_state(
+		CallbackWithStatus cb = NilReturn()
+	);
 
 	virtual void property_get_value(
-	    const std::string& key, CallbackWithStatusArg1 cb);
+		const std::string& key,
+		CallbackWithStatusArg1 cb
+	);
+
 	virtual void property_set_value(
-	    const std::string&                      key,
-	    const boost::any&                       value,
-	    CallbackWithStatus      cb);
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	);
+
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,
@@ -116,26 +152,38 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
-	virtual void data_poll(CallbackWithStatus cb = NilReturn());
-	virtual void host_did_wake(CallbackWithStatus cb = NilReturn());
+	virtual void data_poll(
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual std::string get_name();
+	virtual void host_did_wake(
+		CallbackWithStatus cb = NilReturn()
+	);
+
+	virtual std::string get_name(void);
 
 	virtual NCPInstance& get_ncp_instance(void);
 
-	virtual void pcap_to_fd(int fd, CallbackWithStatus cb = NilReturn());
+	virtual void pcap_to_fd(int fd,
+		CallbackWithStatus cb = NilReturn()
+	);
 
-	virtual void pcap_terminate(CallbackWithStatus cb = NilReturn());
+	virtual void pcap_terminate(
+		CallbackWithStatus cb = NilReturn()
+	);
 
 	/******************* NCPMfgInterface_v1 ********************/
-	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
+	virtual void mfg(
+		const std::string& mfg_command,
+		CallbackWithStatusArg1 cb = NilReturn()
+	);
 
 	static ExternalRoutePriority convert_flags_to_external_route_priority(uint8_t flags);
 	static uint8_t convert_external_route_priority_to_flags(ExternalRoutePriority priority);
 
 private:
 
-	SpinelNCPInstance* mNCPInstance;
+	SpinelNCPInstance *mNCPInstance;
 
 };
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -182,7 +182,7 @@ SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 		for(iter = settings.begin(); iter != settings.end(); iter++) {
 			if (!NCPInstanceBase::setup_property_supported_by_class(iter->first)) {
 				status = static_cast<NCPControlInterface&>(get_control_interface())
-					.set_property(iter->first, iter->second);
+					.property_set_value(iter->first, iter->second);
 
 				if (status != 0) {
 					syslog(LOG_WARNING, "Attempt to set property \"%s\" failed with err %d", iter->first.c_str(), status);
@@ -456,7 +456,7 @@ unpack_thread_off_mesh_routes(const uint8_t *data_in, spinel_size_t data_len, bo
 }
 
 void
-SpinelNCPInstance::get_property(
+SpinelNCPInstance::property_get_value(
 	const std::string& key,
 	CallbackWithStatusArg1 cb
 ) {
@@ -763,20 +763,20 @@ SpinelNCPInstance::get_property(
 		if (cntr_key != 0) {
 			SIMPLE_SPINEL_GET(cntr_key, SPINEL_DATATYPE_UINT32_S);
 		} else {
-			NCPInstanceBase::get_property(key, cb);
+			NCPInstanceBase::property_get_value(key, cb);
 		}
 	} else {
-		NCPInstanceBase::get_property(key, cb);
+		NCPInstanceBase::property_get_value(key, cb);
 	}
 }
 
 void
-SpinelNCPInstance::set_property(
+SpinelNCPInstance::property_set_value(
 	const std::string& key,
 	const boost::any& value,
 	CallbackWithStatus cb
 ) {
-	syslog(LOG_INFO, "set_property: key: \"%s\"", key.c_str());
+	syslog(LOG_INFO, "property_set_value: key: \"%s\"", key.c_str());
 
 	// If we are disabled, then the only property we
 	// are allowed to set is kWPANTUNDProperty_DaemonEnabled.
@@ -1175,18 +1175,18 @@ SpinelNCPInstance::set_property(
 					);
 
 		} else {
-			NCPInstanceBase::set_property(key, value, cb);
+			NCPInstanceBase::property_set_value(key, value, cb);
 		}
 
 	} catch (const boost::bad_any_cast &x) {
 		// We will get a bad_any_cast exception if the property is of
 		// the wrong type.
-		syslog(LOG_ERR,"set_property: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		syslog(LOG_ERR,"property_set_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
 		cb(kWPANTUNDStatus_InvalidArgument);
 	} catch (const std::invalid_argument &x) {
 		// We will get a bad_any_cast exception if the property is of
 		// the wrong type.
-		syslog(LOG_ERR,"set_property: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		syslog(LOG_ERR,"property_set_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
 		cb(kWPANTUNDStatus_InvalidArgument);
 	}
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -460,6 +460,9 @@ SpinelNCPInstance::property_get_value(
 	const std::string& key,
 	CallbackWithStatusArg1 cb
 ) {
+	if (!is_initializing_ncp()) {
+		syslog(LOG_INFO, "property_get_value: key: \"%s\"", key.c_str());
+	}
 
 #define SIMPLE_SPINEL_GET(prop__, type__)                                \
 	start_new_task(SpinelNCPTaskSendCommand::Factory(this)               \
@@ -1189,7 +1192,57 @@ SpinelNCPInstance::property_set_value(
 		syslog(LOG_ERR,"property_set_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
 		cb(kWPANTUNDStatus_InvalidArgument);
 	}
+}
 
+void
+SpinelNCPInstance::property_insert_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_INFO, "property_insert_value: key: \"%s\"", key.c_str());
+
+	if (!mEnabled) {
+		cb(kWPANTUNDStatus_InvalidWhenDisabled);
+		return;
+	}
+
+	try {
+		NCPInstanceBase::property_insert_value(key, value, cb);
+	} catch (const boost::bad_any_cast &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_insert_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	} catch (const std::invalid_argument &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_insert_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	}
+}
+
+void
+SpinelNCPInstance::property_remove_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_INFO, "property_remove_value: key: \"%s\"", key.c_str());
+
+	try {
+		NCPInstanceBase::property_remove_value(key, value, cb);
+	} catch (const boost::bad_any_cast &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_remove_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	} catch (const std::invalid_argument &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_remove_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	}
 }
 
 void

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -155,16 +155,10 @@ public:
 
 	virtual std::set<std::string> get_supported_property_keys()const;
 
-	virtual void property_get_value(
-	    const std::string& key,
-	    CallbackWithStatusArg1 cb
-	);
-
-	virtual void property_set_value(
-	    const std::string& key,
-	    const boost::any& value,
-	    CallbackWithStatus cb
-	);
+	virtual void property_get_value(const std::string& key, CallbackWithStatusArg1 cb);
+	virtual void property_set_value(const std::string& key, const boost::any& value, CallbackWithStatus cb);
+	virtual void property_insert_value(const std::string& key, const boost::any& value, CallbackWithStatus cb);
+	virtual void property_remove_value(const std::string& key, const boost::any& value, CallbackWithStatus cb);
 
 	virtual cms_t get_ms_to_next_event(void);
 

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -155,12 +155,12 @@ public:
 
 	virtual std::set<std::string> get_supported_property_keys()const;
 
-	virtual void get_property(
+	virtual void property_get_value(
 	    const std::string& key,
 	    CallbackWithStatusArg1 cb
 	);
 
-	virtual void set_property(
+	virtual void property_set_value(
 	    const std::string& key,
 	    const boost::any& value,
 	    CallbackWithStatus cb

--- a/src/wpanctl/Makefile.am
+++ b/src/wpanctl/Makefile.am
@@ -47,6 +47,8 @@ wpanctl_SOURCES = \
 	tool-cmd-reset.c \
 	tool-cmd-getprop.c \
 	tool-cmd-setprop.c \
+	tool-cmd-insertprop.c \
+	tool-cmd-removeprop.c \
 	tool-cmd-begin-low-power.c \
 	tool-cmd-begin-net-wake.c \
 	tool-cmd-cd.c \
@@ -55,6 +57,7 @@ wpanctl_SOURCES = \
 	tool-cmd-host-did-wake.c \
 	tool-cmd-add-route.c \
 	tool-cmd-remove-route.c \
+	tool-updateprop.c \
 	wpanctl-utils.h \
 	tool-cmd-scan.h \
 	tool-cmd-join.h \
@@ -68,6 +71,8 @@ wpanctl_SOURCES = \
 	tool-cmd-reset.h \
 	tool-cmd-getprop.h \
 	tool-cmd-setprop.h \
+	tool-cmd-insertprop.h \
+	tool-cmd-removeprop.h \
 	tool-cmd-begin-low-power.h \
 	tool-cmd-begin-net-wake.h \
 	tool-cmd-cd.h \
@@ -80,6 +85,7 @@ wpanctl_SOURCES = \
 	tool-cmd-pcap.c \
 	tool-cmd-commissioner.h \
 	tool-cmd-commissioner.c \
+	tool-updateprop.h \
 	$(NULL)
 
 wpanctl_LDADD = \

--- a/src/wpanctl/tool-cmd-insertprop.c
+++ b/src/wpanctl/tool-cmd-insertprop.c
@@ -21,11 +21,11 @@
 #include <config.h>
 #endif
 
-#include "tool-cmd-setprop.h"
+#include "tool-cmd-insertprop.h"
 #include "tool-updateprop.h"
 #include "wpan-dbus-v1.h"
 
-int tool_cmd_setprop(int argc, char* argv[])
+int tool_cmd_insertprop(int argc, char* argv[])
 {
-	return tool_updateprop(WPANTUND_IF_CMD_PROP_SET, argc, argv);
+	return tool_updateprop(WPANTUND_IF_CMD_PROP_INSERT, argc, argv);
 }

--- a/src/wpanctl/tool-cmd-insertprop.h
+++ b/src/wpanctl/tool-cmd-insertprop.h
@@ -17,15 +17,11 @@
  *
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
+#ifndef WPANCTL_TOOL_CMD_INSERTPROP_H
+#define WPANCTL_TOOL_CMD_INSERTPROP_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_insertprop(int argc, char* argv[]);
+
 #endif
-
-#include "tool-cmd-setprop.h"
-#include "tool-updateprop.h"
-#include "wpan-dbus-v1.h"
-
-int tool_cmd_setprop(int argc, char* argv[])
-{
-	return tool_updateprop(WPANTUND_IF_CMD_PROP_SET, argc, argv);
-}

--- a/src/wpanctl/tool-cmd-removeprop.c
+++ b/src/wpanctl/tool-cmd-removeprop.c
@@ -21,11 +21,11 @@
 #include <config.h>
 #endif
 
-#include "tool-cmd-setprop.h"
+#include "tool-cmd-removeprop.h"
 #include "tool-updateprop.h"
 #include "wpan-dbus-v1.h"
 
-int tool_cmd_setprop(int argc, char* argv[])
+int tool_cmd_removeprop(int argc, char* argv[])
 {
-	return tool_updateprop(WPANTUND_IF_CMD_PROP_SET, argc, argv);
+	return tool_updateprop(WPANTUND_IF_CMD_PROP_REMOVE, argc, argv);
 }

--- a/src/wpanctl/tool-cmd-removeprop.h
+++ b/src/wpanctl/tool-cmd-removeprop.h
@@ -17,15 +17,11 @@
  *
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
+#ifndef WPANCTL_TOOL_CMD_REMOVEPROP_H
+#define WPANCTL_TOOL_CMD_REMOVEPROP_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_removeprop(int argc, char* argv[]);
+
 #endif
-
-#include "tool-cmd-setprop.h"
-#include "tool-updateprop.h"
-#include "wpan-dbus-v1.h"
-
-int tool_cmd_setprop(int argc, char* argv[])
-{
-	return tool_updateprop(WPANTUND_IF_CMD_PROP_SET, argc, argv);
-}

--- a/src/wpanctl/tool-updateprop.c
+++ b/src/wpanctl/tool-updateprop.c
@@ -1,0 +1,248 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-updateprop.h"
+#include "assert-macros.h"
+#include "args.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "string-utils.h"
+
+const char updateprop_syntax[] = "[args] <property-name> <property-value>";
+
+static const arg_list_item_t insertprop_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'d', "data", NULL, "Value is binary data (in hex)"},
+	{'s', "string", NULL, "Value is a string"},
+	{'v', "value", "property-value", "Useful when the value starts with a '-'"},
+	{0}
+};
+
+int tool_updateprop(const char *dbus_method_name, int argc, char* argv[])
+{
+	int ret = 0;
+	int c;
+	int timeout = 30 * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	const char* property_name = NULL;
+	char* property_value = NULL;
+
+	enum {
+		kPropertyType_String,
+		kPropertyType_Data,
+	} property_type = kPropertyType_String;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"timeout", required_argument, 0, 't'},
+			{"data", no_argument, 0, 'd'},
+			{"string", no_argument, 0, 's'},
+			{"value", required_argument, 0, 'v'},
+			{0, 0, 0, 0}
+		};
+
+		int option_index = 0;
+		c = getopt_long(argc, argv, "ht:dsv:", long_options,
+				&option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(insertprop_option_list,
+					    argv[0], updateprop_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+
+		case 'd':
+			property_type = kPropertyType_Data;
+			break;
+
+		case 's':
+			property_type = kPropertyType_String;
+			break;
+
+		case 'v':
+			property_value = optarg;
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		if (!property_name) {
+			property_name = argv[optind];
+			optind++;
+		}
+	}
+
+	if (optind < argc) {
+		if (!property_value) {
+			property_value = argv[optind];
+			optind++;
+		}
+	}
+
+	if (optind < argc) {
+		fprintf(stderr,
+			"%s: error: Unexpected extra argument: \"%s\"\n",
+			argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (!property_name) {
+		fprintf(stderr, "%s: error: Missing property name.\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (!property_value) {
+		fprintf(stderr, "%s: error: Missing property value.\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(stderr,
+		        "%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
+		        argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+
+	if (!connection) {
+		dbus_error_free(&error);
+		dbus_error_init(&error);
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	}
+
+	require_string(connection != NULL, bail, error.message);
+
+	{
+		DBusMessageIter iter;
+		DBusMessageIter list_iter;
+		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
+		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
+		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+		if (ret != 0) {
+			print_error_diagnosis(ret);
+			goto bail;
+		}
+		snprintf(path,
+		         sizeof(path),
+		         "%s/%s",
+		         WPANTUND_DBUS_PATH,
+		         gInterfaceName);
+
+		message = dbus_message_new_method_call(
+		    interface_dbus_name,
+		    path,
+		    WPANTUND_DBUS_APIv1_INTERFACE,
+		    dbus_method_name
+		    );
+
+		dbus_message_append_args(
+		    message,
+		    DBUS_TYPE_STRING, &property_name,
+		    DBUS_TYPE_INVALID
+		    );
+
+		if (property_type == kPropertyType_String) {
+			dbus_message_append_args(
+			    message,
+			    DBUS_TYPE_STRING, &property_value,
+			    DBUS_TYPE_INVALID
+			    );
+		} else if (property_type == kPropertyType_Data) {
+			int length = parse_string_into_data((uint8_t*)property_value,
+			                                    strlen(property_value),
+			                                    property_value);
+			dbus_message_append_args(
+			    message,
+			    DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &property_value, length,
+			    DBUS_TYPE_INVALID
+			    );
+		} else {
+			fprintf(stderr, "%s: error: Bad property type\n", argv[0]);
+			ret = ERRORCODE_UNKNOWN;
+			goto bail;
+		}
+
+		reply = dbus_connection_send_with_reply_and_block(
+		    connection,
+		    message,
+		    timeout,
+		    &error
+		    );
+
+		if (!reply) {
+			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+			ret = ERRORCODE_TIMEOUT;
+			goto bail;
+		}
+
+		dbus_message_get_args(reply, &error,
+		                      DBUS_TYPE_INT32, &ret,
+		                      DBUS_TYPE_INVALID
+		                      );
+
+		if (ret) {
+			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+		}
+	}
+
+bail:
+
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-updateprop.h
+++ b/src/wpanctl/tool-updateprop.h
@@ -17,15 +17,11 @@
  *
  */
 
-#if HAVE_CONFIG_H
-#include <config.h>
+#ifndef WPANCTL_TOOL_UPDATEPROP_H
+#define WPANCTL_TOOL_UPDATEPROP_H
+
+#include "wpanctl-utils.h"
+
+int tool_updateprop(const char *dbus_method_name, int argc, char* argv[]);
+
 #endif
-
-#include "tool-cmd-setprop.h"
-#include "tool-updateprop.h"
-#include "wpan-dbus-v1.h"
-
-int tool_cmd_setprop(int argc, char* argv[])
-{
-	return tool_updateprop(WPANTUND_IF_CMD_PROP_SET, argc, argv);
-}

--- a/src/wpanctl/wpanctl-cmds.h
+++ b/src/wpanctl/wpanctl-cmds.h
@@ -35,6 +35,8 @@
 #include "tool-cmd-host-did-wake.h"
 #include "tool-cmd-getprop.h"
 #include "tool-cmd-setprop.h"
+#include "tool-cmd-insertprop.h"
+#include "tool-cmd-removeprop.h"
 #include "tool-cmd-cd.h"
 #include "tool-cmd-poll.h"
 #include "tool-cmd-config-gateway.h"
@@ -136,16 +138,29 @@
 	}, \
 	{ \
 		"getprop", \
-		"Get a property.", \
+		"Get a property (alias: `get`).", \
 		&tool_cmd_getprop \
 	}, \
 	{ "get", "", &tool_cmd_getprop, 1 }, \
 	{ \
 		"setprop", \
-		"Set a property.", \
+		"Set a property (alias: `set`).", \
 		&tool_cmd_setprop \
 	}, \
 	{ "set", "", &tool_cmd_setprop, 1 }, \
+	{ \
+		"insertprop", \
+		"Insert value in a list-oriented property (alias: `insert`, `add`).", \
+		&tool_cmd_insertprop \
+	}, \
+	{ "insert", "", &tool_cmd_insertprop, 1 }, \
+	{ "add", "", &tool_cmd_insertprop, 1 }, \
+	{ \
+		"removeprop", \
+		"Remove value from a list-oriented property (alias: `remove`).", \
+		&tool_cmd_removeprop \
+	}, \
+	{ "remove", "", &tool_cmd_removeprop, 1 }, \
 	{ \
 		"begin-net-wake", \
 		"Initiate a network wakeup", \

--- a/src/wpantund/NCPControlInterface.cpp
+++ b/src/wpantund/NCPControlInterface.cpp
@@ -86,14 +86,14 @@ struct GetPropertyHelper {
 };
 
 boost::any
-NCPControlInterface::get_property(const std::string& key)
+NCPControlInterface::property_get_value(const std::string& key)
 {
 	// In this function, we want to immediately return the value
-	// for the given key. Since the actual get_property() function
-	// returns the value as a callback, we may not actually
-	// be able to do this. What we do here is give a callback
-	// object that contains a pointer to our return value.
-	// After we call get_property(), we then zero out that
+	// for the given key. Since the actual property_get_value()
+	// function returns the value as a callback, we may not
+	// actually be able to do this. What we do here is give a
+	// callback object that contains a pointer to our return value.
+	// After we call property_get_value(), we then zero out that
 	// pointer. For properties which get updated immediately, our
 	// return value will be updated automatically. For properties
 	// which can't be fetched immediately, we return an empty value.
@@ -106,7 +106,7 @@ NCPControlInterface::get_property(const std::string& key)
 
 	helper->dest = &ret;
 	helper->didFire = &didFire;
-	get_property(key, boost::bind(&GetPropertyHelper::operator(),
+	property_get_value(key, boost::bind(&GetPropertyHelper::operator(),
 	                              helper,
 	                              _1,
 	                              _2));
@@ -119,7 +119,7 @@ NCPControlInterface::get_property(const std::string& key)
 
 std::string
 NCPControlInterface::get_name() {
-	return boost::any_cast<std::string>(get_property(kWPANTUNDProperty_ConfigTUNInterfaceName));
+	return boost::any_cast<std::string>(property_get_value(kWPANTUNDProperty_ConfigTUNInterfaceName));
 }
 
 
@@ -215,14 +215,14 @@ struct SetPropertyHelper {
 #define kWPANTUNDPropertyGlobalIPAddressList       "GlobalIPAddressList"
 
 int
-NCPControlInterface::set_property(const std::string& key, const boost::any& value)
+NCPControlInterface::property_set_value(const std::string& key, const boost::any& value)
 {
 	// In this function, we want to immediately return the status
-	// of the set operation. Since the actual set_property() function
-	// returns the status as a callback, we may not actually
-	// be able to do this. What we do here is give a callback
-	// object that contains a pointer to our return value.
-	// After we call set_property(), we then zero out that
+	// of the set operation. Since the actual property_set_value()
+	// function returns the status as a callback, we may not
+	// actually be able to do this. What we do here is give a
+	// callback object that contains a pointer to our return value.
+	// After we call property_set_value(), we then zero out that
 	// pointer. For properties which get updated immediately, our
 	// return value will be updated automatically. For properties
 	// which can't be fetched immediately, we return -EINPROGRESS.
@@ -235,7 +235,7 @@ NCPControlInterface::set_property(const std::string& key, const boost::any& valu
 
 	helper->dest = &ret;
 	helper->didFire = &didFire;
-	set_property(key, value, boost::bind(&SetPropertyHelper::operator(),
+	property_set_value(key, value, boost::bind(&SetPropertyHelper::operator(),
 	                              helper,
 	                              _1));
 	if (!didFire) {

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -109,12 +109,12 @@ public:
 
 	virtual void refresh_state(CallbackWithStatus cb = NilReturn()) = 0;
 
-	virtual void get_property(
+	virtual void property_get_value(
 	    const std::string& key,
 	    CallbackWithStatusArg1 cb
 	) = 0;
 
-	virtual void set_property(
+	virtual void property_set_value(
 	    const std::string& key,
 	    const boost::any& value,
 	    CallbackWithStatus cb
@@ -215,9 +215,9 @@ public:
 	// ========================================================================
 	// Convenience methods
 
-	boost::any get_property(const std::string& key);
+	boost::any property_get_value(const std::string& key);
 
-	int set_property(const std::string& key, const boost::any& value);
+	int property_set_value(const std::string& key, const boost::any& value);
 
 	virtual std::string get_name();
 

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -92,32 +92,40 @@ public:
 
 	virtual void join(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 	virtual void form(
 		const ValueMap& options,
-	    CallbackWithStatus cb = NilReturn()
+		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
-	virtual void leave(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void leave(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 	//! Deprecated. Set kWPANTUNDProperty_InterfaceUp to true instead.
-	virtual void attach(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void attach(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void reset(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void reset(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void refresh_state(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void refresh_state(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 	virtual void property_get_value(
-	    const std::string& key,
-	    CallbackWithStatusArg1 cb
+		const std::string& key,
+		CallbackWithStatusArg1 cb
 	) = 0;
 
 	virtual void property_set_value(
-	    const std::string& key,
-	    const boost::any& value,
-	    CallbackWithStatus cb
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
 	) = 0;
 
 	virtual void add_on_mesh_prefix(
@@ -166,9 +174,14 @@ public:
 	// ========================================================================
 	// Scan-related Member Functions
 
-	virtual void netscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void netscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void netscan_stop(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void netscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 	boost::signals2::signal<void(const WPAN::NetworkInstance&)> mOnNetScanBeacon;
 
@@ -176,9 +189,14 @@ public:
 	// ========================================================================
 	// EnergyScan-related Member Functions
 
-	virtual void energyscan_start(const ValueMap& options, CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void energyscan_start(
+		const ValueMap& options,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void energyscan_stop(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void energyscan_stop(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 	boost::signals2::signal<void(const EnergyScanResultEntry&)> mOnEnergyScanResult;
 
@@ -186,11 +204,17 @@ public:
 	// ========================================================================
 	// Power-related Member Functions
 
-	virtual void begin_low_power(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void begin_low_power(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void host_did_wake(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void host_did_wake(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
-	virtual void data_poll(CallbackWithStatus cb = NilReturn()) = 0;
+	virtual void data_poll(
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 
 public:
@@ -204,11 +228,11 @@ public:
 	) = 0;
 
 	virtual void permit_join(
-	    int seconds = 15 * 60,
-	    uint8_t commissioning_traffic_type = 0xFF,
-	    in_port_t commissioning_traffic_port = 0,
-	    bool network_wide = false,
-	    CallbackWithStatus cb = NilReturn()
+		int seconds = 15 * 60,
+		uint8_t commissioning_traffic_type = 0xFF,
+		in_port_t commissioning_traffic_port = 0,
+		bool network_wide = false,
+		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 public:
@@ -219,7 +243,7 @@ public:
 
 	int property_set_value(const std::string& key, const boost::any& value);
 
-	virtual std::string get_name();
+	virtual std::string get_name(void);
 
 public:
 	// ========================================================================

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -128,6 +128,18 @@ public:
 		CallbackWithStatus cb
 	) = 0;
 
+	virtual void property_insert_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	) = 0;
+
+	virtual void property_remove_value(
+		const std::string& key,
+		const boost::any& value,
+		CallbackWithStatus cb
+	) = 0;
+
 	virtual void add_on_mesh_prefix(
 		const struct in6_addr *prefix,
 		bool defaultRoute,

--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -45,16 +45,16 @@ NCPInstanceBase::link_state_changed(bool isUp, bool isRunning)
 	// we should autoconnect or not.
 
 	if (isUp) {
-		set_property(kWPANTUNDProperty_DaemonAutoAssociateAfterReset, true);
+		property_set_value(kWPANTUNDProperty_DaemonAutoAssociateAfterReset, true);
 
 		if (!mEnabled) {
-			set_property(kWPANTUNDProperty_DaemonEnabled, true);
+			property_set_value(kWPANTUNDProperty_DaemonEnabled, true);
 		} else if (get_ncp_state() == COMMISSIONED) {
-			set_property(kWPANTUNDProperty_InterfaceUp, true);
+			property_set_value(kWPANTUNDProperty_InterfaceUp, true);
 		}
 	} else {
-		set_property(kWPANTUNDProperty_DaemonAutoAssociateAfterReset, false);
-		set_property(kWPANTUNDProperty_InterfaceUp, false);
+		property_set_value(kWPANTUNDProperty_DaemonAutoAssociateAfterReset, false);
+		property_set_value(kWPANTUNDProperty_InterfaceUp, false);
 	}
 }
 

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -301,7 +301,7 @@ NCPInstanceBase::get_supported_property_keys() const
 }
 
 void
-NCPInstanceBase::get_property(
+NCPInstanceBase::property_get_value(
 	const std::string& in_key,
 	CallbackWithStatusArg1 cb
 ) {
@@ -487,7 +487,7 @@ NCPInstanceBase::get_property(
 		cb(0, mask_string);
 
 	} else if (StatCollector::is_a_stat_property(key)) {
-		get_stat_collector().get_property(key, cb);
+		get_stat_collector().property_get_value(key, cb);
 
 	} else {
 		cb(kWPANTUNDStatus_PropertyNotFound, boost::any(std::string("Property Not Found")));
@@ -495,7 +495,7 @@ NCPInstanceBase::get_property(
 }
 
 void
-NCPInstanceBase::set_property(
+NCPInstanceBase::property_set_value(
 	const std::string& key,
 	const boost::any& value,
 	CallbackWithStatus cb
@@ -611,23 +611,23 @@ NCPInstanceBase::set_property(
 			cb(0);
 
 		} else if (StatCollector::is_a_stat_property(key)) {
-			get_stat_collector().set_property(key, value, cb);
+			get_stat_collector().property_set_value(key, value, cb);
 
 		} else {
-			syslog(LOG_ERR,"set_property: Unsupported property \"%s\"", key.c_str());
+			syslog(LOG_ERR,"property_set_value: Unsupported property \"%s\"", key.c_str());
 			cb(kWPANTUNDStatus_PropertyNotFound);
 		}
 
 	} catch (const boost::bad_any_cast &x) {
 		// We will get a bad_any_cast exception if the property is of
 		// the wrong type.
-		syslog(LOG_ERR,"set_property: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		syslog(LOG_ERR,"property_set_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
 		cb(kWPANTUNDStatus_InvalidArgument);
 
 	} catch (const std::invalid_argument &x) {
 		// We will get a bad_any_cast exception if the property is of
 		// the wrong type.
-		syslog(LOG_ERR,"set_property: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		syslog(LOG_ERR,"property_set_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
 		cb(kWPANTUNDStatus_InvalidArgument);
 	}
 }

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -640,6 +640,26 @@ NCPInstanceBase::property_set_value(
 }
 
 void
+NCPInstanceBase::property_insert_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_ERR, "property_insert_value: Property not supported or not insert-value capable \"%s\"", key.c_str());
+	cb(kWPANTUNDStatus_PropertyNotFound);
+}
+
+void
+NCPInstanceBase::property_remove_value(
+	const std::string& key,
+	const boost::any& value,
+	CallbackWithStatus cb
+) {
+	syslog(LOG_ERR, "property_remove_value: Property not supported or not remove-value capable \"%s\"", key.c_str());
+	cb(kWPANTUNDStatus_PropertyNotFound);
+}
+
+void
 NCPInstanceBase::signal_property_changed(
 	const std::string& key,
 	const boost::any& value

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -213,12 +213,12 @@ public:
 
 	virtual std::set<std::string> get_supported_property_keys()const;
 
-	virtual void get_property(
+	virtual void property_get_value(
 	    const std::string& key,
 	    CallbackWithStatusArg1 cb
 	);
 
-	virtual void set_property(
+	virtual void property_set_value(
 	    const std::string& key,
 	    const boost::any& value,
 		CallbackWithStatus cb = NilReturn()

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -142,12 +142,12 @@ public:
 	void add_address(const struct in6_addr &address, uint8_t prefix = 64, uint32_t valid_lifetime = UINT32_MAX, uint32_t preferred_lifetime = UINT32_MAX);
 	void remove_address(const struct in6_addr &address);
 
-	void refresh_global_addresses();
+	void refresh_global_addresses(void);
 
-	//! Removes all nonpermanent global address entries
+	//! Removes all non-permanent global address entries
 	void clear_nonpermanent_global_addresses();
 
-	void restore_global_addresses();
+	void restore_global_addresses(void);
 
 	bool is_address_known(const struct in6_addr &address);
 
@@ -213,21 +213,11 @@ public:
 
 	virtual std::set<std::string> get_supported_property_keys()const;
 
-	virtual void property_get_value(
-	    const std::string& key,
-	    CallbackWithStatusArg1 cb
-	);
+	virtual void property_get_value(const std::string& key, CallbackWithStatusArg1 cb);
 
-	virtual void property_set_value(
-	    const std::string& key,
-	    const boost::any& value,
-		CallbackWithStatus cb = NilReturn()
-	);
+	virtual void property_set_value(const std::string& key, const boost::any& value, CallbackWithStatus cb = NilReturn());
 
-	virtual void signal_property_changed(
-	    const std::string& key,
-	    const boost::any& value = boost::any()
-	);
+	virtual void signal_property_changed(const std::string& key, const boost::any& value = boost::any());
 
 	wpantund_status_t set_ncp_version_string(const std::string& version_string);
 

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -217,6 +217,10 @@ public:
 
 	virtual void property_set_value(const std::string& key, const boost::any& value, CallbackWithStatus cb = NilReturn());
 
+	virtual void property_insert_value(const std::string& key, const boost::any& value, CallbackWithStatus cb = NilReturn());
+
+	virtual void property_remove_value(const std::string& key, const boost::any& value, CallbackWithStatus cb = NilReturn());
+
 	virtual void signal_property_changed(const std::string& key, const boost::any& value = boost::any());
 
 	wpantund_status_t set_ncp_version_string(const std::string& version_string);

--- a/src/wpantund/StatCollector.cpp
+++ b/src/wpantund/StatCollector.cpp
@@ -1438,7 +1438,7 @@ StatCollector::get_stat_property(const std::string& key, StringList& output) con
 }
 
 void
-StatCollector::get_property(const std::string& key, CallbackWithStatusArg1 cb)
+StatCollector::property_get_value(const std::string& key, CallbackWithStatusArg1 cb)
 {
 	// First check for AutoLog properties.
 	if (strcaseequal(key.c_str(), kWPANTUNDProperty_StatAutoLog)) {
@@ -1513,7 +1513,7 @@ StatCollector::get_property(const std::string& key, CallbackWithStatusArg1 cb)
 }
 
 void
-StatCollector::set_property(const std::string& key, const boost::any& value, CallbackWithStatus cb)
+StatCollector::property_set_value(const std::string& key, const boost::any& value, CallbackWithStatus cb)
 {
 	int status = kWPANTUNDStatus_Ok;
 

--- a/src/wpantund/StatCollector.h
+++ b/src/wpantund/StatCollector.h
@@ -73,8 +73,8 @@ public:
 
 	static bool is_a_stat_property(const std::string& key);   // returns true if the property key is associated with stat module
 
-	void get_property(const std::string& key, CallbackWithStatusArg1 cb);
-	void set_property(const std::string& key, const boost::any& value, CallbackWithStatus cb);
+	void property_get_value(const std::string& key, CallbackWithStatusArg1 cb);
+	void property_set_value(const std::string& key, const boost::any& value, CallbackWithStatus cb);
 
 	// Methods to inform StatCollector about received/sent packets and state changes
 	void record_inbound_packet(const uint8_t *ipv6_packet);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -111,6 +111,10 @@
 
 #define kWPANTUNDProperty_DebugIPv6GlobalIPAddressList          "Debug:IPv6:GlobalIPAddressList"
 
+#define kWPANTUNDProperty_MACWhitelistEnabled                   "MAC:Whitelist:Enabled"
+#define kWPANTUNDProperty_MACWhitelistEntries                   "MAC:Whitelist:Entries"
+#define kWPANTUNDProperty_MACWhitelistEntriesAsValMap           "MAC:Whitelist:Entries:AsValMap"
+
 #define kWPANTUNDProperty_JamDetectionStatus                    "JamDetection:Status"
 #define kWPANTUNDProperty_JamDetectionEnable                    "JamDetection:Enable"
 #define kWPANTUNDProperty_JamDetectionRssiThreshold             "JamDetection:RssiThreshold"
@@ -133,7 +137,6 @@
 #define kWPANTUNDProperty_NestLabs_NetworkWakeBlacklist         "com.nestlabs.internal:NetworkWake:Blacklist"
 #define kWPANTUNDProperty_NestLabs_HackUseDeepSleepOnLowPower   "com.nestlabs.internal:Hack:UseDeepSleepOnLowPower"
 #define kWPANTUNDProperty_NestLabs_HackAlwaysResetToWake        "com.nestlabs.internal:Hack:AlwaysResetToWake"
-
 
 #define kWPANTUNDProperty_Stat_Prefix                           "Stat:"
 #define kWPANTUNDProperty_StatRX                                "Stat:RX"
@@ -197,6 +200,10 @@
 // ----------------------------------------------------------------------------
 
 // Values for value map keys
+
+#define kWPANTUNDValueMapKey_Whitelist_ExtAddress               "ExtAddress"
+#define kWPANTUNDValueMapKey_Whitelist_Rssi                     "FixedRssi"
+
 #define kWPANTUNDValueMapKey_NetworkTopology_ExtAddress         "ExtAddress"
 #define kWPANTUNDValueMapKey_NetworkTopology_RLOC16             "RLOC16"
 #define kWPANTUNDValueMapKey_NetworkTopology_LinkQualityIn      "LinkQualityIn"

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -922,7 +922,7 @@ main(int argc, char * argv[])
 		// We only expose the interface via IPC after it is
 		// successfully initialized for the first time.
 		if (!interface_added) {
-			const boost::any value = ncp_instance->get_control_interface().get_property(kWPANTUNDProperty_NCPState);
+			const boost::any value = ncp_instance->get_control_interface().property_get_value(kWPANTUNDProperty_NCPState);
 			if ((value.type() == boost::any(std::string()).type())
 			 && (boost::any_cast<std::string>(value) != kWPANTUNDStateUninitialized)
 			) {


### PR DESCRIPTION
Spinel provides support for properties that are list-based. It also defines `VALUE_INSERT` and `VALUE_REMOVE` to insert or remove an element into a list-based property. This turned out to be a very useful model. This PR aims to provide base support for similar functionality in wpantund. 

There are a bunch of seperate commits in this PR:

---
    Rename `get/set_property()` to `property_get/set_value()`.
    
    This commit renames two of `NcpControlInterface` methods and updates
    their use across wpantund source code:
    
    - `property_set_value()` replacing `set_property()`,
    - `property_get_value()` replacing `get_property()`.

---

    Fix spacing/alignment and use tab for indentation
    
    This commit contains no logic change and is cosmetic change only. It
    makes the formating of method declarations in `NCPControlInterface.h`
    and its subclasses under `Dummy and `Spinel` plug-ins consistent. It
    also converts indentations from space to tabs.

---

    Add `property_insert_value()` and `property_remove_value()` definitions
    
    This commit adds the definitions of new `insert_value()` and
    `remove_value()` methods  across all different classes with empty
    implementation.

---

    Add support for "PropInsert" and "PropRemove" in DBus IPC API v1

---

    Add support for "PropInsert" and "PropRemove" in DBus IPC API v0




