### PR TITLE
Multicasts fix for OSX

### DIFF
--- a/src/util/netif-mgmt.c
+++ b/src/util/netif-mgmt.c
@@ -206,6 +206,12 @@ netif_mgmt_get_ifindex(int reqfd, const char* if_name) {
 	if (ret >= 0) {
 		ret = ifr.ifr_ifindex;
 	}
+#else
+	ret = if_nametoindex(if_name);
+	// if_nametoindex returns 0 on error and sets errno
+	if (ret == 0) {
+		ret = -1;
+	}
 #endif
 
 	return ret;


### PR DESCRIPTION
Fix for #244

SIOGIFINDEX doesn't exist on OSX and no interface index was retrieved.
This was the under the hood problem of join_multicast_group() failure.