### PR TITLE
Ensure to clear `mIsCommisioned` during "Leave"

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskLeave.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskLeave.cpp
@@ -72,6 +72,8 @@ nl::wpantund::SpinelNCPTaskLeave::vprocess_event(int event, va_list args)
 	// to execute.
 	EH_WAIT_UNTIL(EVENT_STARTING_TASK != event);
 
+	mInstance->mIsCommissioned = false;
+
 	mNextCommand = SpinelPackData(
 		SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
 		SPINEL_PROP_NET_STACK_UP,

--- a/src/wpantund/NetworkRetain.cpp
+++ b/src/wpantund/NetworkRetain.cpp
@@ -69,8 +69,8 @@ NetworkRetain::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_
 		recall_network_info();
 	}
 
-	// Joined --> Offline
-	else if (ncp_state_has_joined(old_ncp_state) && (new_ncp_state == OFFLINE)) {
+	// Commissioned --> Offline
+	else if (ncp_state_is_commissioned(old_ncp_state) && (new_ncp_state == OFFLINE)) {
 		erase_network_info();
 	}
 


### PR DESCRIPTION
This commit contains two changes related to "Leave" operation:

- Clearing the flag `mIsCommisioned` from the `SpinelNCPTaskLeave()`.

- In `NetworkRetain` include the transmission from COMMISIONED to
  OFFLINE to trigger the `erase_network_info()` call. This ensures
  that any retained network info is erased in case AutoResume is
  not enabled and "leave" is issued.