### PR TITLE
Notes about Docker

### DIFF
--- a/etc/Readme.md
+++ b/etc/Readme.md
@@ -1,10 +1,29 @@
 # Getting started with Docker
 
-1. Install Docker
-1. Run
+1. [Install Docker](https://docs.docker.com/engine/installation/)
+1. Build the Image (from the etc folder)
 
-    ./etc//build-in-docker.sh
+      cd etc
+      docker build -t wpantund .
 
-**Note:** for OSX users, you **will not** be able to share your serial device with the 
+1. Run (from base directory)
+
+      cd ..
+      ./etc/build-in-docker.sh
+
+**Note:** for OSX users, you **will not** be able to share your serial device with the
 container that gets generated. Unfortunately this is due to the limitations of [Xhyve]("https://github.com/mist64/xhyve")
 If you are looking to run `wpantund` as a daemon with real hardware, the vagrant solution [here](https://github.com/openthread/openthread/tree/master/etc/vagrant) is recommended.
+
+1. To save changes and re-use this image later on:
+
+      docker commit abed87d93dc0 nestlabs/wpantund-build
+
+**Note** you can get the installed image name and container name by running these commands
+
+      docker container ls
+      docker image ls
+
+1. To run everything normally thereafter run the following
+
+      docker run -ti --rm nestlabs/wpantund-build

--- a/etc/Readme.md
+++ b/etc/Readme.md
@@ -1,0 +1,10 @@
+# Getting started with Docker
+
+1. Install Docker
+1. Run
+
+    ./etc//build-in-docker.sh
+
+**Note:** for OSX users, you **will not** be able to share your serial device with the 
+container that gets generated. Unfortunately this is due to the limitations of [Xhyve]("https://github.com/mist64/xhyve")
+If you are looking to run `wpantund` as a daemon with real hardware, the vagrant solution [here](https://github.com/openthread/openthread/tree/master/etc/vagrant) is recommended.

--- a/etc/build-in-docker.sh
+++ b/etc/build-in-docker.sh
@@ -21,8 +21,10 @@ DIR="`dirname $0`"
 
 "${DIR}"/run-in-docker.sh -i 'DIR="`pwd`" &&
 mkdir -p /build &&
-cd /build && "${DIR}"/configure --enable-all-restricted-plugins --with-connman --with-readline &&
-make -j `nproc` distcheck AM_DEFAULT_VERBOSITY=1
+cd /build && "${DIR}"/bootstrap.sh &&
+"${DIR}"/configure --sysconfdir=/etc &&
+make -j `nproc` &&
+sudo make install
 ' || exit 1
 
 "${DIR}"/run-in-docker.sh -i 'DIR="`pwd`" &&


### PR DESCRIPTION
I spent some cycles trying to figure out if the Docker setup in /etc/ would have been useful for my hardware testing. Unfortunately not (at least on OS X) I added a Readme so people don't waste their time doing the same. Also the `build-in-docker.sh` was out of date and was not consistent with the other documentation. 

Summary:

Adding notes about the end-to-end process of using Docker.
Updating the `build-in-docker.sh` to run the bootstrap script before configure