### PR TITLE
Adding new property wpantund "Thread:RouterTable"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -299,6 +299,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 		properties.insert(kWPANTUNDProperty_ThreadStableLeaderNetworkData);
 		properties.insert(kWPANTUNDProperty_ThreadChildTable);
 		properties.insert(kWPANTUNDProperty_ThreadNeighborTable);
+		properties.insert(kWPANTUNDProperty_ThreadRouterTable);
 		properties.insert(kWPANTUNDProperty_ThreadCommissionerEnabled);
 		properties.insert(kWPANTUNDProperty_ThreadOffMeshRoutes);
 		properties.insert(kWPANTUNDProperty_NetworkPartitionId);
@@ -1005,6 +1006,26 @@ SpinelNCPInstance::property_get_value(
 				this,
 				cb,
 				SpinelNCPTaskGetNetworkTopology::kNeighborTable,
+				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
+			)
+		));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadRouterTable)) {
+		start_new_task(boost::shared_ptr<SpinelNCPTask>(
+			new SpinelNCPTaskGetNetworkTopology(
+				this,
+				cb,
+				SpinelNCPTaskGetNetworkTopology::kRouterTable,
+				SpinelNCPTaskGetNetworkTopology::kResultFormat_StringArray
+			)
+		));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadRouterTableAsValMap)) {
+		start_new_task(boost::shared_ptr<SpinelNCPTask>(
+			new SpinelNCPTaskGetNetworkTopology(
+				this,
+				cb,
+				SpinelNCPTaskGetNetworkTopology::kRouterTable,
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
@@ -2374,6 +2395,21 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			syslog(LOG_INFO, "[-NCP-] Neighbor: %02d %s", num_neighbor, it->get_as_string().c_str());
 		}
 		syslog(LOG_INFO, "[-NCP-] Neighbor: Total %d neighbor%s", num_neighbor, (num_neighbor > 1) ? "s" : "");
+
+	} else if (key == SPINEL_PROP_THREAD_ROUTER_TABLE) {
+		SpinelNCPTaskGetNetworkTopology::Table router_table;
+		SpinelNCPTaskGetNetworkTopology::Table::iterator it;
+		int num_router = 0;
+
+		SpinelNCPTaskGetNetworkTopology::parse_router_table(value_data_ptr, value_data_len, router_table);
+
+		for (it = router_table.begin(); it != router_table.end(); it++)
+		{
+			num_router++;
+			syslog(LOG_INFO, "[-NCP-] Router: %02d %s", num_router, it->get_as_string().c_str());
+		}
+		syslog(LOG_INFO, "[-NCP-] Router: Total %d router%s", num_router, (num_router > 1) ? "es" : "");
+
 
 	} else if (key == SPINEL_PROP_NET_PARTITION_ID) {
 		uint32_t paritition_id = 0;

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
@@ -179,6 +179,116 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::parse_neighbor_table(const uint8_
 }
 
 int
+nl::wpantund::SpinelNCPTaskGetNetworkTopology::parse_router_table(const uint8_t *data_in, spinel_size_t data_len, Table& router_table)
+{
+	int ret = kWPANTUNDStatus_Ok;
+
+	router_table.clear();
+
+	while (data_len > 0)
+	{
+		spinel_ssize_t len = 0;
+		const uint8_t *struct_data;
+		spinel_size_t struct_len;
+		TableEntry router_info;
+
+		len = spinel_datatype_unpack(
+			data_in,
+			data_len,
+			SPINEL_DATATYPE_DATA_WLEN_S,
+			&struct_data,
+			&struct_len
+		);
+
+		require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+
+		ret = parse_router_entry(struct_data, struct_len, router_info);
+
+		require_noerr(ret, bail);
+
+		router_table.push_back(router_info);
+
+		data_in += len;
+		data_len -= len;
+	}
+
+bail:
+	return ret;
+}
+
+int
+nl::wpantund::SpinelNCPTaskGetNetworkTopology::parse_router_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& router_info)
+{
+	int ret = kWPANTUNDStatus_Ok;
+	spinel_ssize_t len = 0;
+	const spinel_eui64_t *eui64 = NULL;
+	uint8_t age;
+	bool link_established = false;
+
+	memset(&router_info, 0, sizeof(router_info));
+
+	router_info.mType = kRouterTable;
+
+	len = spinel_datatype_unpack(
+		data_in,
+		data_len,
+		(
+			SPINEL_DATATYPE_EUI64_S         // EUI64 Address
+			SPINEL_DATATYPE_UINT16_S        // Rloc16
+			SPINEL_DATATYPE_UINT8_S         // Router Id
+			SPINEL_DATATYPE_UINT8_S         // Next hop
+			SPINEL_DATATYPE_UINT8_S         // Path Cost
+			SPINEL_DATATYPE_UINT8_S         // Link Quality In
+			SPINEL_DATATYPE_UINT8_S         // Link Quality Out
+			SPINEL_DATATYPE_UINT8_S         // Age
+			SPINEL_DATATYPE_BOOL_S          // Is Link Established
+		),
+		&eui64,
+		&router_info.mRloc16,
+		&router_info.mRouterId,
+		&router_info.mNextHop,
+		&router_info.mPathCost,
+		&router_info.mLinkQualityIn,
+		&router_info.mLinkQualityOut,
+		&age,
+		&link_established
+	);
+
+	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+
+	memcpy(router_info.mExtAddress, eui64, sizeof(router_info.mExtAddress));
+
+	router_info.mAge = age;
+	router_info.mLinkEstablished = link_established;
+
+bail:
+	return ret;
+}
+
+unsigned int
+nl::wpantund::SpinelNCPTaskGetNetworkTopology::property_key_for_type(Type type)
+{
+	unsigned int prop_key = 0;
+
+	switch (type)
+	{
+	case kChildTable:
+		prop_key = SPINEL_PROP_THREAD_CHILD_TABLE;
+		break;
+
+	case kNeighborTable:
+		prop_key = SPINEL_PROP_THREAD_NEIGHBOR_TABLE;
+		break;
+
+	case kRouterTable:
+		prop_key = SPINEL_PROP_THREAD_ROUTER_TABLE;
+		break;
+	}
+
+	return prop_key;
+}
+
+int
 nl::wpantund::SpinelNCPTaskGetNetworkTopology::vprocess_event(int event, va_list args)
 {
 	int ret = kWPANTUNDStatus_Failure;
@@ -217,7 +327,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::vprocess_event(int event, va_list
 
 	mNextCommand = SpinelPackData(
 		SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET,
-		(mType == kChildTable) ? SPINEL_PROP_THREAD_CHILD_TABLE : SPINEL_PROP_THREAD_NEIGHBOR_TABLE
+		property_key_for_type(mType)
 	);
 
 	EH_SPAWN(&mSubPT, vprocess_send_command(event, args));
@@ -232,12 +342,14 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::vprocess_event(int event, va_list
 	data_in = va_arg(args, const uint8_t*);
 	data_len = va_arg_small(args, spinel_size_t);
 
+	require(prop_key == property_key_for_type(mType), on_error);
+
 	if (mType == kChildTable) {
-		require(prop_key == SPINEL_PROP_THREAD_CHILD_TABLE, on_error);
 		parse_child_table(data_in, data_len, mTable);
-	} else {
-		require(prop_key == SPINEL_PROP_THREAD_NEIGHBOR_TABLE, on_error);
+	} else if (mType == kNeighborTable) {
 		parse_neighbor_table(data_in, data_len, mTable);
+	} else if (mType == kRouterTable) {
+		parse_router_table(data_in, data_len, mTable);
 	}
 
 	ret = kWPANTUNDStatus_Ok;
@@ -295,7 +407,9 @@ SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_string(void) const
 {
 	char c_string[800];
 
-	if (mType == kChildTable) {
+	switch (mType)
+	{
+	case kChildTable:
 		snprintf(c_string, sizeof(c_string),
 			"%02X%02X%02X%02X%02X%02X%02X%02X, "
 			"RLOC16:%04x, "
@@ -323,8 +437,9 @@ SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_string(void) const
 			mSecureDataRequest ? "yes" : "no",
 			mFullNetworkData ? "yes" : "no"
 		);
+		break;
 
-	} else {
+	case kNeighborTable:
 		snprintf(c_string, sizeof(c_string),
 			"%02X%02X%02X%02X%02X%02X%02X%02X, "
 			"RLOC16:%04x, "
@@ -354,6 +469,35 @@ SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_string(void) const
 			mSecureDataRequest ? "yes" : "no",
 			mFullNetworkData ? "yes" : "no"
 		);
+		break;
+
+	case kRouterTable:
+		snprintf(c_string, sizeof(c_string),
+			"%02X%02X%02X%02X%02X%02X%02X%02X, "
+			"RLOC16:%04x, "
+			"RouterId:%d, "
+			"NextHop:%d, "
+			"PathCost:%d, "
+			"LQIn:%d, "
+			"LQOut:%d, "
+			"Age:%d, "
+			"LinkEst:%s",
+			mExtAddress[0], mExtAddress[1], mExtAddress[2], mExtAddress[3],
+			mExtAddress[4], mExtAddress[5], mExtAddress[6], mExtAddress[7],
+			mRloc16,
+			mRouterId,
+			mNextHop,
+			mPathCost,
+			mLinkQualityIn,
+			mLinkQualityOut,
+			mAge,
+			mLinkEstablished ? "yes" : "no"
+		);
+		break;
+
+	default:
+		c_string[0] = 0;
+		break;
 	}
 
 	return std::string(c_string);
@@ -364,6 +508,10 @@ SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_valuemap(void) const
 {
 	ValueMap entryMap;
 	uint64_t addr;
+
+	if (mType == kRouterTable) {
+		goto bail;
+	}
 
 	addr  = (uint64_t) mExtAddress[7];
 	addr |= (uint64_t) mExtAddress[6] << 8;
@@ -396,5 +544,6 @@ SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_valuemap(void) const
 	SPINEL_TOPO_MAP_INSERT( kWPANTUNDValueMapKey_NetworkTopology_IsChild,          mIsChild          );
 	}
 
+bail:
 	return entryMap;
 }

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
@@ -39,7 +39,8 @@ public:
 	enum Type
 	{
 		kChildTable,                   // Get the child table
-		kNeighborTable                 // Get the neighbor table
+		kNeighborTable,                // Get the neighbor table
+		kRouterTable,                  // Get the router table
 	};
 
 	enum ResultFormat
@@ -61,11 +62,13 @@ public:
 	{
 		Type      mType;     // Indicates if this entry is for a child or a neighbor
 
-		// Common fields for both child info and neighbor info
+		// Common fields for child info, neighbor info, and router info:
 		uint8_t   mExtAddress[8];
 		uint32_t  mAge;
 		uint16_t  mRloc16;
 		uint8_t   mLinkQualityIn;
+
+		// Common fields for both child info and neighbor info
 		int8_t    mAverageRssi;
 		int8_t    mLastRssi;
 		bool      mRxOnWhenIdle : 1;
@@ -81,6 +84,13 @@ public:
 		uint32_t  mLinkFrameCounter;
 		uint32_t  mMleFrameCounter;
 		bool      mIsChild : 1;
+
+		// Router info only
+		uint8_t   mRouterId;
+		uint8_t   mNextHop;
+		uint8_t   mPathCost;
+		uint8_t   mLinkQualityOut;
+		bool      mLinkEstablished : 1;
 
 	public:
 		std::string get_as_string(void) const;
@@ -104,7 +114,15 @@ public:
 	// Parses the spinel neighbor table property and updates the neighbor_table
 	static int parse_neighbor_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_table);
 
+	// Parses the spinel router table property and updates the router_table
+	static int parse_router_table(const uint8_t *data_in, spinel_size_t data_len, Table& router_table);
+
+	// Parses a single router entry and updates the router_info
+	static int parse_router_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& router_info);
+
 private:
+	static unsigned int property_key_for_type(Type type);
+
 	Type mType;
 	Table mTable;
 	ResultFormat mResultFormat;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -97,6 +97,8 @@
 #define kWPANTUNDProperty_ThreadChildTableAsValMap              "Thread:ChildTable:AsValMap"
 #define kWPANTUNDProperty_ThreadNeighborTable                   "Thread:NeighborTable"
 #define kWPANTUNDProperty_ThreadNeighborTableAsValMap           "Thread:NeighborTable:AsValMap"
+#define kWPANTUNDProperty_ThreadRouterTable                     "Thread:RouterTable"
+#define kWPANTUNDProperty_ThreadRouterTableAsValMap             "Thread:RouterTable:AsValMap"
 #define kWPANTUNDProperty_ThreadNetworkDataVersion              "Thread:NetworkDataVersion"
 #define kWPANTUNDProperty_ThreadStableNetworkData               "Thread:StableNetworkData"
 #define kWPANTUNDProperty_ThreadStableNetworkDataVersion        "Thread:StableNetworkDataVersion"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1413,6 +1413,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_STEERING_DATA";
         break;
 
+    case SPINEL_PROP_THREAD_ROUTER_TABLE:
+        ret = "PROP_THREAD_ROUTER_TABLE";
+        break;
+
     case SPINEL_PROP_IPV6_LL_ADDR:
         ret = "PROP_IPV6_LL_ADDR";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1010,6 +1010,24 @@ typedef enum
      */
     SPINEL_PROP_THREAD_STEERING_DATA    = SPINEL_PROP_THREAD_EXT__BEGIN + 22,
 
+    /// Thread Router Table.
+    /** Format: `A(t(ESCCCCCCb)`.
+     *
+     * Data per item is:
+     *
+     *  `E`: IEEE 802.15.4 Extended Address
+     *  `S`: RLOC16
+     *  `C`: Router ID
+     *  `C`: Next hop to router
+     *  `C`: Path cost to router
+     *  `C`: Link Quality In
+     *  `C`: Link Quality Out
+     *  `C`: Age (seconds since last heard)
+     *  `b`: Link established with Router ID or not.
+     *
+     */
+    SPINEL_PROP_THREAD_ROUTER_TABLE     = SPINEL_PROP_THREAD_EXT__BEGIN + 23,
+
     SPINEL_PROP_THREAD_EXT__END         = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN             = 0x60,


### PR DESCRIPTION
This commit adds a new wpantund property "Thread:RouteTable" which
provides the list of all routers within the Thread network. This is
mapped to spinel `SPINEL_PROP_THREAD_ROUTER_TABLE`. This commit also
updated the `SpinelNCPTaskGetNetworkTopology` class to add support
for parsing a single router entry or entire router table.

The related PR in OpenThread: https://github.com/openthread/openthread/pull/2303