### PR TITLE
Temporary work-around for #245: Ignore macOS build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ env:
 
 matrix:
     allow_failures:
-        - os: linux        # This seems to be some sort of weird failure to
-          compiler: clang  # find boost-signals. Needs further investigation.
+        - os: osx # See issue #245: "Travis macOS builds are failing"
     exclude:
         - os: osx
           compiler: gcc


### PR DESCRIPTION
This is a temporary work-around for issue #245.