### PR TITLE
npc-spinel: Allow user to control filtering of RLOC addresses

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -240,6 +240,7 @@ private:
 	int mTXPower;
 	uint8_t mThreadMode;
 	bool mIsCommissioned;
+	bool mFilterRLOCAddresses;
 
 	std::set<unsigned int> mCapabilities;
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -105,6 +105,7 @@
 #define kWPANTUNDProperty_ThreadDeviceMode                      "Thread:DeviceMode"
 #define kWPANTUNDProperty_ThreadOffMeshRoutes                   "Thread:OffMeshRoutes"
 #define kWPANTUNDProperty_ThreadOnMeshPrefixes                  "Thread:OnMeshPrefixes"
+#define kWPANTUNDProperty_ThreadConfigFilterRLOCAddresses       "Thread:Config:FilterRLOCAddresses"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"


### PR DESCRIPTION
By default, the RLOC IPv6 addresses from NCP are filtered by wpantund
and are not added on the primary wpan interface. This commits adds a
new wpan property "Thread:Config:FilterRLOCAddresses" to allow user
to control/change this behavior. It is expected that this configuration
property  is set as part of `wpantund.conf` settings.