### PR TITLE
Update `spinel.h` and `spinel.c` from OpenThread

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -295,7 +295,7 @@ SpinelNCPControlInterface::add_external_route(
 				SPINEL_DATATYPE_BOOL_S
 				SPINEL_DATATYPE_UINT8_S
 			),
-			SPINEL_PROP_THREAD_LOCAL_ROUTES,
+			SPINEL_PROP_THREAD_OFF_MESH_ROUTES,
 			prefix,
 			prefix_len_in_bits,
 			true,
@@ -380,7 +380,7 @@ SpinelNCPControlInterface::remove_external_route(
 				SPINEL_DATATYPE_BOOL_S
 				SPINEL_DATATYPE_UINT8_S
 			),
-			SPINEL_PROP_THREAD_LOCAL_ROUTES,
+			SPINEL_PROP_THREAD_OFF_MESH_ROUTES,
 			prefix,
 			prefix_len_in_bits,
 			true,

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -50,7 +50,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-
+#include <stdbool.h>
 // ----------------------------------------------------------------------------
 // MARK: -
 
@@ -947,6 +947,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_HBO_BLOCK_MAX";
         break;
 
+    case SPINEL_PROP_HOST_POWER_STATE:
+        ret = "PROP_HOST_POWER_STATE";
+        break;
+
     case SPINEL_PROP_STREAM_DEBUG:
         ret = "PROP_STREAM_DEBUG";
         break;
@@ -961,6 +965,14 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 
     case SPINEL_PROP_STREAM_NET_INSECURE:
         ret = "PROP_STREAM_NET_INSECURE";
+        break;
+
+    case SPINEL_PROP_UART_BITRATE:
+        ret = "PROP_UART_BITRATE";
+        break;
+
+    case SPINEL_PROP_UART_XON_XOFF:
+        ret = "PROP_UART_XON_XOFF";
         break;
 
     case SPINEL_PROP_PHY_ENABLED:
@@ -1155,8 +1167,8 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_ON_MESH_NETS";
         break;
 
-    case SPINEL_PROP_THREAD_LOCAL_ROUTES:
-        ret = "PROP_THREAD_LOCAL_ROUTES";
+    case SPINEL_PROP_THREAD_OFF_MESH_ROUTES:
+        ret = "PROP_THREAD_OFF_MESH_ROUTES";
         break;
 
     case SPINEL_PROP_THREAD_ASSISTING_PORTS:
@@ -1168,19 +1180,19 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         break;
 
     case SPINEL_PROP_THREAD_JOINERS:
-        ret = "SPINEL_PROP_THREAD_JOINERS";
+        ret = "PROP_THREAD_JOINERS";
         break;
 
     case SPINEL_PROP_THREAD_COMMISSIONER_ENABLED:
-        ret = "SPINEL_PROP_THREAD_COMMISSIONER_ENABLED";
+        ret = "PROP_THREAD_COMMISSIONER_ENABLED";
         break;
 
     case SPINEL_PROP_THREAD_BA_PROXY_ENABLED:
-        ret = "SPINEL_PROP_THREAD_BA_PROXY_ENABLED";
+        ret = "PROP_THREAD_BA_PROXY_ENABLED";
         break;
 
     case SPINEL_PROP_THREAD_BA_PROXY_STREAM:
-        ret = "SPINEL_PROP_THREAD_BA_PROXY_STREAM";
+        ret = "PROP_THREAD_BA_PROXY_STREAM";
         break;
 
     case SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU:
@@ -1200,19 +1212,19 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         break;
 
     case SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG:
-        ret = "SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG";
+        ret = "PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG";
         break;
 
     case SPINEL_PROP_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING:
-        ret = "SPINEL_PROP_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING";
+        ret = "PROP_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING";
         break;
 
     case SPINEL_PROP_THREAD_DISCOVERY_SCAN_PANID:
-        ret = "SPINEL_PROP_THREAD_DISCOVERY_SCAN_PANID";
+        ret = "PROP_THREAD_DISCOVERY_SCAN_PANID";
         break;
 
     case SPINEL_PROP_THREAD_STEERING_DATA:
-        ret = "SPINEL_PROP_THREAD_STEERING_DATA";
+        ret = "PROP_THREAD_STEERING_DATA";
         break;
 
     case SPINEL_PROP_MAC_WHITELIST:
@@ -1299,12 +1311,192 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_GPIO_STATE_CLEAR";
         break;
 
