### PR TITLE
Ensure to switch to ASSOCIATED on NCP role change from detached

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1729,7 +1729,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_UINT8_S, &value);
 		syslog(LOG_INFO,"[-NCP-]: Net Role \"%s\" (%d)", spinel_net_role_to_cstr(value), value);
 
-		if ( ncp_state_is_joining(get_ncp_state())
+		if ( ncp_state_is_joining_or_joined(get_ncp_state())
 		  && (value != SPINEL_NET_ROLE_DETACHED)
 		) {
 			change_ncp_state(ASSOCIATED);


### PR DESCRIPTION
This change fixes an issue where we could remain in the ISOLATED
state even after receiving an NCP event with role change to other
than detached.

Here is the flow to get stuck in isloated state
- A NCP role change to detached will trigger a `change_ncp_state(ISOLATED);`
- Later if we get a role change back to router, we won't change the wpantund state
- The change uses `ncp_state_is_joining_or_joined()` which includes the `ISOLATED` state to update.