### PR TITLE
Log NCP capabilities when parsing `SPINEL_PROP_CAPS` response

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1194,6 +1194,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 				break;
 			}
 			capabilities.insert(value);
+			syslog(LOG_INFO, "[-NCP-]: Capability (%s, %d)", spinel_capability_to_cstr(value), value);
 
 			data_ptr += parse_len;
 			data_len -= parse_len;


### PR DESCRIPTION
This commit adds new logs to show what capabilities the NCP is providing (e.g., during initialization when we get the `SPINEL_PROP_CAPS` property).  Helpful for debugging