### PR TITLE
Add support for "offline:commissioned"  state

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -153,35 +153,7 @@ SpinelNCPInstance::vprocess_resume(int event, va_list args)
 
 	EH_BEGIN_SUB(&mSubPT);
 
-	// Get the `SPINEL_PROP_NET_SAVED` property to check if the NCP is commissioned.
-
-	CONTROL_REQUIRE_PREP_TO_SEND_COMMAND_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
-
-	command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_NET_SAVED);
-	require(command.size() < sizeof(mOutboundBuffer), on_error);
-	memcpy(mOutboundBuffer, command.data(), command.size());
-	mOutboundBufferLen = static_cast<spinel_ssize_t>(command.size());
-
-	CONTROL_REQUIRE_OUTBOUND_BUFFER_FLUSHED_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
-	CONTROL_REQUIRE_COMMAND_RESPONSE_WITHIN(NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT, on_error);
-
-	ret = peek_ncp_callback_status(event, args);
-
-	check_noerr(ret);
-
-	if (ret == 0) {
-		unsigned int key = va_arg(args, unsigned int);
-		const uint8_t* data_in = va_arg(args, const uint8_t*);
-		spinel_size_t data_len = va_arg_small(args, spinel_size_t);
-		spinel_ssize_t len = 0;
-
-		require(key == SPINEL_PROP_NET_SAVED, on_error);
-
-		len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_BOOL_S, &is_commissioned);
-		require(len > 0, on_error);
-	}
-
-	if (!is_commissioned) {
+	if (!mIsCommissioned) {
 		syslog(LOG_NOTICE, "NCP is NOT commissioned. Cannot resume.");
 		EH_EXIT();
 	}
@@ -489,6 +461,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 				SPINEL_PROP_IPV6_ML_ADDR,
 				SPINEL_PROP_THREAD_ASSISTING_PORTS,
 				SPINEL_PROP_THREAD_MODE,
+				SPINEL_PROP_NET_SAVED,
 				SPINEL_PROP_NET_IF_UP,
 				SPINEL_PROP_NET_STACK_UP,
 				SPINEL_PROP_NET_ROLE,
@@ -601,8 +574,8 @@ SpinelNCPInstance::vprocess_event(int event, va_list args)
 
 	EH_WAIT_UNTIL(mTaskQueue.empty());
 
-	// If we are offline and autoResume is enabled
-	if (mAutoResume && mEnabled && (get_ncp_state() == OFFLINE)) {
+	// If we are commissioned and autoResume is enabled
+	if (mAutoResume && mEnabled && (get_ncp_state() == COMMISSIONED)) {
 		syslog(LOG_NOTICE, "AutoResume is enabled. Trying to resume.");
 		EH_SPAWN(&mSubPT, vprocess_resume(event, args));
 	}

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -232,6 +232,7 @@ private:
 
 	int mTXPower;
 	uint8_t mThreadMode;
+	bool mIsCommissioned;
 
 	std::set<unsigned int> mCapabilities;
 	uint32_t mDefaultChannelMask;


### PR DESCRIPTION
This commit adds support in spinel plug-in for detecting if the NCP
has saved network info (using property `SPINEL_PROP_NET_SAVED`) and
change the wpantund NCP state to  `COMMISSIONED` state. This change
help simplify the auto-resume implementation.