### PR TITLE
string-utils: Fix for one-byte buffer overflow in parse_string_into_data

### DIFF
--- a/src/util/string-utils.c
+++ b/src/util/string-utils.c
@@ -81,7 +81,7 @@ parse_string_into_data(uint8_t* buffer, size_t len, const char* c_str)
 		len = 0;
 	}
 
-	while (*c_str != 0) {
+	while ((*c_str != 0) && (len > 0)) {
 		char c = tolower(*c_str++);
 		if (!(isdigit(c) || (c >= 'a' && c <= 'f'))) {
 			continue;


### PR DESCRIPTION
This change addresses a one-byte buffer overflow in the function which parses a hex string into data, `parse_string_into_data()`. The buffer overflow would occur when the input string consisted of a single valid hexadecimal digit, and would result in the a byte with the valid of that digit in the upper nibble (and a zero in the lower nibble) being written to an invalid location in the stack.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3396