### PR TITLE
Fix segment fault when use Ctrl-D to end wpanctl

### DIFF
--- a/src/wpanctl/wpanctl.c
+++ b/src/wpanctl/wpanctl.c
@@ -289,6 +289,13 @@ get_current_prompt()
 void
 process_input_readline(char *l)
 {
+	if (NULL == l)
+	{
+		gRet = ERRORCODE_QUIT;
+		rl_callback_handler_remove();
+		return;
+	}
+
 	process_input_line(l);
 	if (istty) {
 #if HAVE_RL_SET_PROMPT


### PR DESCRIPTION
This PR fixes the segment fault when using Ctrl-D to end **wpanctl**. #170

This is caused by not handling EOF in *readline* handler function.

*See*
[1] http://www.delorie.com/gnu/docs/readline/rlman_41.html