### PR TITLE
Adding new wpan property "Thread:OffMeshRoutes" and its 'get' support

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -130,6 +130,9 @@ public:
 	/******************* NCPMfgInterface_v1 ********************/
 	virtual void mfg(const std::string& mfg_command, CallbackWithStatusArg1 cb = NilReturn());
 
+	static ExternalRoutePriority convert_flags_to_external_route_priority(uint8_t flags);
+	static uint8_t convert_external_route_priority_to_flags(ExternalRoutePriority priority);
+
 private:
 
 	SpinelNCPInstance* mNCPInstance;

--- a/src/wpantund/NCPControlInterface.cpp
+++ b/src/wpantund/NCPControlInterface.cpp
@@ -46,17 +46,23 @@ using namespace wpantund;
 std::string
 NCPControlInterface::external_route_priority_to_string(ExternalRoutePriority route_priority)
 {
+	const char *ret = "unknown";
+
 	switch(route_priority) {
 		case ROUTE_LOW_PREFRENCE:
-			return std::string("low preference");
+			ret = "low";
+			break;
 
 		case ROUTE_MEDIUM_PREFERENCE:
-			return std::string("Medium (normal) preference");
+			ret = "medium(normal)";
+			break;
 
 		case ROUTE_HIGH_PREFERENCE:
-			return std::string("High preference");
+			ret = "high";
+			break;
 	}
-	return std::string("Unknown route preference");
+
+	return ret;
 }
 
 NCPControlInterface::~NCPControlInterface() {

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -77,7 +77,6 @@ public:
 	// ========================================================================
 	// Static Functions
 
-
 	static std::string external_route_priority_to_string(ExternalRoutePriority route_priority);
 
 public:

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -100,6 +100,7 @@
 #define kWPANTUNDProperty_ThreadPreferredRouterID               "Thread:PreferredRouterID"
 #define kWPANTUNDProperty_ThreadCommissionerEnabled             "Thread:Commissioner:Enabled"
 #define kWPANTUNDProperty_ThreadDeviceMode                      "Thread:DeviceMode"
+#define kWPANTUNDProperty_ThreadOffMeshRoutes                   "Thread:OffMeshRoutes"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"


### PR DESCRIPTION
The wpan property is related to `SPINEL_PROP_THREAD_OFF_MESH_ROUTES`
property.