### PR TITLE
[connman-plugin] include `COMMISSIONED` in `true` case of `ncp_state_…

### DIFF
--- a/src/connman-plugin/wpan-connman-plugin.c
+++ b/src/connman-plugin/wpan-connman-plugin.c
@@ -134,6 +134,7 @@ ncp_state_is_not_associated(ncp_state_t ncp_state)
 {
 	switch(ncp_state) {
 	case NCP_STATE_OFFLINE:
+	case NCP_STATE_COMMISSIONED:
 	case NCP_STATE_UPGRADING:
 	case NCP_STATE_UNINITIALIZED:
 		return true;


### PR DESCRIPTION
…is_not_associated()`