### PR TITLE
Add SLACC address only for non-local on-mesh-prefixes

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2246,7 +2246,8 @@ SpinelNCPInstance::refresh_on_mesh_prefix(struct in6_addr *prefix, uint8_t prefi
 		memcpy(&addr, prefix, sizeof(in6_addr));
 		add_prefix(addr, UINT32_MAX, UINT32_MAX, flags);
 	}
-	if ( ((flags & (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC)) == (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC))
+	if (!isLocal
+	  && ((flags & (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC)) == (SPINEL_NET_FLAG_ON_MESH | SPINEL_NET_FLAG_SLAAC))
 	  && !lookup_address_for_prefix(NULL, *prefix, prefix_len)
 	) {
 		SpinelNCPTaskSendCommand::Factory factory(this);


### PR DESCRIPTION
The on-mesh-prefixes from `ON_MESH_NETS` property includes both local and leader/network-wide list.  This commit adds the check to ensure that a SLAAC address is pushed to NCP only for non-local prefixes.