### PR TITLE
Managing off-mesh-routes and their mapping to interface routes

### DIFF
--- a/src/ncp-dummy/DummyNCPInstance.cpp
+++ b/src/ncp-dummy/DummyNCPInstance.cpp
@@ -128,3 +128,17 @@ DummyNCPInstance::remove_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint
 {
 	return;
 }
+
+void
+DummyNCPInstance::add_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+	bool stable, CallbackWithStatus cb)
+{
+	return;
+}
+
+void
+DummyNCPInstance::remove_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+	bool stable, CallbackWithStatus cb)
+{
+	return;
+}

--- a/src/ncp-dummy/DummyNCPInstance.h
+++ b/src/ncp-dummy/DummyNCPInstance.h
@@ -66,6 +66,11 @@ protected:
 	virtual void remove_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags, bool stable,
 					CallbackWithStatus cb);
 
+	virtual void add_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+					bool stable, CallbackWithStatus cb);
+	virtual void remove_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+					bool stable, CallbackWithStatus cb);
+
 public:
 	static bool setup_property_supported_by_class(const std::string& prop_name);
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -149,7 +149,7 @@ public:
 
 	virtual void add_external_route(
 		const struct in6_addr *prefix,
-		int prefix_len_in_bits,
+		int prefix_len,
 		int domain_id,
 		ExternalRoutePriority priority,
 		CallbackWithStatus cb = NilReturn()
@@ -157,7 +157,7 @@ public:
 
 	virtual void remove_external_route(
 		const struct in6_addr *prefix,
-		int prefix_len_in_bits,
+		int prefix_len,
 		int domain_id,
 		CallbackWithStatus cb = NilReturn()
 	);
@@ -197,9 +197,6 @@ public:
 		const std::string& mfg_command,
 		CallbackWithStatusArg1 cb = NilReturn()
 	);
-
-	static ExternalRoutePriority convert_flags_to_external_route_priority(uint8_t flags);
-	static uint8_t convert_external_route_priority_to_flags(ExternalRoutePriority priority);
 
 private:
 	void handle_permit_join_timeout(Timer *timer, int seconds);

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -333,7 +333,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 
 	set_ncp_power(true);
 
-	remove_ncp_originated_addresses();
+	remove_ncp_originated_address_prefix_route_entries();
 
 	mNCPVersionString = "";
 

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -140,21 +140,31 @@ protected:
 	void handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
+	void handle_ncp_spinel_value_is_OFF_MESH_ROUTE(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
+
 	bool should_filter_address(const struct in6_addr &address, uint8_t prefix_len);
 	void filter_addresses(void);
 
 	virtual void add_unicast_address_on_ncp(const struct in6_addr &addr, uint8_t prefix_len,
-					CallbackWithStatus cb = NilReturn());
+					CallbackWithStatus cb);
 	virtual void remove_unicast_address_on_ncp(const struct in6_addr& addr, uint8_t prefix_len,
-					CallbackWithStatus cb = NilReturn());
+					CallbackWithStatus cb);
 
-	virtual void add_multicast_address_on_ncp(const struct in6_addr &addr, CallbackWithStatus cb = NilReturn());
-	virtual void remove_multicast_address_on_ncp(const struct in6_addr &addr, CallbackWithStatus cb = NilReturn());
+	virtual void add_multicast_address_on_ncp(const struct in6_addr &addr, CallbackWithStatus cb);
+	virtual void remove_multicast_address_on_ncp(const struct in6_addr &addr, CallbackWithStatus cb);
 
 	virtual void add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags, bool stable,
-					CallbackWithStatus cb = NilReturn());
+					CallbackWithStatus cb);
 	virtual void remove_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags,
-					bool stable, CallbackWithStatus cb = NilReturn());
+					bool stable, CallbackWithStatus cb);
+
+	virtual void add_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+					bool stable, CallbackWithStatus cb);
+	virtual void remove_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
+					bool stable, CallbackWithStatus cb);
+
+	static RoutePreference convert_flags_to_route_preference(uint8_t flags);
+	static uint8_t convert_route_preference_to_flags(RoutePreference priority);
 
 	uint32_t get_default_channel_mask(void);
 

--- a/src/util/TunnelIPv6Interface.cpp
+++ b/src/util/TunnelIPv6Interface.cpp
@@ -518,15 +518,15 @@ bail:
 
 
 bool
