### PR TITLE
Remove extra use of lock property `ALLOW_LOCAL_NET_DATA_CHANGE`

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -326,7 +326,6 @@ SpinelNCPControlInterface::joiner_add(
 				joiner_timeout,
 				addr
 			))
-			.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE)
 			.finish()
 		);
 	}
@@ -342,7 +341,6 @@ SpinelNCPControlInterface::joiner_add(
 				psk,
 				joiner_timeout
 			))
-			.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE)
 			.finish()
 		);
 	}

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -3102,7 +3102,6 @@ SpinelNCPInstance::add_unicast_address_on_ncp(const struct in6_addr &addr, uint8
 
 	syslog(LOG_NOTICE, "Adding address \"%s/%d\" to NCP", in6_addr_to_string(addr).c_str(), prefix_len);
 
-	factory.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
 	factory.set_callback(cb);
 
 	factory.add_command(
@@ -3131,7 +3130,6 @@ SpinelNCPInstance::remove_unicast_address_on_ncp(const struct in6_addr& addr, ui
 
 	syslog(LOG_NOTICE, "Removing address \"%s/%d\" from NCP", in6_addr_to_string(addr).c_str(), prefix_len);
 
-	factory.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
 	factory.set_callback(cb);
 
 	factory.add_command(
@@ -3156,7 +3154,6 @@ SpinelNCPInstance::add_multicast_address_on_ncp(const struct in6_addr &addr, Cal
 
 	syslog(LOG_NOTICE, "Adding multicast address \"%s\" to NCP", in6_addr_to_string(addr).c_str());
 
-	factory.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
 	factory.set_callback(cb);
 
 	factory.add_command(
@@ -3179,7 +3176,6 @@ SpinelNCPInstance::remove_multicast_address_on_ncp(const struct in6_addr &addr, 
 
 	syslog(LOG_NOTICE, "Removing multicast address \"%s\" from NCP", in6_addr_to_string(addr).c_str());
 
-	factory.set_lock_property(SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
 	factory.set_callback(cb);
 
 	factory.add_command(

--- a/src/ncp-spinel/SpinelNCPTaskSendCommand.h
+++ b/src/ncp-spinel/SpinelNCPTaskSendCommand.h
@@ -56,7 +56,7 @@ public:
 		Factory& set_reply_format(const std::string& packed_format);
 		Factory& set_reply_unpacker(const ReplyUnpacker &reply_unpacker);
 
-		Factory& set_lock_property(int lock_property = SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE);
+		Factory& set_lock_property(int lock_property);
 
 		boost::shared_ptr<SpinelNCPTask> finish(void);
 


### PR DESCRIPTION
The lock property `SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE` should be used when the underlying spinel propery would change the Thread Network Data (e.g., on-mesh prefixes or off-mesh routes). This commit fixes the extra/incorrect use of this lock property for other properties.

This should address https://github.com/openthread/openthread/issues/2110.