### PR TITLE
Adding support for "peek" and "poke" command in wpantund and wpanctl

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -214,6 +214,16 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_peek_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_poke_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 private:
 	typedef DBusHandlerResult (interface_handler_cb)(
 		NCPControlInterface*,

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -82,6 +82,9 @@
 
 #define WPANTUND_IF_CMD_JOINER_ADD            "JoinerAdd"
 
+#define WPANTUND_IF_CMD_PEEK                  "Peek"
+#define WPANTUND_IF_CMD_POKE                  "Poke"
+
 // ============================================================================
 // NestLabs Internal API Interface
 

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -305,3 +305,15 @@ DummyNCPControlInterface::property_remove_value(
 	syslog(LOG_INFO, "property_remove_value: key: \"%s\"", key.c_str());
 	mNCPInstance->property_remove_value(key, value, cb);
 }
+
+void
+DummyNCPControlInterface::peek(uint32_t address, uint16_t count, CallbackWithStatusArg1 cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented, std::string("No peeking!"));
+}
+
+void
+DummyNCPControlInterface::poke(uint32_t address, Data bytes, CallbackWithStatus cb)
+{
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -175,6 +175,9 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
+	virtual void peek(uint32_t address, uint16_t count,	CallbackWithStatusArg1 cb = NilReturn());
+	virtual void poke(uint32_t address, Data bytes,	CallbackWithStatus cb = NilReturn());
+
 	virtual std::string get_name(void);
 
 	virtual NCPInstance& get_ncp_instance(void);

--- a/src/ncp-spinel/Makefile.am
+++ b/src/ncp-spinel/Makefile.am
@@ -76,6 +76,8 @@ NCP_SOURCES = \
 	SpinelNCPTaskJoin.h \
 	SpinelNCPTaskLeave.cpp \
 	SpinelNCPTaskLeave.h \
+	SpinelNCPTaskPeek.cpp \
+	SpinelNCPTaskPeek.h \
 	SpinelNCPTaskScan.cpp \
 	SpinelNCPTaskScan.h \
 	SpinelNCPTaskSendCommand.cpp \

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -176,6 +176,9 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
+	virtual void peek(uint32_t address, uint16_t count, CallbackWithStatusArg1 cb = NilReturn());
+	virtual void poke(uint32_t address, Data bytes, CallbackWithStatus cb = NilReturn());
+
 	virtual std::string get_name(void);
 
 	virtual NCPInstance& get_ncp_instance(void);

--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -385,6 +385,16 @@ SpinelNCPInstance::driver_to_ncp_pump()
 				syslog(LOG_INFO, "[->NCP] CMD_RESET tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
 			} else if (mOutboundBuffer[1] == SPINEL_CMD_NET_CLEAR) {
 				syslog(LOG_INFO, "[->NCP] CMD_NET_CLEAR tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
+			} else if (mOutboundBuffer[1] == SPINEL_CMD_PEEK) {
+				uint32_t address = 0;
+				uint16_t count = 0;
+				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "CiLS", NULL, NULL, &address, &count);
+				syslog(LOG_INFO, "[->NCP] CMD_PEEK(0x%x,%d) tid:%d", address, count, SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
+			} else if (mOutboundBuffer[1] == SPINEL_CMD_POKE) {
+				uint32_t address = 0;
+				uint16_t count = 0;
+				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "CiLS", NULL, NULL, &address, &count);
+				syslog(LOG_INFO, "[->NCP] CMD_NET_POKE(0x%x,%d) tid:%d", address, count, SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
 			} else {
 				syslog(LOG_INFO, "[->NCP] Spinel command 0x%02X tid:%d", mOutboundBuffer[1], SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
 			}

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2445,6 +2445,23 @@ SpinelNCPInstance::handle_ncp_spinel_callback(unsigned int command, const uint8_
 		}
 		break;
 
+	case SPINEL_CMD_PEEK_RET:
+		{
+			uint32_t address;
+			uint16_t count;
+			spinel_ssize_t ret;
+
+			ret = spinel_datatype_unpack(cmd_data_ptr, cmd_data_len, "CiLS", NULL, NULL, &address, &count);
+
+			__ASSERT_MACROS_check(ret != -1);
+
+			if (ret > 0) {
+				syslog(LOG_INFO, "[NCP->] CMD_PEEK_RET(0x%x,%d) tid:%d", address, count, SPINEL_HEADER_GET_TID(cmd_data_ptr[0]));
+			}
+		}
+		break;
+
+
 	default:
 		break;
 	}

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -95,6 +95,7 @@ class SpinelNCPInstance : public NCPInstanceBase {
 	friend class SpinelNCPTaskForm;
 	friend class SpinelNCPTaskScan;
 	friend class SpinelNCPTaskLeave;
+	friend class SpinelNCPTaskPeek;
 	friend class SpinelNCPTaskSendCommand;
 	friend class SpinelNCPTaskGetNetworkTopology;
 	friend class SpinelNCPTaskGetMsgBufferCounters;

--- a/src/ncp-spinel/SpinelNCPTaskPeek.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskPeek.cpp
@@ -1,0 +1,129 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "assert-macros.h"
+#include <syslog.h>
+#include <errno.h>
+#include "SpinelNCPTaskPeek.h"
+#include "SpinelNCPInstance.h"
+#include "spinel-extra.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+nl::wpantund::SpinelNCPTaskPeek::SpinelNCPTaskPeek(
+	SpinelNCPInstance* instance,
+	CallbackWithStatusArg1 cb,
+	uint32_t address,
+	uint16_t count
+):	SpinelNCPTask(instance, cb), mAddress(address), mCount(count)
+{
+}
+
+int
+nl::wpantund::SpinelNCPTaskPeek::vprocess_event(int event, va_list args)
+{
+	int ret = kWPANTUNDStatus_Failure;
+
+	EH_BEGIN();
+
+	if (!mInstance->mEnabled) {
+		ret = kWPANTUNDStatus_InvalidWhenDisabled;
+		finish(ret);
+		EH_EXIT();
+	}
+
+	if (mInstance->get_ncp_state() == UPGRADING) {
+		ret = kWPANTUNDStatus_InvalidForCurrentState;
+		finish(ret);
+		EH_EXIT();
+	}
+
+	// Wait for a bit to see if the NCP will enter the right state.
+	EH_REQUIRE_WITHIN(
+		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
+		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		on_error
+	);
+
+	// The first event to a task is EVENT_STARTING_TASK. The following
+	// line makes sure that we don't start processing this task
+	// until it is properly scheduled. All tasks immediately receive
+	// the initial `EVENT_STARTING_TASK` event, but further events
+	// will only be received by that task once it is that task's turn
+	// to execute.
+	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
+
+	mNextCommand = SpinelPackData(
+	    SPINEL_FRAME_PACK_CMD(
+	        SPINEL_DATATYPE_UINT32_S   // Address
+	        SPINEL_DATATYPE_UINT16_S   // Count
+	    ),
+	    SPINEL_CMD_PEEK,
+	    mAddress,
+	    mCount
+	);
+
+	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
+
+	ret = mNextCommandRet;
+
+	require_noerr(ret, on_error);
+
+	if (event == EVENT_NCP(SPINEL_CMD_PEEK_RET))
+	{
+		spinel_prop_key_t prop_key = va_arg_small(args, spinel_prop_key_t);
+		const uint8_t *frame_ptr = va_arg(args, const uint8_t*);
+		spinel_size_t frame_len = va_arg_small(args, spinel_size_t);
+		const uint8_t *data_ptr = NULL;
+		spinel_size_t data_len = 0;
+		spinel_ssize_t parsed_len;
+		uint32_t address;
+		uint16_t count;
+
+		parsed_len = spinel_datatype_unpack(frame_ptr, frame_len, "CiLSD", NULL, NULL, &address, &count, &data_ptr, &data_len);
+
+		require(parsed_len > 0, on_error);
+		require(address == mAddress, on_error);
+		require(data_len == mCount, on_error);
+
+		ret = kWPANTUNDStatus_Ok;
+
+		finish(ret, Data(data_ptr, data_len));
+
+		EH_EXIT();
+	}
+
+on_error:
+
+	if (ret == kWPANTUNDStatus_Ok) {
+		ret = kWPANTUNDStatus_Failure;
+	}
+
+	syslog(LOG_ERR, "Peek failed: %d", ret);
+
+	finish(ret);
+
+	EH_END();
+}
+

--- a/src/ncp-spinel/SpinelNCPTaskPeek.h
+++ b/src/ncp-spinel/SpinelNCPTaskPeek.h
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef __wpantund__SpinelNCPTaskPeek__
+#define __wpantund__SpinelNCPTaskPeek__
+
+#include "SpinelNCPTask.h"
+#include "SpinelNCPInstance.h"
+
+using namespace nl;
+using namespace nl::wpantund;
+
+namespace nl {
+namespace wpantund {
+
+class SpinelNCPTaskPeek : public SpinelNCPTask
+{
+public:
+	SpinelNCPTaskPeek(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		uint32_t address,
+		uint16_t count = 1
+	);
+
+	virtual int vprocess_event(int event, va_list args);
+
+private:
+
+	uint32_t mAddress;
+	uint16_t mCount;
+};
+
+}; // namespace wpantund
+}; // namespace nl
+
+#endif /* defined(__wpantund__SpinelNCPTaskPeek__) */

--- a/src/wpanctl/Makefile.am
+++ b/src/wpanctl/Makefile.am
@@ -85,6 +85,10 @@ wpanctl_SOURCES = \
 	tool-cmd-remove-route.h \
 	tool-cmd-pcap.h \
 	tool-cmd-pcap.c \
+	tool-cmd-peek.h \
+	tool-cmd-peek.c \
+	tool-cmd-poke.h \
+	tool-cmd-poke.c \
 	tool-cmd-commissioner.h \
 	tool-cmd-commissioner.c \
 	tool-updateprop.h \

--- a/src/wpanctl/tool-cmd-peek.c
+++ b/src/wpanctl/tool-cmd-peek.c
@@ -1,0 +1,274 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-cmd-peek.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "args.h"
+
+#include <errno.h>
+
+const char peek_cmd_syntax[] = "[args] <address>";
+
+static const arg_list_item_t peek_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'c', "count", "bytes", "Number of bytes to peek"},
+	{'d', "data", "", "Show the result as a sequence of unformatted hex bytes"},
+	{0}
+};
+
+static void dump_data(const uint8_t *data_ptr, uint16_t data_len)
+{
+	uint16_t len;
+	char buf[100];
+	char *cur;
+	uint16_t address_index = 0;
+	uint16_t i;
+
+	fprintf(stdout, "+------+-------------------------+-------------------------+------------------+\n");
+
+	while (data_len > 0)
+	{
+		len = data_len < 16 ? data_len : 16;
+		cur = buf;
+		cur += sprintf(cur, "| %04X |", address_index);
+
+		for (i = 0; i < 16; i++) {
+			if (i < len) {
+				cur += sprintf(cur, " %02X", data_ptr[i]);
+			} else {
+				cur += sprintf(cur, "   ");
+			}
+
+			if ((i == 7) || (i == 15)) {
+				cur += sprintf(cur, " |");
+			}
+		}
+
+		*cur++ = ' ';
+
+		for (i = 0; i < 16; i++) {
+			char c = (char)(0x7f & (data_ptr)[i]);
+			*cur++ = (i < len) ? (isprint(c) ? c : '.') :  ' ';
+		}
+
+		cur += sprintf(cur, " |");
+
+		fprintf(stdout, "%s\n", buf);
+
+		data_ptr += len;
+		data_len -= len;
+		address_index += 16;
+	}
+
+	fprintf(stdout, "+------+-------------------------+-------------------------+------------------+\n");
+}
+
+int tool_cmd_peek(int argc, char* argv[])
+{
+	int ret = 0;
+	int c;
+	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	uint32_t address = 0;
+	uint16_t count = 32;
+	bool simple_data_format = false;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"timeout", required_argument, 0, 't'},
+			{"count", required_argument, 0, 'c'},
+			{"data", no_argument, 0, 'd'},
+			{0, 0, 0, 0}
+		};
+
+		int option_index = 0;
+		c = getopt_long(argc, argv, "ht:c:d", long_options,	&option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(peek_option_list, argv[0], peek_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+
+		case 'c':
+			count = strtol(optarg, NULL, 0);
+			break;
+
+		case 'd':
+			simple_data_format = true;
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		address = strtol(argv[optind], NULL, 0);
+		optind++;
+	} else {
+		fprintf(stderr,	"%s: error: Missing required address parameter\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (optind < argc) {
+		fprintf(stderr,	"%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(
+			stderr,
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
+			argv[0]
+		);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+
+	if (!connection) {
+		dbus_error_free(&error);
+		dbus_error_init(&error);
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	}
+
+	require_string(connection != NULL, bail, error.message);
+
+	{
+		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
+		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
+		bool did_succeed;
+		uint8_t *data_ptr = NULL;
+		int data_len = 0;
+		uint16_t i;
+
+		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+		if (ret != 0) {
+			print_error_diagnosis(ret);
+			goto bail;
+		}
+		snprintf(path,
+				 sizeof(path),
+				 "%s/%s",
+				 WPANTUND_DBUS_PATH,
+				 gInterfaceName);
+
+		message = dbus_message_new_method_call(
+			interface_dbus_name,
+			path,
+			WPANTUND_DBUS_APIv1_INTERFACE,
+			WPANTUND_IF_CMD_PEEK
+		);
+
+		fprintf(stdout, "Peeking at address 0x%x (%d) for %d bytes\n", address, address, count);
+
+		dbus_message_append_args(
+			message,
+			DBUS_TYPE_UINT32, &address,
+			DBUS_TYPE_UINT16, &count,
+			DBUS_TYPE_INVALID
+		);
+
+		reply = dbus_connection_send_with_reply_and_block(
+			connection,
+			message,
+			timeout,
+			&error
+		);
+
+		if (!reply) {
+			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+			ret = ERRORCODE_TIMEOUT;
+			goto bail;
+		}
+
+		did_succeed = dbus_message_get_args(reply, &error,
+			DBUS_TYPE_INT32, &ret,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &data_ptr, &data_len,
+			DBUS_TYPE_INVALID
+		);
+
+		if (!did_succeed)
+		{
+			did_succeed = dbus_message_get_args(reply, NULL,
+				DBUS_TYPE_INT32, &ret,
+				DBUS_TYPE_INVALID
+			);
+		}
+
+		if (!did_succeed || ret != 0) {
+			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+			print_error_diagnosis(ret);
+			goto bail;
+		}
+
+		if (simple_data_format) {
+			for (i = 0; i < data_len; i++) {
+				fprintf(stdout, "%02X ", *data_ptr++);
+				if (i % 32 == 31) {
+					fprintf(stdout, "\n");
+				}
+			}
+			fprintf(stdout, "\n");
+		} else {
+			dump_data(data_ptr, data_len);
+		}
+	}
+
+bail:
+
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-peek.h
+++ b/src/wpanctl/tool-cmd-peek.h
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_PEEK_H
+#define WPANCTL_TOOL_CMD_PEEK_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_peek(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/tool-cmd-poke.c
+++ b/src/wpanctl/tool-cmd-poke.c
@@ -1,0 +1,253 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-cmd-peek.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "args.h"
+
+#include <errno.h>
+
+const char poke_cmd_syntax[] = "[args] <address> <value>";
+
+static const arg_list_item_t poke_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'d', "data", NULL, "Value is binary data (in hex)"},
+	{'s', "string", NULL, "Value is a string"},
+	{'v', "value", "property-value", "Useful when the value starts with a '-'"},
+	{0}
+};
+
+int tool_cmd_poke(int argc, char* argv[])
+{
+	int ret = 0;
+	int c;
+	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	enum {
+		kValueType_String,
+		kValueType_Data,
+		kValueType_Byte
+	} value_type = kValueType_Byte;
+	char *value = NULL;
+	uint32_t address = 0;
+	uint16_t count;
+	uint8_t byte;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"timeout", required_argument, 0, 't'},
+			{"data", no_argument, 0, 'd'},
+			{"string", no_argument, 0, 's'},
+			{"value", required_argument, 0, 'v'},
+			{0, 0, 0, 0}
+		};
+
+		int option_index = 0;
+		c = getopt_long(argc, argv, "ht:dsv:", long_options, &option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(poke_option_list, argv[0], poke_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+
+		case 'd':
+			value_type = kValueType_Data;
+			break;
+
+		case 's':
+			value_type = kValueType_String;
+			break;
+
+		case 'v':
+			value = optarg;
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		address = strtol(argv[optind], NULL, 0);
+		optind++;
+	} else {
+		fprintf(stderr,	"%s: error: Missing required address parameter\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (optind < argc) {
+		if (!value) {
+			value = argv[optind];
+			optind++;
+		}
+	}
+
+	if (optind < argc) {
+		fprintf(stderr,	"%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (!value) {
+		fprintf(stderr, "%s: error: Missing value.\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(
+			stderr,
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
+			argv[0]
+		);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+
+	if (!connection) {
+		dbus_error_free(&error);
+		dbus_error_init(&error);
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	}
+
+	require_string(connection != NULL, bail, error.message);
+
+	{
+		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
+		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
+		bool did_succeed = false;
+
+		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+		if (ret != 0) {
+			print_error_diagnosis(ret);
+			goto bail;
+		}
+		snprintf(path,
+				 sizeof(path),
+				 "%s/%s",
+				 WPANTUND_DBUS_PATH,
+				 gInterfaceName);
+
+		message = dbus_message_new_method_call(
+			interface_dbus_name,
+			path,
+			WPANTUND_DBUS_APIv1_INTERFACE,
+			WPANTUND_IF_CMD_POKE
+		);
+
+		dbus_message_append_args(
+			message,
+			DBUS_TYPE_UINT32, &address,
+			DBUS_TYPE_INVALID
+		);
+
+		if (value_type == kValueType_Byte) {
+			byte = (uint8_t)strtol(value, NULL, 0);
+			value = (char *)(&byte);
+			count = 1;
+		} else if (value_type == kValueType_String) {
+			count = strlen(value);
+		} else if (value_type == kValueType_Data) {
+			count = parse_string_into_data((uint8_t*)value,
+											strlen(value),
+											value);
+		} else {
+			fprintf(stderr, "%s: error: Bad value type\n", argv[0]);
+			ret = ERRORCODE_UNKNOWN;
+			goto bail;
+		}
+
+		dbus_message_append_args(
+				message,
+				DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &value, count,
+				DBUS_TYPE_INVALID
+			);
+
+		if (value_type == kValueType_Byte) {
+			fprintf(stdout, "Poking address 0x%x (%d) with single byte 0x%02x\n", address, address, byte);
+		} else {
+			fprintf(stdout, "Poking address 0x%x (%d) with %d byte(s)\n", address, address, count);
+		}
+
+		reply = dbus_connection_send_with_reply_and_block(
+			connection,
+			message,
+			timeout,
+			&error
+		);
+
+		if (!reply) {
+			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+			ret = ERRORCODE_TIMEOUT;
+			goto bail;
+		}
+
+		did_succeed = dbus_message_get_args(reply, NULL,
+				DBUS_TYPE_INT32, &ret,
+				DBUS_TYPE_INVALID
+			);
+
+		if (!did_succeed || ret != 0) {
+			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+			print_error_diagnosis(ret);
+			goto bail;
+		}
+	}
+
+bail:
+
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-poke.h
+++ b/src/wpanctl/tool-cmd-poke.h
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright (c) 2017 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_POKE_H
+#define WPANCTL_TOOL_CMD_POKE_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_poke(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/wpanctl-cmds.h
+++ b/src/wpanctl/wpanctl-cmds.h
@@ -42,6 +42,8 @@
 #include "tool-cmd-config-gateway.h"
 #include "tool-cmd-add-route.h"
 #include "tool-cmd-remove-route.h"
+#include "tool-cmd-peek.h"
+#include "tool-cmd-poke.h"
 #include "tool-cmd-pcap.h"
 #include "tool-cmd-commissioner.h"
 
@@ -175,6 +177,16 @@
 		"pcap", \
 		"Start a packet capture", \
 		&tool_cmd_pcap \
+	}, \
+	{ \
+		"peek", \
+		"Peek into NCP memory", \
+		&tool_cmd_peek \
+	}, \
+	{ \
+		"poke", \
+		"Poke NCP memory (change content at a NCP memory address)", \
+		&tool_cmd_poke \
 	}, \
 	{ "cd",   "Change current interface (command mode)", \
 	  &tool_cmd_cd                                            }

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -238,6 +238,21 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
+public:
+	// ========================================================================
+	// Debug-related Member Functions
+
+	virtual void peek(
+		uint32_t address,
+		uint16_t count,
+		CallbackWithStatusArg1 cb = NilReturn()
+	) = 0;
+
+	virtual void poke(
+		uint32_t address,
+		Data bytes,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
 
 public:
 	// ========================================================================


### PR DESCRIPTION
Peek command allows wpantund to fetch values from the NCP memory. Poke  command writes  bytes to a specified memory address on NCP. These commands are intended for debugging purposes.
    
The first commit contains the following:
    - It defines peek/poke commands in `NCPControlInterface`.
    - It implements peek/poke operation in spinel pluggin.
    - It add new dbus API (v1) for peek and poke operations.

The second commit contains the implementation of "peek" and "poke" command in wpantcl.
