### PR TITLE
Make consistent of bash or sh in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,10 +30,10 @@ die() {
 
 	echo " ***************************** "
 
-	[[ $prog == "autoreconf" ]] && cat "$LOGFILE"
+	[ "$prog" == "autoreconf" ] && cat "$LOGFILE"
 
 	echo ""
-	if [[ $# -ge 1 ]]
+	if [ $# -ge 1 ]
 	then echo " *** $prog failed: \"$*\""
 	else echo " *** $prog failed with error code $errcode"
 	fi


### PR DESCRIPTION
header of bootstrap.sh is
```sh
#!/bin/sh
```
However it uses feature `[[` which is of `bash` only. We can either change the header, to remove the dependency on `bash`. I think `sh` is more general. This PR simply removes the usage of `[[`.