### PR TITLE
ncp-spinel: Ensure all SpinelNCPInstance member variables are initialized

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -167,19 +167,32 @@ nl::wpantund::peek_ncp_callback_status(int event, va_list args)
 SpinelNCPInstance::SpinelNCPInstance(const Settings& settings) :
 	NCPInstanceBase(settings), mControlInterface(this)
 {
-	mLastTID = 0;
-	mOutboundBufferLen = 0;
+	mInboundFrameDataLen = 0;
+	mInboundFrameDataPtr = NULL;
+	mInboundFrameDataType = 0;
+	mInboundFrameHDLCCRC = 0;
+	mInboundFrameSize = 0;
 	mInboundHeader = 0;
-	mSupprotedChannels.clear();
-
-	mSetSteeringDataWhenJoinable = false;
-	memset(mSteeringDataAddress, 0xff, sizeof(mSteeringDataAddress));
-
-	mIsPcapInProgress = false;
-	mSettings.clear();
-	mXPANIDWasExplicitlySet = false;
-	mThreadMode = 0;
 	mIsCommissioned = false;
+	mIsPcapInProgress = false;
+	mLastHeader = 0;
+	mLastTID = 0;
+	mNetworkKeyIndex = 0;
+	mOutboundBufferEscapedLen = 0;
+	mOutboundBufferLen = 0;
+	mOutboundBufferSent = 0;
+	mOutboundBufferType = 0;
+	mResetIsExpected = false;
+	mSetSteeringDataWhenJoinable = false;
+	mSubPTIndex = 0;
+	mTXPower = 0;
+	mThreadMode = 0;
+	mXPANIDWasExplicitlySet = false;
+
+	mSupprotedChannels.clear();
+	mSettings.clear();
+
+	memset(mSteeringDataAddress, 0xff, sizeof(mSteeringDataAddress));
 
 	if (!settings.empty()) {
 		int status;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -242,7 +242,6 @@ private:
 	bool mIsCommissioned;
 
 	std::set<unsigned int> mCapabilities;
-	uint32_t mDefaultChannelMask;
 
 	bool mSetSteeringDataWhenJoinable;
 	uint8_t mSteeringDataAddress[8];


### PR DESCRIPTION
This seems to be causing some noise in the fuzzer and likely contributing to unpredictable behavior; so let's fix it.

Also removes `mDefaultChannelMask`, since it was unused.