### PR TITLE
Allow controlling of steering data independent of joinability state

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -417,20 +417,11 @@ SpinelNCPControlInterface::permit_join(
 	)
 {
 	SpinelNCPTaskSendCommand::Factory factory(mNCPInstance);
-	bool should_update_steering_data = false;
-	uint8_t steering_data_addr[sizeof(mNCPInstance->mSteeringDataAddress)];
-
 	int ret = kWPANTUNDStatus_Ok;
 
 	if (!mNCPInstance->mEnabled) {
 		ret = kWPANTUNDStatus_InvalidWhenDisabled;
 		goto bail;
-	}
-
-	if (mNCPInstance->mCapabilities.count(SPINEL_CAP_OOB_STEERING_DATA)
-		&& mNCPInstance->mSetSteeringDataWhenJoinable
-	) {
-		should_update_steering_data = true;
 	}
 
 	if (traffic_port == 0) {
@@ -452,24 +443,12 @@ SpinelNCPControlInterface::permit_join(
 			ntohs(traffic_port)
 		));
 
-		memcpy(steering_data_addr, mNCPInstance->mSteeringDataAddress, sizeof(steering_data_addr));
-
 	} else {
 
 		factory.add_command(SpinelPackData(
 			SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_NULL_S),
 			SPINEL_PROP_THREAD_ASSISTING_PORTS
 		));
-
-		memset(steering_data_addr, 0, sizeof(steering_data_addr));
-	}
-
-	if (should_update_steering_data) {
-			factory.add_command(SpinelPackData(
-				SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_EUI64_S),
-				SPINEL_PROP_THREAD_STEERING_DATA,
-				steering_data_addr
-			));
 	}
 
 	mNCPInstance->start_new_task(factory.finish());
@@ -478,19 +457,7 @@ bail:
 	if (ret) {
 		cb(ret);
 	} else {
-		if (!should_update_steering_data) {
-			syslog(LOG_NOTICE, "PermitJoin: seconds=%d type=%d port=%d", seconds, traffic_type, ntohs(traffic_port));
-		} else {
-			syslog(
-				LOG_NOTICE,
-				"PermitJoin: seconds=%d type=%d port=%d, steering_data_addr=%02X%02X%02X%02X%02X%02X%02X%02X",
-				seconds,
-				traffic_type,
-				ntohs(traffic_port),
-				steering_data_addr[0], steering_data_addr[1], steering_data_addr[2], steering_data_addr[3],
-				steering_data_addr[4], steering_data_addr[5], steering_data_addr[6], steering_data_addr[7]
-			);
-		}
+		syslog(LOG_NOTICE, "PermitJoin: seconds=%d type=%d port=%d", seconds, traffic_type, ntohs(traffic_port));
 	}
 }
 

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -237,7 +237,6 @@ private:
 	std::set<unsigned int> mCapabilities;
 	uint32_t mDefaultChannelMask;
 
-	bool mSetSteeringDataWhenJoinable;
 	uint8_t mSteeringDataAddress[8];
 
 	SettingsMap mSettings;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -105,7 +105,6 @@
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"
-#define kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable "OpenThread:SteeringData:SetWhenJoinable"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCounters           "OpenThread:MsgBufferCounters"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCountersAsString   "OpenThread:MsgBufferCounters:AsString"
 #define kWPANTUNDProperty_OpenThreadDebugTestAssert             "OpenThread:Debug:TestAssert"


### PR DESCRIPTION
This commit allows full control of steering data independent of
joinability status of device. Changing steering data requires
`SPINEL_CAP_OOB_STEERING_DATA` capability on NCP. The wpan property
`OpenThread:SteeringData:Address`  (EUI64 value) can be used to
directly change steering data on NCP (using the spinel property
`SPINEL_PROP_THREAD_STEERING_DATA`). Default value of steering data is
all zeros (which means there is no steering data (no bloom filter)).

This commit also ensures to retain the last value of steering data in
`mSettings` list so that it is re-applied on an NCP reset.

This commit also removes `OpenThread:SteeringData:SetWhenJoinable`
(boolean) wpantund property and the code associated with it.