+    case SPINEL_PROP_CNTR_RESET:
+        ret = "PROP_CNTR_RESET";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_TOTAL:
+        ret = "PROP_CNTR_TX_PKT_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_ACK_REQ:
+        ret = "PROP_CNTR_TX_PKT_ACK_REQ";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_ACKED:
+        ret = "PROP_CNTR_TX_PKT_ACKED";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ:
+        ret = "PROP_CNTR_TX_PKT_NO_ACK_REQ";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_DATA:
+        ret = "PROP_CNTR_TX_PKT_DATA";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_DATA_POLL:
+        ret = "PROP_CNTR_TX_PKT_DATA_POLL";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_BEACON:
+        ret = "PROP_CNTR_TX_PKT_BEACON";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ:
+        ret = "PROP_CNTR_TX_PKT_BEACON_REQ";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_OTHER:
+        ret = "PROP_CNTR_TX_PKT_OTHER";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_RETRY:
+        ret = "PROP_CNTR_TX_PKT_RETRY";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_ERR_CCA:
+        ret = "PROP_CNTR_TX_ERR_CCA";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_UNICAST:
+        ret = "PROP_CNTR_TX_PKT_UNICAST";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_PKT_BROADCAST:
+        ret = "PROP_CNTR_TX_PKT_BROADCAST";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_ERR_ABORT:
+        ret = "PROP_CNTR_TX_ERR_ABORT";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_TOTAL:
+        ret = "PROP_CNTR_RX_PKT_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DATA:
+        ret = "PROP_CNTR_RX_PKT_DATA";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DATA_POLL:
+        ret = "PROP_CNTR_RX_PKT_DATA_POLL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_BEACON:
+        ret = "PROP_CNTR_RX_PKT_BEACON";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ:
+        ret = "PROP_CNTR_RX_PKT_BEACON_REQ";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_OTHER:
+        ret = "PROP_CNTR_RX_PKT_OTHER";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_FILT_WL:
+        ret = "PROP_CNTR_RX_PKT_FILT_WL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_FILT_DA:
+        ret = "PROP_CNTR_RX_PKT_FILT_DA";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_EMPTY:
+        ret = "PROP_CNTR_RX_ERR_EMPTY";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR:
+        ret = "PROP_CNTR_RX_ERR_UKWN_NBR";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR:
+        ret = "PROP_CNTR_RX_ERR_NVLD_SADDR";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_SECURITY:
+        ret = "PROP_CNTR_RX_ERR_SECURITY";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_BAD_FCS:
+        ret = "PROP_CNTR_RX_ERR_BAD_FCS";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_ERR_OTHER:
+        ret = "PROP_CNTR_RX_ERR_OTHER";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_DUP:
+        ret = "PROP_CNTR_RX_PKT_DUP";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_UNICAST:
+        ret = "PROP_CNTR_RX_PKT_UNICAST";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_PKT_BROADCAST:
+        ret = "PROP_CNTR_RX_PKT_BROADCAST";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL:
+        ret = "PROP_CNTR_TX_IP_SEC_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL:
+        ret = "PROP_CNTR_TX_IP_INSEC_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_IP_DROPPED:
+        ret = "PROP_CNTR_TX_IP_DROPPED";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_IP_SEC_TOTAL:
+        ret = "PROP_CNTR_RX_IP_SEC_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_IP_INSEC_TOTAL:
+        ret = "PROP_CNTR_RX_IP_INSEC_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_IP_DROPPED:
+        ret = "PROP_CNTR_RX_IP_DROPPED";
+        break;
+
+    case SPINEL_PROP_CNTR_TX_SPINEL_TOTAL:
+        ret = "PROP_CNTR_TX_SPINEL_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_SPINEL_TOTAL:
+        ret = "PROP_CNTR_RX_SPINEL_TOTAL";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_SPINEL_ERR:
+        ret = "PROP_CNTR_RX_SPINEL_ERR";
+        break;
+
+    case SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID:
+        ret = "PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID";
+        break;
+
+    case SPINEL_PROP_MSG_BUFFER_COUNTERS:
+        ret = "PROP_MSG_BUFFER_COUNTERS";
+        break;
+
+    case SPINEL_PROP_NEST_LEGACY_ULA_PREFIX:
+        ret = "PROP_NEST_LEGACY_ULA_PREFIX";
+        break;
+
+    case SPINEL_PROP_NEST_LEGACY_JOINED_NODE:
+        ret = "PROP_NEST_LEGACY_JOINED_NODE";
+        break;
+
     case SPINEL_PROP_DEBUG_TEST_ASSERT:
-        ret = "SPINEL_PROP_DEBUG_TEST_ASSERT";
+        ret = "PROP_DEBUG_TEST_ASSERT";
         break;
 
     case SPINEL_PROP_DEBUG_NCP_LOG_LEVEL:
-        ret = "SPINEL_PROP_DEBUG_NCP_LOG_LEVEL";
+        ret = "PROP_DEBUG_NCP_LOG_LEVEL";
         break;
 
     default:
@@ -1487,6 +1679,151 @@ const char *spinel_status_to_cstr(spinel_status_t status)
 
     case SPINEL_STATUS_RESET_WATCHDOG:
         ret = "STATUS_RESET_WATCHDOG";
