### PR TITLE
Adding logs to show spinel property values and refactor common code

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -152,6 +152,9 @@ private:
 	void refresh_on_mesh_prefix(struct in6_addr *addr, uint8_t prefix_len, bool stable, uint8_t flags, bool isLocal);
 
 	void update_node_type(NodeType node_type);
+	void update_link_local_address(struct in6_addr *addr);
+	void update_mesh_local_address(struct in6_addr *addr);
+	void update_mesh_local_prefix(struct in6_addr *addr);
 
 public:
 	static bool setup_property_supported_by_class(const std::string& prop_name);
@@ -170,6 +173,7 @@ public:
 	static void handle_ncp_log(const uint8_t* data_ptr, int data_len);
 
 	static std::string thread_mode_to_string(uint8_t mode);
+	static std::string on_mesh_prefix_flags_to_string(uint8_t flags);
 
 	uint8_t get_thread_mode(void);
 


### PR DESCRIPTION
This commit adds three new methods `update_link_local_address()`,
`update_mesh_local_address()` and `update_mesh_local_prefix()` to
refactor common code called from `value_is` and `value_inserted`
methods.

It also adds new logs in `handle_ncp_spinel_value_is` to show the
value received from NCP for certain spinel properties (e.g., network
name, PANID, XPANID,  channel, list of IPv6 addresses, and list of on-
mesh prefixes).