### PR TITLE
Replace fragile string prefix checks with `strhasprefix()`

### DIFF
--- a/src/util/socket-utils.c
+++ b/src/util/socket-utils.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include "socket-utils.h"
+#include "string-utils.h"
 #include <ctype.h>
 #include <syslog.h>
 #include <errno.h>
@@ -240,9 +241,9 @@ int gSocketWrapperBaud = 115200;
 static bool
 socket_name_is_system_command(const char* socket_name)
 {
-	return strncmp(socket_name,SOCKET_SYSTEM_COMMAND_PREFIX,strlen(SOCKET_SYSTEM_COMMAND_PREFIX)) == 0
-	    || strncmp(socket_name,SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX,strlen(SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX)) == 0
-	    || strncmp(socket_name,SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX,strlen(SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX)) == 0
+	return strhasprefix(socket_name, SOCKET_SYSTEM_COMMAND_PREFIX)
+		|| strhasprefix(socket_name, SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX)
+		|| strhasprefix(socket_name, SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX)
 	;
 }
 
@@ -640,19 +641,19 @@ get_super_socket_type_from_path(const char* socket_name)
 {
 	int socket_type = SUPER_SOCKET_TYPE_UNKNOWN;
 
-	if (strncasecmp(socket_name, SOCKET_SYSTEM_COMMAND_PREFIX, sizeof(SOCKET_SYSTEM_COMMAND_PREFIX)-1) == 0) {
+	if (strcasehasprefix(socket_name, SOCKET_SYSTEM_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_SYSTEM;
-	} else if (strncasecmp(socket_name, SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX, sizeof(SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_SYSTEM_FORKPTY_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_SYSTEM_FORKPTY;
-	} else if (strncasecmp(socket_name, SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX, sizeof(SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_SYSTEM_SOCKETPAIR_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_SYSTEM_SOCKETPAIR;
-	} else if (strncasecmp(socket_name, SOCKET_FD_COMMAND_PREFIX, sizeof(SOCKET_FD_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_FD_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_FD;
-	} else if (strncasecmp(socket_name, SOCKET_FILE_COMMAND_PREFIX, sizeof(SOCKET_FILE_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_FILE_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_DEVICE;
-	} else if (strncasecmp(socket_name, SOCKET_SERIAL_COMMAND_PREFIX, sizeof(SOCKET_SERIAL_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_SERIAL_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_DEVICE;
-	} else if (strncasecmp(socket_name, SOCKET_TCP_COMMAND_PREFIX, sizeof(SOCKET_TCP_COMMAND_PREFIX)-1) == 0) {
+	} else if (strcasehasprefix(socket_name, SOCKET_TCP_COMMAND_PREFIX)) {
 		socket_type = SUPER_SOCKET_TYPE_TCP;
 	} else if (socket_name_is_inet(socket_name) || socket_name_is_port(socket_name)) {
 		socket_type = SUPER_SOCKET_TYPE_TCP;
@@ -719,13 +720,13 @@ open_super_socket(const char* socket_name)
 
 	if (socket_type == SUPER_SOCKET_TYPE_DEVICE) {
 		socket_name_is_well_formed =
-			(strncasecmp(socket_name, SOCKET_SERIAL_COMMAND_PREFIX, sizeof(SOCKET_SERIAL_COMMAND_PREFIX)-1) == 0)
-			|| (strncasecmp(socket_name, SOCKET_FILE_COMMAND_PREFIX, sizeof(SOCKET_FILE_COMMAND_PREFIX)-1) == 0);
+			(strcasehasprefix(socket_name, SOCKET_SERIAL_COMMAND_PREFIX))
+			|| (strcasehasprefix(socket_name, SOCKET_FILE_COMMAND_PREFIX));
 	}
 
 	if (socket_type == SUPER_SOCKET_TYPE_TCP) {
 		socket_name_is_well_formed =
-			(strncasecmp(socket_name, SOCKET_TCP_COMMAND_PREFIX, sizeof(SOCKET_TCP_COMMAND_PREFIX)-1) == 0);
+			(strcasehasprefix(socket_name, SOCKET_TCP_COMMAND_PREFIX));
 		if (!socket_name_is_well_formed) {
 			filename = (char*)socket_name;
 		}
@@ -878,13 +879,13 @@ open_super_socket(const char* socket_name)
 
 		// Parse the options, if any
 		for (; NULL != options; options = strchr(options+1, ',')) {
-			if (strncasecmp(options, ",b", 2) == 0 && isdigit(options[2])) {
+			if (strcasehasprefix(options, ",b") && isdigit(options[2])) {
 				// Change Baud rate
 				int baud = baud_rate_to_termios_constant((int)strtol(options+2,NULL,10));
 				FETCH_TERMIOS();
 				cfsetspeed(&tios, baud);
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",default", strlen(",default")) == 0) {
+			} else if (strcasehasprefix(options, ",default")) {
 				FETCH_TERMIOS();
 				for (i=0; i < NCCS; i++) {
 					tios.c_cc[i] = _POSIX_VDISABLE;
@@ -898,12 +899,12 @@ open_super_socket(const char* socket_name)
 				cfmakeraw(&tios);
 				cfsetspeed(&tios, baud_rate_to_termios_constant(gSocketWrapperBaud));
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",raw", 4) == 0) {
+			} else if (strcasehasprefix(options, ",raw")) {
 				// Raw mode
 				FETCH_TERMIOS();
 				cfmakeraw(&tios);
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",clocal=", 8) == 0) {
+			} else if (strcasehasprefix(options, ",clocal=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				if (options[1] == '1') {
@@ -912,7 +913,7 @@ open_super_socket(const char* socket_name)
 					tios.c_cflag &= ~CLOCAL;
 				}
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",ixoff=", 6) == 0) {
+			} else if (strcasehasprefix(options, ",ixoff=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				if (options[1] == '1') {
@@ -921,7 +922,7 @@ open_super_socket(const char* socket_name)
 					tios.c_iflag &= ~IXOFF;
 				}
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",ixon=", 6) == 0) {
+			} else if (strcasehasprefix(options, ",ixon=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				if (options[1] == '1') {
@@ -930,7 +931,7 @@ open_super_socket(const char* socket_name)
 					tios.c_iflag &= ~IXON;
 				}
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",ixany=", 6) == 0) {
+			} else if (strcasehasprefix(options, ",ixany=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				if (options[1] == '1') {
@@ -939,7 +940,7 @@ open_super_socket(const char* socket_name)
 					tios.c_iflag &= ~IXANY;
 				}
 				COMMIT_TERMIOS();
-			} else if (strncasecmp(options, ",crtscts=", 9) == 0) {
+			} else if (strcasehasprefix(options, ",crtscts=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				// Hardware flow control
@@ -952,7 +953,7 @@ open_super_socket(const char* socket_name)
 				COMMIT_TERMIOS();
 
 #ifdef CCTS_OFLOW
-			} else if (strncasecmp(options, ",ccts_oflow=", 12) == 0) {
+			} else if (strcasehasprefix(options, ",ccts_oflow=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				// Hardware output flow control
@@ -965,7 +966,7 @@ open_super_socket(const char* socket_name)
 				COMMIT_TERMIOS();
 #endif
 #ifdef CRTS_IFLOW
-			} else if (strncasecmp(options, ",crts_iflow=", 12) == 0) {
+			} else if (strcasehasprefix(options, ",crts_iflow=")) {
 				FETCH_TERMIOS();
 				options = strchr(options,'=');
 				// Hardware input flow control

--- a/src/util/string-utils.h
+++ b/src/util/string-utils.h
@@ -51,6 +51,16 @@ int_to_hex_digit(uint8_t x)
 	return "0123456789ABCDEF"[x & 0xF];
 }
 
+static inline bool
+strhasprefix(const char* str, const char* prefix) {
+	return strnequal(str, prefix, strlen(prefix));
+}
+
+static inline bool
+strcasehasprefix(const char* str, const char* prefix) {
+	return strncaseequal(str, prefix, strlen(prefix));
+}
+
 uint32_t strtomask_uint32(const char* in_string);
 
 extern bool strtobool(const char* string);

--- a/src/util/tunnel.c
+++ b/src/util/tunnel.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "tunnel.h"
+#include "string-utils.h"
 #include <syslog.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -109,7 +110,7 @@ tunnel_open(const char* tun_name)
 	addr.ss_sysaddr = AF_SYS_CONTROL;
 	addr.sc_unit = 0;  /* allocate dynamically */
 
-	if (strncmp(tun_name, "utun", 4) == 0)
+	if (strhasprefix(tun_name, "utun"))
 		addr.sc_unit = (int)strtol(tun_name + 4, NULL, 10) + 1;
 
 	error = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
@@ -131,7 +132,7 @@ tunnel_open(const char* tun_name)
 #else
 
 #ifdef __APPLE__
-	if (strncmp(tun_name, "utun", 4) == 0)
+	if (strhasprefix(tun_name, "utun"))
 		tun_name = "tun0";
 	asprintf(&device, "/dev/%s", tun_name);
 #else

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -781,7 +781,7 @@ main(int argc, char * argv[])
 			break;
 
 		case 'o':
-			if ((optind >= argc) || (strncmp(argv[optind], "-", 1) == 0)) {
+			if ((optind >= argc) || (strhasprefix(argv[optind], "-"))) {
 				syslog(LOG_ERR, "Missing argument to '-o'.");
 				gRet = ERRORCODE_BADARG;
 				goto bail;


### PR DESCRIPTION
This commit introduces two new functions to `string-utils.h`:

*   `strhasprefix(cstr, prefix)`: Returns true if the c-string `cstr`    is prefixed by the c-string `prefix`.
*   `strcasehasprefix(cstr, prefix)`: Case insensitive version of    `strhasprefix()`.

Previously, we were using `strncmp()` for this sort of thing. However, this is dangerous because when copying and pasting code it is easy to forget to update the prefix length argument. Indeed, this has happened several times. Using `strhasprefix()` will eliminate such problems.

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3448#c3