-TunnelIPv6Interface::add_route(const struct in6_addr *route, int prefixlen)
+TunnelIPv6Interface::add_route(const struct in6_addr *route, int prefixlen, uint32_t metric)
 {
 	bool ret = false;
 
-	if (netif_mgmt_add_ipv6_route(mNetifMgmtFD, mInterfaceName.c_str(), route->s6_addr, prefixlen) != 0) {
+	if (netif_mgmt_add_ipv6_route(mNetifMgmtFD, mInterfaceName.c_str(), route->s6_addr, prefixlen, metric) != 0) {
 		mLastError = errno;
 		goto bail;
 	}
-	syslog(LOG_INFO, "Adding route prefix \"%s/%d\" -> \"%s\".",
+	syslog(LOG_INFO, "Adding route prefix \"%s/%d\" on interface \"%s\".",
 	       in6_addr_to_string(*route).c_str(), prefixlen, mInterfaceName.c_str());
 
 	ret = true;
@@ -536,16 +536,16 @@ bail:
 }
 
 bool
-TunnelIPv6Interface::remove_route(const struct in6_addr *route, int prefixlen)
+TunnelIPv6Interface::remove_route(const struct in6_addr *route, int prefixlen, uint32_t metric)
 {
 	bool ret = false;
 
-	if (netif_mgmt_remove_ipv6_route(mNetifMgmtFD, mInterfaceName.c_str(), route->s6_addr, prefixlen) != 0) {
+	if (netif_mgmt_remove_ipv6_route(mNetifMgmtFD, mInterfaceName.c_str(), route->s6_addr, prefixlen, metric) != 0) {
 		mLastError = errno;
 		goto bail;
 	}
 
-	syslog(LOG_INFO, "Removing route prefix \"%s/%d\" -> \"%s\".",
+	syslog(LOG_INFO, "Removing route prefix \"%s/%d\" on interface \"%s\".",
 	       in6_addr_to_string(*route).c_str(), prefixlen, mInterfaceName.c_str());
 
 	ret = true;

--- a/src/util/TunnelIPv6Interface.h
+++ b/src/util/TunnelIPv6Interface.h
@@ -64,8 +64,8 @@ public:
 	bool add_address(const struct in6_addr *addr, int prefixlen = 64);
 	bool remove_address(const struct in6_addr *addr, int prefixlen = 64);
 
-	bool add_route(const struct in6_addr *route, int prefixlen = 64);
-	bool remove_route(const struct in6_addr *route, int prefixlen = 64);
+	bool add_route(const struct in6_addr *route, int prefixlen, uint32_t metric);
+	bool remove_route(const struct in6_addr *route, int prefixlen, uint32_t metric);
 
 	bool join_multicast_address(const struct in6_addr *addr);
 	bool leave_multicast_address(const struct in6_addr *addr);

--- a/src/util/netif-mgmt.c
+++ b/src/util/netif-mgmt.c
@@ -364,7 +364,7 @@ bail:
 }
 
 int
-netif_mgmt_add_ipv6_route(int reqfd, const char* if_name, const uint8_t route[16], int prefixlen)
+netif_mgmt_add_ipv6_route(int reqfd, const char* if_name, const uint8_t route[16], int prefixlen, uint32_t metric)
 {
 	int ret = -1;
 
@@ -390,7 +390,7 @@ netif_mgmt_add_ipv6_route(int reqfd, const char* if_name, const uint8_t route[16
 	if (prefixlen == 128) {
 		rt.rtmsg_flags |= RTF_HOST;
 	}
-	rt.rtmsg_metric = 512;
+	rt.rtmsg_metric = metric;
 
 	ret = ioctl(reqfd, SIOGIFINDEX, &ifr);
 
@@ -410,7 +410,7 @@ bail:
 }
 
 int
-netif_mgmt_remove_ipv6_route(int reqfd, const char* if_name, const uint8_t route[16], int prefixlen)
+netif_mgmt_remove_ipv6_route(int reqfd, const char* if_name, const uint8_t route[16], int prefixlen, uint32_t metric)
 {
 	int ret = -1;
 
@@ -430,7 +430,7 @@ netif_mgmt_remove_ipv6_route(int reqfd, const char* if_name, const uint8_t route
 
 	rt.rtmsg_dst_len = prefixlen;
 	rt.rtmsg_flags = RTF_UP;
-	rt.rtmsg_metric = 512;
+	rt.rtmsg_metric = metric;
 
 	if (prefixlen == 128) {
 		rt.rtmsg_flags |= RTF_HOST;

--- a/src/util/netif-mgmt.h
+++ b/src/util/netif-mgmt.h
@@ -47,8 +47,8 @@ extern int netif_mgmt_set_running(int fd, const char* if_name, bool value);
 extern int netif_mgmt_add_ipv6_address(int fd, const char* if_name, const uint8_t addr[16], int prefixlen);
 extern int netif_mgmt_remove_ipv6_address(int fd, const char* if_name, const uint8_t addr[16]);
 
-extern int netif_mgmt_add_ipv6_route(int fd, const char* if_name, const uint8_t route[16], int prefixlen);
-extern int netif_mgmt_remove_ipv6_route(int fd, const char* if_name, const uint8_t route[16], int prefixlen);
+extern int netif_mgmt_add_ipv6_route(int fd, const char* if_name, const uint8_t route[16], int prefixlen, uint32_t metric);
+extern int netif_mgmt_remove_ipv6_route(int fd, const char* if_name, const uint8_t route[16], int prefixlen, uint32_t metric);
 
 extern int netif_mgmt_join_ipv6_multicast_address(int reqfd, const char* if_name, const uint8_t addr[16]);
 extern int netif_mgmt_leave_ipv6_multicast_address(int reqfd, const char* if_name, const uint8_t addr[16]);

--- a/src/wpantund/NCPControlInterface.cpp
+++ b/src/wpantund/NCPControlInterface.cpp
@@ -54,7 +54,7 @@ NCPControlInterface::external_route_priority_to_string(ExternalRoutePriority rou
 			break;
 
 		case ROUTE_MEDIUM_PREFERENCE:
-			ret = "medium(normal)";
+			ret = "medium";
 			break;
 
 		case ROUTE_HIGH_PREFERENCE:

--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -21,6 +21,7 @@
 #include <config.h>
 #endif
 
+#include <utility>
 #include "assert-macros.h"
 #include "NCPInstanceBase.h"
 #include "tunnel.h"
@@ -34,6 +35,40 @@
 
 using namespace nl;
 using namespace wpantund;
+
+NCPInstanceBase::IPv6Prefix::IPv6Prefix(const in6_addr &prefix, uint8_t len):
+	mPrefix(prefix), mLength(len)
+{
+	in6_addr_apply_mask(mPrefix, mLength);
+}
+
+bool
+NCPInstanceBase::IPv6Prefix::operator==(const IPv6Prefix &another_prefix) const
+{
+	return (mPrefix == another_prefix.mPrefix) && (mLength == another_prefix.mLength);
+}
+
+bool
+NCPInstanceBase::IPv6Prefix::operator<(const IPv6Prefix &another_prefix) const
+{
+	bool is_less = false;
+
+	if (mLength < another_prefix.mLength) {
+		is_less = true;
+	} else if (mLength == another_prefix.mLength) {
+		is_less = (memcmp(&mPrefix, &another_prefix.mPrefix, sizeof(mPrefix)) < 0);
+	}
+
+	return is_less;
+}
+
+std::string
+NCPInstanceBase::IPv6Prefix::to_string(void) const
+{
+	char c_string[100];
+	snprintf(c_string, sizeof(c_string), "%s/%d", in6_addr_to_string(mPrefix).c_str(), mLength);
+	return std::string(c_string);
+}
 
 std::string
 NCPInstanceBase::EntryBase::get_origin_as_string(void) const
@@ -168,9 +203,72 @@ NCPInstanceBase::OnMeshPrefixEntry::get_description(const struct in6_addr &addre
 			is_stable() ? "yes" : "no ", on_mesh_prefix_flags_to_string(get_flags(), true).c_str());
 
 	} else {
-		snprintf(c_string, sizeof(c_string), "\"%s/%d\", origin:%s, stable:%s, flags:%s, ",
+		snprintf(c_string, sizeof(c_string), "\"%s/%d\", origin:%s, stable:%s, flags:%s",
 			in6_addr_to_string(address).c_str(), get_prefix_len(), get_origin_as_string().c_str(),
 			is_stable() ? "yes" : "no", on_mesh_prefix_flags_to_string(get_flags()).c_str());
+	}
+
+	return std::string(c_string);
+}
+
+bool
+NCPInstanceBase::OffMeshRouteEntry::operator==(const OffMeshRouteEntry &entry)
+{
+	bool retval = true;
+
+	// Check the originator first.
+	if (get_origin() != entry.get_origin()) {
+		retval = false;
+		goto bail;
+	}
+
+	// If the entry is from NCP then ensure other fields also match.
+	if (is_from_ncp()) {
+
+		// Note that we intentionally don't check `mNextHopIsHost` as the RLOC16 value
+		// assigned to the node can be changed (e.g., after a re-attach) causing the
+		// `mNextHopIsHost` value to also change.
+
+		if ((mPreference != entry.mPreference) || (mStable != entry.mStable) || (mRloc != entry.mRloc)) {
+			retval = false;
+			goto bail;
+		}
+	}
+
+bail:
+	return retval;
+}
+
+std::string
+NCPInstanceBase::OffMeshRouteEntry::get_description(const IPv6Prefix &route, bool align) const
+{
+	char c_string[300];
+
+	if (align) {
+		snprintf(c_string, sizeof(c_string), "%-26s origin:%-8s stable:%s preference:%-7s rloc:0x%04x next_hop_is_host:%s",
+			route.to_string().c_str(), get_origin_as_string().c_str(), is_stable() ? "yes" : "no ",
+			NCPControlInterface::external_route_priority_to_string(get_preference()).c_str(), get_rloc(),
+			is_next_hop_host() ? "yes" : "no ");
+
+	} else {
+		snprintf(c_string, sizeof(c_string), "\"%s\", origin:%s, stable:%s, preference:%s, rloc:0x%04x, next_hop_is_host:%s",
+			route.to_string().c_str(), get_origin_as_string().c_str(), is_stable() ? "yes" : "no",
+			NCPControlInterface::external_route_priority_to_string(get_preference()).c_str(), get_rloc(),
+			is_next_hop_host() ? "yes" : "no");
+	}
+
+	return std::string(c_string);
+}
+
+std::string
+NCPInstanceBase::InterfaceRouteEntry::get_description(const IPv6Prefix &route, bool align) const
+{
+	char c_string[300];
+
+	if (align) {
+		snprintf(c_string, sizeof(c_string), "%-26s metric:%-6d", route.to_string().c_str(), mMetric);
+	} else {
+		snprintf(c_string, sizeof(c_string), "\"%s\", metric:%d", route.to_string().c_str(), mMetric);
 	}
 
 	return std::string(c_string);
@@ -180,18 +278,20 @@ NCPInstanceBase::OnMeshPrefixEntry::get_description(const struct in6_addr &addre
 // MARK: Global Entries Management
 
 void
-NCPInstanceBase::refresh_address_entries(void)
+NCPInstanceBase::refresh_address_route_prefix_entries(void)
 {
-	// Here is where we would do any periodic global address bookkeeping,
-	// which doesn't appear to be necessary yet but may become necessary
-	// in the future.
+	if (mRequestRouteRefresh) {
+		mRequestRouteRefresh = false;
+		refresh_routes_on_interface();
+	}
 }
 
 void
-NCPInstanceBase::remove_all_address_prefix_entries(void)
+NCPInstanceBase::remove_all_address_prefix_route_entries(void)
 {
-	syslog(LOG_INFO, "Removing all address/prefix entries");
+	syslog(LOG_INFO, "Removing all address/prefix/route entries");
 
+	// Unicast addresses
 	for (
 		std::map<struct in6_addr, UnicastAddressEntry>::iterator iter = mUnicastAddresses.begin();
 		iter != mUnicastAddresses.end();
@@ -200,6 +300,7 @@ NCPInstanceBase::remove_all_address_prefix_entries(void)
 		mPrimaryInterface->remove_address(&iter->first, iter->second.get_prefix_len());
 	}
 
+	// Multicast addresses
 	for (
 		std::map<struct in6_addr, MulticastAddressEntry>::iterator iter = mMulticastAddresses.begin();
 		iter != mMulticastAddresses.end();
@@ -208,21 +309,31 @@ NCPInstanceBase::remove_all_address_prefix_entries(void)
 		mPrimaryInterface->leave_multicast_address(&iter->first);
 	}
 
+	// Routes
+	for (
+		std::map<IPv6Prefix, InterfaceRouteEntry>::iterator iter = mInterfaceRoutes.begin();
+		iter != mInterfaceRoutes.end();
+		++iter
+	) {
+		mPrimaryInterface->remove_route(&iter->first.get_prefix(), iter->first.get_length(), iter->second.get_metric());
+	}
+
 	memset(&mNCPLinkLocalAddress, 0, sizeof(mNCPLinkLocalAddress));
 	memset(&mNCPMeshLocalAddress, 0, sizeof(mNCPMeshLocalAddress));
 
 	mUnicastAddresses.clear();
 	mMulticastAddresses.clear();
 	mOnMeshPrefixes.clear();
+	mOffMeshRoutes.clear();
+	mInterfaceRoutes.clear();
 }
 
 void
-NCPInstanceBase::remove_ncp_originated_addresses(void)
+NCPInstanceBase::remove_ncp_originated_address_prefix_route_entries(void)
 {
 	bool did_remove = false;
 
-	// We remove all of the addresses/prefixes that originated
-	// from the NCP.
+	// We remove all of the addresses/prefixes/routes that originated from the NCP.
 
 	syslog(LOG_INFO, "Removing all NCP originated addresses");
 
@@ -282,13 +393,33 @@ NCPInstanceBase::remove_ncp_originated_addresses(void)
 			break;
 		}
 	} while (did_remove);
+
+	// Off-Mesh Routes
+	do {
+		std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter;
+
+		did_remove = false;
+
+		for (iter = mOffMeshRoutes.begin(); iter != mOffMeshRoutes.end(); iter++) {
+			if (!iter->second.is_from_ncp()) {
+				continue;
+			}
+
+			syslog(LOG_INFO, "OffMeshRoutes: Removing %s", iter->second.get_description(iter->first).c_str());
+			mOffMeshRoutes.erase(iter);
+			did_remove = true;
+			mRequestRouteRefresh = true;
+			break;
+		}
+	} while (did_remove);
 }
 
 void
-NCPInstanceBase::restore_address_prefix_entries_on_ncp(void)
+NCPInstanceBase::restore_address_prefix_route_entries_on_ncp(void)
 {
-	syslog(LOG_INFO, "Restoring interface/user originated address/prefix entries on NCP");
+	syslog(LOG_INFO, "Restoring interface/user originated address/prefix/route entries on NCP");
 
+	// Unicast addresses
 	for (
 		std::map<struct in6_addr, UnicastAddressEntry>::iterator iter = mUnicastAddresses.begin();
 		iter != mUnicastAddresses.end();
@@ -299,23 +430,39 @@ NCPInstanceBase::restore_address_prefix_entries_on_ncp(void)
 		}
 	}
 
+	// Multicast addresses
 	for (
 		std::map<struct in6_addr, MulticastAddressEntry>::iterator iter = mMulticastAddresses.begin();
 		iter != mMulticastAddresses.end();
 		++iter
 	) {
 		if (iter->second.is_from_interface() || iter->second.is_from_user()) {
-			add_multicast_address_on_ncp(iter->first);
+			add_multicast_address_on_ncp(iter->first,
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "restoring multicast address", NilReturn()));
 		}
 	}
 
+	// On-mesh prefixes
 	for (
 		std::map<struct in6_addr, OnMeshPrefixEntry>::iterator iter = mOnMeshPrefixes.begin();
 		iter != mOnMeshPrefixes.end();
 		++iter
 	) {
 		if (iter->second.is_from_interface() || iter->second.is_from_user()) {
-			add_on_mesh_prefix_on_ncp(iter->first, iter->second.get_prefix_len(), iter->second.get_flags(), iter->second.is_stable());
+			add_on_mesh_prefix_on_ncp(iter->first, iter->second.get_prefix_len(), iter->second.get_flags(), iter->second.is_stable(),
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "restoring on-mesh prefix", NilReturn()));
+		}
+	}
+
+	// Off-mesh-routes
+	for (
+		std::map<IPv6Prefix, OffMeshRouteEntry>::iterator iter = mOffMeshRoutes.begin();
+		iter != mOffMeshRoutes.end();
+		++iter
+	) {
+		if (iter->second.is_from_interface() || iter->second.is_from_user()) {
+			add_route_on_ncp(iter->first.get_prefix(), iter->first.get_length(), iter->second.get_preference(), iter->second.is_stable(),
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "restoring off-mesh route", NilReturn()));
 		}
 	}
 }
@@ -323,9 +470,11 @@ NCPInstanceBase::restore_address_prefix_entries_on_ncp(void)
 void
 NCPInstanceBase::check_ncp_entry_update_status(int status, std::string operation, CallbackWithStatus cb)
 {
-	if (status == kWPANTUNDStatus_Timeout)
+	if (status != kWPANTUNDStatus_Ok)
 	{
-		syslog(LOG_ERR, "Timed out while performing \"%s\" on NCP - Resetting NCP.", operation.c_str());
+		syslog(LOG_ERR, "Error %s (%d) while performing \"%s\" on NCP - Resetting NCP.", wpantund_status_to_cstr(status),
+			status, operation.c_str());
+
 		ncp_is_misbehaving();
 	}
 
@@ -415,7 +564,8 @@ NCPInstanceBase::add_address_on_ncp_and_update_prefixes(const in6_addr &address,
 void
 NCPInstanceBase::remove_address_on_ncp_and_update_prefixes(const in6_addr &address, const UnicastAddressEntry &entry)
 {
-	remove_unicast_address_on_ncp(address, entry.get_prefix_len());
+	remove_unicast_address_on_ncp(address, entry.get_prefix_len(),
+		boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "removing unicast address", NilReturn()));
 
 	if (!entry.is_from_ncp()
 	   && !IN6_IS_ADDR_LINKLOCAL(&address)
@@ -443,7 +593,8 @@ NCPInstanceBase::multicast_address_was_joined(Origin origin, const struct in6_ad
 		}
 
 		if ((origin == kOriginPrimaryInterface) || (origin == kOriginUser)) {
-			add_multicast_address_on_ncp(address);
+			add_multicast_address_on_ncp(address,
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "adding multicast address", NilReturn()));
 		}
 	}
 }
@@ -466,7 +617,8 @@ NCPInstanceBase::multicast_address_was_left(Origin origin, const struct in6_addr
 			}
 
 			if ((origin == kOriginPrimaryInterface) || (origin == kOriginUser)) {
-				remove_multicast_address_on_ncp(address);
+				remove_multicast_address_on_ncp(address,
+					boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "removing multicast address", NilReturn()));
 			}
 		}
 	}
@@ -520,7 +672,7 @@ NCPInstanceBase::on_mesh_prefix_was_added(Origin origin, const struct in6_addr &
 		}
 	} else {
 		entry = mOnMeshPrefixes[prefix];
-		cb(kWPANTUNDStatus_Already);
+		cb(kWPANTUNDStatus_Ok);
 	}
 
 	if (entry.is_on_mesh() && entry.is_slaac()
@@ -556,7 +708,8 @@ NCPInstanceBase::on_mesh_prefix_was_removed(Origin origin, const struct in6_addr
 			mOnMeshPrefixes.erase(prefix);
 
 			if ((origin == kOriginPrimaryInterface) || (origin == kOriginUser)) {
-				remove_on_mesh_prefix_on_ncp(prefix, entry.get_prefix_len(), entry.get_flags(), entry.is_stable(), cb);
+				remove_on_mesh_prefix_on_ncp(prefix, entry.get_prefix_len(), entry.get_flags(), entry.is_stable(),
+					boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "removing on-mesh prefix", cb));
 			} else {
 				cb(kWPANTUNDStatus_Ok);
 			}
@@ -565,12 +718,227 @@ NCPInstanceBase::on_mesh_prefix_was_removed(Origin origin, const struct in6_addr
 				&& entry.is_slaac() && entry.is_on_mesh()
 			) {
 				syslog(LOG_NOTICE, "Removing SLAAC address %s/%d from NCP", in6_addr_to_string(address).c_str(), prefix_len);
-				remove_unicast_address_on_ncp(address, prefix_len);
+				remove_unicast_address_on_ncp(address, prefix_len,
+					boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "removing SLAAC address", NilReturn()));
 			}
 		} else {
 			cb(kWPANTUNDStatus_InvalidForCurrentState);
 		}
 	} else {
-		cb(kWPANTUNDStatus_Already);
+		cb(kWPANTUNDStatus_Ok);
+	}
+}
+
+// ========================================================================
+// MARK: Route Management
+
+// Searches for a given route entry in the `mOffMeshRoutes` multimap.
+std::multimap<NCPInstanceBase::IPv6Prefix, NCPInstanceBase::OffMeshRouteEntry>::iterator
+NCPInstanceBase::find_route_entry(const IPv6Prefix &route, const OffMeshRouteEntry &entry)
+{
+	std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter;
+
+	iter = mOffMeshRoutes.lower_bound(route);
+
+	if (iter != mOffMeshRoutes.end()) {
+		std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator upper_iter = mOffMeshRoutes.upper_bound(route);
+
+		for (; iter != upper_iter; iter++) {
+			if (iter->second == entry) {
+				break;
+			}
+		}
+
+		if (iter == upper_iter) {
+			iter = mOffMeshRoutes.end();
+		}
+	}
+
+	return iter;
+}
+
+void
+NCPInstanceBase::route_was_added(Origin origin, const struct in6_addr &route_prefix, uint8_t prefix_len, RoutePreference preference,
+	bool stable, uint16_t rloc16, bool next_hop_is_host, CallbackWithStatus cb)
+{
+	OffMeshRouteEntry entry(origin, preference, stable, rloc16, next_hop_is_host);
+	IPv6Prefix route(route_prefix, prefix_len);
+	std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter;
+
+	iter = find_route_entry(route, entry);
+
+	if (iter == mOffMeshRoutes.end()) {
+		mOffMeshRoutes.insert(std::make_pair(route, entry));
+		mRequestRouteRefresh = true;
+		syslog(LOG_INFO, "OffMeshRoutes: Adding %s", entry.get_description(route).c_str());
+
+		if (origin != kOriginThreadNCP) {
+			add_route_on_ncp(route.get_prefix(), prefix_len, preference, stable,
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "adding off-mesh route", cb));
+
+		} else {
+			cb(kWPANTUNDStatus_Ok);
+		}
+	} else {
+		cb(kWPANTUNDStatus_Ok);
+	}
+}
+
+void
+NCPInstanceBase::route_was_removed(Origin origin, const struct in6_addr &route_prefix, uint8_t prefix_len,
+	RoutePreference preference, bool stable, uint16_t rloc16, CallbackWithStatus cb)
+{
+	OffMeshRouteEntry entry(origin, preference, stable, rloc16);
+	std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter;
+	IPv6Prefix route(route_prefix, prefix_len);
+
+	iter = find_route_entry(route, entry);
+
+	if (iter != mOffMeshRoutes.end()) {
+		syslog(LOG_INFO, "OffMeshRoutes: Removing %s", iter->second.get_description(route).c_str());
+		mOffMeshRoutes.erase(iter);
+		mRequestRouteRefresh = true;
+
+		if (origin != kOriginThreadNCP) {
+			remove_route_on_ncp(route.get_prefix(), prefix_len, preference, stable,
+				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "removing off-mesh route", cb));
+
+		} else {
+			cb(kWPANTUNDStatus_Ok);
+		}
+	} else {
+		cb(kWPANTUNDStatus_Ok);
+	}
+}
+
+// Decides if the given route should be added on the primary interface, if we need to add the route `metric` is also
+// updated.
+bool
+NCPInstanceBase::should_add_route_on_interface(const IPv6Prefix &route, uint32_t &metric)
+{
+	bool should_add = false;
+	bool route_added_by_device = false;
+	bool route_added_by_others = false;
+	RoutePreference preference_device = NCPControlInterface::ROUTE_LOW_PREFRENCE;
+	RoutePreference preference_others = NCPControlInterface::ROUTE_LOW_PREFRENCE;
+
+	std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter, sub_iter, upper_iter;
+
+	for (iter = mOffMeshRoutes.begin(); iter != mOffMeshRoutes.end(); iter = upper_iter) {
+
+		// Get the iterator pointing to the first element that is greater than current key/route.
+		upper_iter = mOffMeshRoutes.upper_bound(iter->first);
+
+		// Skip all elements for which the multimap key does not match the route.
+		if (iter->first != route) {
+			continue;
+		}
+
+		// Iterate through all multimap elements with same key (i.e., same route).
+		for (sub_iter = iter; sub_iter != upper_iter; ++sub_iter) {
+
+			if ((sub_iter->second.get_origin() != kOriginThreadNCP) || sub_iter->second.is_next_hop_host()) {
+				route_added_by_device = true;
+				if (preference_device < sub_iter->second.get_preference()) {
+					preference_device = sub_iter->second.get_preference();
+				}
+			} else {
+				route_added_by_others = true;
+				if (preference_others < sub_iter->second.get_preference()) {
+					preference_others = sub_iter->second.get_preference();
+				}
+			}
+		}
+	}
+
+	// The route should be added on host primary interface, if it
+	// is added by at least one other device within the network and,
+	// either it is not added by host/this-device or added but with
+	// a lower preference level.
+
+	if (route_added_by_others) {
+		if (!route_added_by_device || (preference_others > preference_device)) {
+			should_add = true;
+		}
+	}
+
+	// If the route should be added, map the preference level to route metric.
+
+	if (should_add) {
+		switch (preference_others) {
+		case NCPControlInterface::ROUTE_LOW_PREFRENCE:
+			metric = InterfaceRouteEntry::kRouteMetricLow;
+			break;
+
+		case NCPControlInterface::ROUTE_MEDIUM_PREFERENCE:
+			metric = InterfaceRouteEntry::kRouteMetricMedium;
+			break;
+
+		case NCPControlInterface::ROUTE_HIGH_PREFERENCE:
+			metric = InterfaceRouteEntry::kRouteMetricHigh;
+			break;
+		}
+	}
+
+	return should_add;
+}
+
+void
+NCPInstanceBase::refresh_routes_on_interface(void)
+{
+	bool did_remove = false;
+	uint32_t metric;
+
+	syslog(LOG_INFO, "Refreshing routes on primary interface");
+
+	// First, check all currently added routes on primary interface and remove any one that is no longer valid.
+
+	do {
+		std::map<IPv6Prefix, InterfaceRouteEntry>::iterator iter;
+
+		did_remove = false;
+
+		for (iter = mInterfaceRoutes.begin(); iter != mInterfaceRoutes.end(); iter++) {
+
+			// If the route should not be added on interface or it has been added with
+			// incorrect metric value, remove it from the `mInterfaceRoute` list (note
+			// that it will be re-added if route metric is changed).
+
+			if (!should_add_route_on_interface(iter->first, metric)
+				|| (metric != iter->second.get_metric())
+			) {
+				syslog(LOG_INFO, "InterfaceRoutes: Removing %s", iter->second.get_description(iter->first).c_str());
+				mPrimaryInterface->remove_route(&iter->first.get_prefix(), iter->first.get_length(),
+					iter->second.get_metric());
+				mInterfaceRoutes.erase(iter);
+
+				// We removed an element from `mInterfaceRoutes` while iterating over it,
+				// so we break from the `for` loop and start the iteration over again on the
+				// new updated `mInterfaceRoutes` list.
+
+				did_remove = true;
+				break;
+			}
+		}
+	} while (did_remove);
+
+	// Iterate through all off-mesh route entries to check if there is a new route that should be added on interface.
+
+	{
+		std::multimap<IPv6Prefix, OffMeshRouteEntry>::iterator iter, upper_iter;
+
+		for (iter = mOffMeshRoutes.begin(); iter != mOffMeshRoutes.end(); iter = upper_iter) {
+
+			// Get the iterator pointing to the first element that is greater than current key/route.
+			upper_iter = mOffMeshRoutes.upper_bound(iter->first);
+
+			if (should_add_route_on_interface(iter->first, metric)
+				&& (mInterfaceRoutes.count(iter->first) == 0)
+			) {
+				syslog(LOG_INFO, "InterfaceRoutes: Adding %s", iter->second.get_description(iter->first).c_str());
+				mPrimaryInterface->add_route(&iter->first.get_prefix(), iter->first.get_length(), metric);
+				mInterfaceRoutes[iter->first] = InterfaceRouteEntry(metric);
+			}
+		}
 	}
 }