+        break;
+
+    default:
+        break;
+    }
+
+    return ret;
+}
+
+const char *spinel_capability_to_cstr(unsigned int capability)
+{
+    const char *ret = "UNKNOWN";
+
+    switch (capability)
+    {
+    case SPINEL_CAP_LOCK:
+        ret = "CAP_LOCK";
+        break;
+
+    case SPINEL_CAP_NET_SAVE:
+        ret = "CAP_NET_SAVE";
+        break;
+
+    case SPINEL_CAP_HBO:
+        ret = "CAP_HBO";
+        break;
+
+    case SPINEL_CAP_POWER_SAVE:
+        ret = "CAP_POWER_SAVE";
+        break;
+
+    case SPINEL_CAP_COUNTERS:
+        ret = "CAP_COUNTERS";
+        break;
+
+    case SPINEL_CAP_JAM_DETECT:
+        ret = "CAP_JAM_DETECT";
+        break;
+
+    case SPINEL_CAP_PEEK_POKE:
+        ret = "CAP_PEEK_POKE";
+        break;
+
+    case SPINEL_CAP_WRITABLE_RAW_STREAM:
+        ret = "CAP_WRITABLE_RAW_STREAM";
+        break;
+
+    case SPINEL_CAP_GPIO:
+        ret = "CAP_GPIO";
+        break;
+
+    case SPINEL_CAP_TRNG:
+        ret = "CAP_TRNG";
+        break;
+
+    case SPINEL_CAP_CMD_MULTI:
+        ret = "CAP_CMD_MULTI";
+        break;
+
+    case SPINEL_CAP_802_15_4_2003:
+        ret = "CAP_802_15_4_2003";
+        break;
+
+    case SPINEL_CAP_802_15_4_2006:
+        ret = "CAP_802_15_4_2006";
+        break;
+
+    case SPINEL_CAP_802_15_4_2011:
+        ret = "CAP_802_15_4_2011";
+        break;
+
+    case SPINEL_CAP_802_15_4_PIB:
+        ret = "CAP_802_15_4_PIB";
+        break;
+
+    case SPINEL_CAP_802_15_4_2450MHZ_OQPSK:
+        ret = "CAP_802_15_4_2450MHZ_OQPSK";
+        break;
+
+    case SPINEL_CAP_802_15_4_915MHZ_OQPSK:
+        ret = "CAP_802_15_4_915MHZ_OQPSK";
+        break;
+
+    case SPINEL_CAP_802_15_4_868MHZ_OQPSK:
+        ret = "CAP_802_15_4_868MHZ_OQPSK";
+        break;
+
+    case SPINEL_CAP_802_15_4_915MHZ_BPSK:
+        ret = "CAP_802_15_4_915MHZ_BPSK";
+        break;
+
+    case SPINEL_CAP_802_15_4_868MHZ_BPSK:
+        ret = "CAP_802_15_4_868MHZ_BPSK";
+        break;
+
+    case SPINEL_CAP_802_15_4_915MHZ_ASK:
+        ret = "CAP_802_15_4_915MHZ_ASK";
+        break;
+
+    case SPINEL_CAP_802_15_4_868MHZ_ASK:
+        ret = "CAP_802_15_4_868MHZ_ASK";
+        break;
+
+    case SPINEL_CAP_ROLE_ROUTER:
+        ret = "CAP_ROLE_ROUTER";
+        break;
+
+    case SPINEL_CAP_ROLE_SLEEPY:
+        ret = "CAP_ROLE_SLEEPY";
+        break;
+
+    case SPINEL_CAP_NET_THREAD_1_0:
+        ret = "CAP_NET_THREAD_1_0";
+        break;
+
+    case SPINEL_CAP_MAC_WHITELIST:
+        ret = "CAP_MAC_WHITELIST";
+        break;
+
+    case SPINEL_CAP_MAC_RAW:
+        ret = "CAP_MAC_RAW";
+        break;
+
+    case SPINEL_CAP_OOB_STEERING_DATA:
+        ret = "CAP_OOB_STEERING_DATA";
+        break;
+
+    case SPINEL_CAP_THREAD_COMMISSIONER:
+        ret = "CAP_THREAD_COMMISSIONER";
+        break;
+
+    case SPINEL_CAP_THREAD_BA_PROXY:
+        ret = "CAP_THREAD_BA_PROXY";
+        break;
+
+    case SPINEL_CAP_NEST_LEGACY_INTERFACE:
+        ret = "CAP_NEST_LEGACY_INTERFACE";
+        break;
+
+    case SPINEL_CAP_NEST_LEGACY_NET_WAKE:
+        ret = "CAP_NEST_LEGACY_NET_WAKE";
+        break;
+
+    case SPINEL_CAP_NEST_TRANSMIT_HOOK:
+        ret = "CAP_NEST_TRANSMIT_HOOK";
         break;
 
     default:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -190,6 +190,15 @@ typedef enum
     SPINEL_POWER_STATE_ONLINE           = 4,
 } spinel_power_state_t;
 
+typedef enum
+{
+    SPINEL_HOST_POWER_STATE_OFFLINE     = 0,
+    SPINEL_HOST_POWER_STATE_DEEP_SLEEP  = 1,
+    SPINEL_HOST_POWER_STATE_RESERVED    = 2,
+    SPINEL_HOST_POWER_STATE_LOW_POWER   = 3,
+    SPINEL_HOST_POWER_STATE_ONLINE      = 4,
+} spinel_host_power_state_t;
+
 enum
 {
     SPINEL_NET_FLAG_ON_MESH             = (1 << 0),
@@ -399,6 +408,7 @@ typedef enum
     SPINEL_PROP_LOCK                    = 9,        ///< PropLock [b]
     SPINEL_PROP_HBO_MEM_MAX             = 10,       ///< Max offload mem [S]
     SPINEL_PROP_HBO_BLOCK_MAX           = 11,       ///< Max offload block [S]
+    SPINEL_PROP_HOST_POWER_STATE        = 12,       ///< Host MCU power state [C]
 
     SPINEL_PROP_BASE_EXT__BEGIN         = 0x1000,
 
@@ -443,7 +453,7 @@ typedef enum
      * number and flags fields MUST be present, the GPIO name (if present)
      * would be ignored. This command can only be used to modify the
      * configuration of GPIOs which are already exposed---it cannot be used
-     * by the host to add addional GPIOs.
+     * by the host to add additional GPIOs.
      */
     SPINEL_PROP_GPIO_CONFIG             = SPINEL_PROP_BASE_EXT__BEGIN + 0,
 
@@ -715,8 +725,8 @@ typedef enum
                                         = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
                                         = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
-    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
-    SPINEL_PROP_THREAD_LOCAL_ROUTES     = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags) [A(t(6CbC))]
+    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal) [A(t(6CbCb))]
+    SPINEL_PROP_THREAD_OFF_MESH_ROUTES  = SPINEL_PROP_THREAD__BEGIN + 11, ///< array(ipv6prefix,prefixlen,stable,flags,isLocal) [A(t(6CbCb))]
     SPINEL_PROP_THREAD_ASSISTING_PORTS  = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
     SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
                                         = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
