### PR TITLE
Let ncp_is_misbehaving() trigger an NCP reset/reinit from process()

### DIFF
--- a/src/wpantund/NCPInstanceBase-AsyncIO.cpp
+++ b/src/wpantund/NCPInstanceBase-AsyncIO.cpp
@@ -157,6 +157,10 @@ NCPInstanceBase::get_ms_to_next_event(void)
 		ret = 0;
 	}
 
+	if (mNCPIsMisbehaving) {
+		ret = 0;
+	}
+
 	if (ret < 0) {
 		ret = 0;
 	}
@@ -205,6 +209,20 @@ void
 NCPInstanceBase::process(void)
 {
 	int ret = 0;
+
+	if (mNCPIsMisbehaving) {
+		mFailureCount++;
+		hard_reset_ncp();
+		reset_tasks();
+		reinitialize_ncp();
+
+		if (mFailureCount >= mFailureThreshold) {
+			change_ncp_state(FAULT);
+		}
+
+		mNCPIsMisbehaving = false;
+		goto socket_failure;
+	}
 
 	mRunawayResetBackoffManager.update();
 

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -79,6 +79,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mSetSLAACForAutoAddedPrefix = false;
 	mTerminateOnFault = false;
 	mWasBusy = false;
+	mNCPIsMisbehaving = false;
 
 	memset(mNCPMeshLocalAddress.s6_addr, 0, sizeof(mNCPMeshLocalAddress));
 	memset(mNCPLinkLocalAddress.s6_addr, 0, sizeof(mNCPLinkLocalAddress));
@@ -1001,14 +1002,7 @@ NCPInstanceBase::update_busy_indication(void)
 void
 NCPInstanceBase::ncp_is_misbehaving(void)
 {
-	mFailureCount++;
-	hard_reset_ncp();
-	reset_tasks();
-	reinitialize_ncp();
-
-	if (mFailureCount >= mFailureThreshold) {
-		change_ncp_state(FAULT);
-	}
+	mNCPIsMisbehaving = true;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -535,6 +535,8 @@ private:
 	bool mWasBusy;
 	cms_t mLastChangedBusy;
 
+	bool mNCPIsMisbehaving;
+
 	FirmwareUpgrade mFirmwareUpgrade;
 
 	NetworkRetain mNetworkRetain;


### PR DESCRIPTION
This commit changes the behavior of `ncp_is_misbehaving()` such
that the reseting and reinitialization of NCP happens from the
main `NCPInstanceBase::process()`. This should help address the
following oss-fuzz issue:

* [4639](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=4639)