--- a/src/wpantund/NCPInstanceBase-AsyncIO.cpp
+++ b/src/wpantund/NCPInstanceBase-AsyncIO.cpp
@@ -153,6 +153,10 @@ NCPInstanceBase::get_ms_to_next_event(void)
 		}
 	}
 
+	if (mRequestRouteRefresh) {
+		ret = 0;
+	}
+
 	if (ret < 0) {
 		ret = 0;
 	}
@@ -209,7 +213,7 @@ NCPInstanceBase::process(void)
 	mPcapManager.process();
 
 	if (get_upgrade_status() != EINPROGRESS) {
-		refresh_address_entries();
+		refresh_address_route_prefix_entries();
 
 		require_noerr(ret = mPrimaryInterface->process(), socket_failure);
 

--- a/src/wpantund/NCPInstanceBase-NetInterface.cpp
+++ b/src/wpantund/NCPInstanceBase-NetInterface.cpp
@@ -77,7 +77,7 @@ NCPInstanceBase::set_online(bool is_online)
 		ret = mPrimaryInterface->set_online(is_online);
 
 		if (is_online) {
-			restore_address_prefix_entries_on_ncp();
+			restore_address_prefix_route_entries_on_ncp();
 		}
 
 		if ((ret == 0) && static_cast<bool>(mLegacyInterface)) {
@@ -155,8 +155,8 @@ NCPInstanceBase::reset_interface(void)
 
 	mPrimaryInterface->reset();
 
-	// The global entries table (addresses, prefixes) must be cleared upon reset
-	remove_all_address_prefix_entries();
+	// All IPv6 address (unicast/multicast), on-mesh-prefixes, routes (off-mesh/interface) must be cleared upon reset.
+	remove_all_address_prefix_route_entries();
 
 	if (static_cast<bool>(mLegacyInterface)) {
 		mLegacyInterface->reset();

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -72,6 +72,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mLastChangedBusy = 0;
 	mLegacyInterfaceEnabled = false;
 	mNCPState = UNINITIALIZED;
+	mRequestRouteRefresh = false;
 	mNodeType = UNKNOWN;
 	mNodeTypeSupportsLegacy = false;
 	mSetDefaultRouteForAutoAddedPrefix = false;
@@ -272,8 +273,10 @@ NCPInstanceBase::get_supported_property_keys(void) const
 	properties.insert(kWPANTUNDProperty_IPv6AllAddresses);
 	properties.insert(kWPANTUNDProperty_IPv6MulticastAddresses);
 	properties.insert(kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix);
+	properties.insert(kWPANTUNDProperty_IPv6InterfaceRoutes);
 
 	properties.insert(kWPANTUNDProperty_ThreadOnMeshPrefixes);
+	properties.insert(kWPANTUNDProperty_ThreadOffMeshRoutes);
 
 	properties.insert(kWPANTUNDProperty_DaemonAutoAssociateAfterReset);
 	properties.insert(kWPANTUNDProperty_DaemonAutoDeepSleep);
@@ -461,6 +464,14 @@ NCPInstanceBase::property_get_value(
 		}
 		cb(0, boost::any(result));
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadOffMeshRoutes)) {
+		std::list<std::string> result;
+		std::multimap<IPv6Prefix, OffMeshRouteEntry>::const_iterator iter;
+		for (iter = mOffMeshRoutes.begin(); iter != mOffMeshRoutes.end(); iter++ ) {
+			result.push_back(iter->second.get_description(iter->first, true));
+		}
+		cb(0, boost::any(result));
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6AllAddresses)
 		|| strcaseequal(key.c_str(), kWPANTUNDProperty_DebugIPv6GlobalIPAddressList)
 	) {
@@ -475,6 +486,14 @@ NCPInstanceBase::property_get_value(
 		std::list<std::string> result;
 		std::map<struct in6_addr, MulticastAddressEntry>::const_iterator iter;
 		for (iter = mMulticastAddresses.begin(); iter != mMulticastAddresses.end(); iter++ ) {
+			result.push_back(iter->second.get_description(iter->first, true));
+		}
+		cb(0, boost::any(result));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6InterfaceRoutes)) {
+		std::list<std::string> result;
+		std::map<IPv6Prefix, InterfaceRouteEntry>::const_iterator iter;
+		for (iter = mInterfaceRoutes.begin(); iter != mInterfaceRoutes.end(); iter++ ) {
 			result.push_back(iter->second.get_description(iter->first, true));
 		}
 		cb(0, boost::any(result));

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -82,6 +82,7 @@
 #define kWPANTUNDProperty_IPv6MeshLocalPrefix                   "IPv6:MeshLocalPrefix"
 #define kWPANTUNDProperty_IPv6AllAddresses                      "IPv6:AllAddresses"
 #define kWPANTUNDProperty_IPv6MulticastAddresses                "IPv6:MulticastAddresses"
+#define kWPANTUNDProperty_IPv6InterfaceRoutes                   "IPv6:Routes"
 #define kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix        "IPv6:SetSLAACForAutoAddedPrefix"
 
 #define kWPANTUNDProperty_ThreadRLOC16                          "Thread:RLOC16"


### PR DESCRIPTION
This commit adds support for managing off-mesh-routes from Thread
network. All off-mesh routes (aka external routes) from NCP or user-
added (e.g, using `add_external_route()`) are stored in a
`std::multimap` list `mOffMeshRoutes`. Property "Thread:OffMeshRoutes"
can be used to get the full list which contains information about the
origin of each entry along with preference level.

This commit also adds logic to manage the routes on wpan network
interface corresponding to the off-mesh routes from the network: A
route is added on wpan network interface if there is an off-mesh route
on at least one other device within network AND either the same route
is not added by the device itself, or if it is added, it is added with
a lower preference level from at least one other device within
network.

The change in this commit ensures that user-added off-mesh routes are
restored on NCP in case of an NCP reset.