@@ -1100,11 +1110,11 @@ typedef enum
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_PKT_DUP         = SPINEL_PROP_CNTR__BEGIN + 114,
 
-    /// The number of unicast packets recived.
+    /// The number of unicast packets received.
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_PKT_UNICAST     = SPINEL_PROP_CNTR__BEGIN + 115,
 
-    /// The number of broadcast packets recived.
+    /// The number of broadcast packets received.
     /** Format: `L` (Read-only) */
     SPINEL_PROP_CNTR_RX_PKT_BROADCAST   = SPINEL_PROP_CNTR__BEGIN + 116,
 
@@ -1165,8 +1175,8 @@ typedef enum
      *      `S`, (MleBuffers)             The number of buffers in the MLE send queue.
      *      `S`, (ArpMessages)            The number of messages in the ARP send queue.
      *      `S`, (ArpBuffers)             The number of buffers in the ARP send queue.
-     *      `S`, (CoapClientMessages)     The number of messages in the CoAP client send queue.
-     *      `S`, (CoapClientBuffers)      The number of buffers in the CoAP client send queue.
+     *      `S`, (CoapMessages)           The number of messages in the CoAP send queue.
+     *      `S`, (CoapBuffers)            The number of buffers in the CoAP send queue.
      */
     SPINEL_PROP_MSG_BUFFER_COUNTERS     = SPINEL_PROP_CNTR__BEGIN + 400,
 
@@ -1313,6 +1323,11 @@ typedef char spinel_datatype_t;
                                         SPINEL_DATATYPE_UTF8_S /* network name */                       \
                                         SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
 
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V2_S                                                        \
+                                        SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                        \
+                                        SPINEL_DATATYPE_DATA_WLEN_S /* steering data */
+
+
 #define SPINEL_MAX_UINT_PACKED          2097151
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len,
@@ -1338,6 +1353,8 @@ SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key
 SPINEL_API_EXTERN const char *spinel_net_role_to_cstr(uint8_t net_role);
 
 SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
+
+SPINEL_API_EXTERN const char *spinel_capability_to_cstr(unsigned int capability);
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit updates the spinel source files from OpenThread at commit
https://github.com/openthread/openthread/commit/9c09577d528bcf89f0197a68b9db775915ebebfd. It also addresses a property name change:

- `THREAD_LOCAL_ROUTES` -> `THREAD_OFF_MESH_ROUTES`.