### PR TITLE
Add option: SLAAC for auto added prefix.

### DIFF
--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -403,6 +403,10 @@ NCPInstanceBase::add_address_on_ncp_and_update_prefixes(const in6_addr &address,
 			flags |= OnMeshPrefixEntry::kFlagDefaultRoute;
 		}
 
+		if (mSetSLAACForAutoAddedPrefix) {
+			flags |= OnMeshPrefixEntry::kFlagSLAAC;
+		}
+
 		in6_addr_apply_mask(prefix, entry.get_prefix_len());
 		on_mesh_prefix_was_added(entry.get_origin(), address, entry.get_prefix_len(), flags);
 	}

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -75,6 +75,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mNodeType = UNKNOWN;
 	mNodeTypeSupportsLegacy = false;
 	mSetDefaultRouteForAutoAddedPrefix = false;
+	mSetSLAACForAutoAddedPrefix = false;
 	mTerminateOnFault = false;
 	mWasBusy = false;
 
@@ -270,6 +271,7 @@ NCPInstanceBase::get_supported_property_keys(void) const
 	properties.insert(kWPANTUNDProperty_IPv6LinkLocalAddress);
 	properties.insert(kWPANTUNDProperty_IPv6AllAddresses);
 	properties.insert(kWPANTUNDProperty_IPv6MulticastAddresses);
+	properties.insert(kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix);
 
 	properties.insert(kWPANTUNDProperty_ThreadOnMeshPrefixes);
 
@@ -391,6 +393,9 @@ NCPInstanceBase::property_get_value(
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPHardwareAddress)) {
 		cb(0, boost::any(nl::Data(mMACHardwareAddress, sizeof(mMACHardwareAddress))));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix)) {
+		cb(0, boost::any(mSetSLAACForAutoAddedPrefix));
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
 		if (buffer_is_nonzero(mNCPV6Prefix, sizeof(mNCPV6Prefix))) {
@@ -592,6 +597,10 @@ NCPInstanceBase::property_set_value(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix)) {
 			mSetDefaultRouteForAutoAddedPrefix = any_to_bool(value);
+			cb(0);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix)) {
+			mSetSLAACForAutoAddedPrefix = any_to_bool(value);
 			cb(0);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -395,6 +395,7 @@ protected:
 	//  is updated on NCP if `mDefaultRouteForAutoAddedPrefix` is true the prefix
 	// is added with flag "DefaultRoute" set.
 	bool mSetDefaultRouteForAutoAddedPrefix;
+	bool mSetSLAACForAutoAddedPrefix;
 
 private:
 	NCPState mNCPState;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -82,6 +82,7 @@
 #define kWPANTUNDProperty_IPv6MeshLocalPrefix                   "IPv6:MeshLocalPrefix"
 #define kWPANTUNDProperty_IPv6AllAddresses                      "IPv6:AllAddresses"
 #define kWPANTUNDProperty_IPv6MulticastAddresses                "IPv6:MulticastAddresses"
+#define kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix        "IPv6:SetSLAACForAutoAddedPrefix"
 
 #define kWPANTUNDProperty_ThreadRLOC16                          "Thread:RLOC16"
 #define kWPANTUNDProperty_ThreadRouterID                        "Thread:RouterID"


### PR DESCRIPTION
This pull request adds option SLAAC for auto added prefixes. This option can be used to setup IPv6 addresses for prefixes delegated via DHCPv6-PD on the BR.