### PR TITLE
Handle and log child entry inserted/removed spinel messages from NCP

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2470,9 +2470,38 @@ SpinelNCPInstance::handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const
 				on_mesh_prefix_was_added(kOriginThreadNCP, *prefix, prefix_len, flags, stable);
 			}
 		}
+
+	} else if (key == SPINEL_PROP_THREAD_CHILD_TABLE) {
+		SpinelNCPTaskGetNetworkTopology::TableEntry child_entry;
+		int status;
+
+		status = SpinelNCPTaskGetNetworkTopology::parse_child_entry(value_data_ptr, value_data_len, child_entry);
+
+		if (status == kWPANTUNDStatus_Ok) {
+			syslog(LOG_INFO, "[-NCP-]: ChildTable entry added: %s", child_entry.get_as_string().c_str());
+		}
+
 	}
 
 	process_event(EVENT_NCP_PROP_VALUE_INSERTED, key, value_data_ptr, value_data_len);
+}
+
+void
+SpinelNCPInstance::handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len)
+{
+	if (key == SPINEL_PROP_THREAD_CHILD_TABLE) {
+		SpinelNCPTaskGetNetworkTopology::TableEntry child_entry;
+		int status;
+
+		status = SpinelNCPTaskGetNetworkTopology::parse_child_entry(value_data_ptr, value_data_len, child_entry);
+
+		if (status == kWPANTUNDStatus_Ok) {
+			syslog(LOG_INFO, "[-NCP-]: ChildTable entry removed: %s", child_entry.get_as_string().c_str());
+		}
+
+	}
+
+	process_event(EVENT_NCP_PROP_VALUE_REMOVED, key, value_data_ptr, value_data_len);
 }
 
 void
@@ -2513,12 +2542,6 @@ SpinelNCPInstance::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_
 			);
 		}
 	}
-}
-
-void
-SpinelNCPInstance::handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len)
-{
-	process_event(EVENT_NCP_PROP_VALUE_REMOVED, key, value_data_ptr, value_data_len);
 }
 
 void

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
@@ -111,6 +111,9 @@ public:
 	// Parses the spinel child table property and updates the child_table
 	static int parse_child_table(const uint8_t *data_in, spinel_size_t data_len, Table& child_table);
 
+	// Parses a single child entry and updates the child_info
+	static int parse_child_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& child_info);
+
 	// Parses the spinel neighbor table property and updates the neighbor_table
 	static int parse_neighbor_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_table);
 


### PR DESCRIPTION
This commit contains the following changes: (a) It updates the
`SpinelNCPTaskGetNetworkTopology` to provide a new  static method for
parsing of a single child table entry (which is also used in the
method for parsing the entire child table). (b) It also updates the
`handle_ncp_spinel_value_inserted/removed()` methods to parse and log
`CHILD_TABLE` updates from NCP.