### PR TITLE
Fix 'prase' typo

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1970,7 +1970,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		SpinelNCPTaskGetNetworkTopology::Table::iterator it;
 		int num_children = 0;
 
-		SpinelNCPTaskGetNetworkTopology::prase_child_table(value_data_ptr, value_data_len, child_table);
+		SpinelNCPTaskGetNetworkTopology::parse_child_table(value_data_ptr, value_data_len, child_table);
 
 		for (it = child_table.begin(); it != child_table.end(); it++)
 		{

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
@@ -41,7 +41,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::SpinelNCPTaskGetNetworkTopology(
 }
 
 int
-nl::wpantund::SpinelNCPTaskGetNetworkTopology::prase_child_table(
+nl::wpantund::SpinelNCPTaskGetNetworkTopology::parse_child_table(
 	const uint8_t *data_in,
 	spinel_size_t data_len,
 	Table& child_table
@@ -109,7 +109,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::prase_child_table(
 }
 
 int
-nl::wpantund::SpinelNCPTaskGetNetworkTopology::prase_neighbor_table(const uint8_t *data_in, spinel_size_t data_len,
+nl::wpantund::SpinelNCPTaskGetNetworkTopology::parse_neighbor_table(const uint8_t *data_in, spinel_size_t data_len,
 																			 Table& neighbor_table)
 {
 	int ret = kWPANTUNDStatus_Ok;
@@ -234,10 +234,10 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::vprocess_event(int event, va_list
 
 	if (mType == kChildTable) {
 		require(prop_key == SPINEL_PROP_THREAD_CHILD_TABLE, on_error);
-		prase_child_table(data_in, data_len, mTable);
+		parse_child_table(data_in, data_len, mTable);
 	} else {
 		require(prop_key == SPINEL_PROP_THREAD_NEIGHBOR_TABLE, on_error);
-		prase_neighbor_table(data_in, data_len, mTable);
+		parse_neighbor_table(data_in, data_len, mTable);
 	}
 
 	ret = kWPANTUNDStatus_Ok;

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
@@ -99,10 +99,10 @@ public:
 	virtual int vprocess_event(int event, va_list args);
 
 	// Parses the spinel child table property and updates the child_table
-	static int prase_child_table(const uint8_t *data_in, spinel_size_t data_len, Table& child_table);
+	static int parse_child_table(const uint8_t *data_in, spinel_size_t data_len, Table& child_table);
 
 	// Parses the spinel neighbor table property and updates the neighbor_table
-	static int prase_neighbor_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_table);
+	static int parse_neighbor_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_table);
 
 private:
 	Type mType;


### PR DESCRIPTION
Fix a typo: "prase" should be "parse".