### PR TITLE
Speculative/Diagnostic fix for oss-fuzz-3565

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2546,7 +2546,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_NET_SAVED) {
-		bool is_commissioned;
+		bool is_commissioned = false;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_BOOL_S, &is_commissioned);
 		syslog(LOG_INFO, "[-NCP-]: NetSaved (NCP is commissioned?) \"%s\" ", is_commissioned ? "yes" : "no");
 		mIsCommissioned = is_commissioned;
@@ -2557,7 +2557,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_NET_STACK_UP) {
-		bool is_stack_up;
+		bool is_stack_up = false;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_BOOL_S, &is_stack_up);
 		syslog(LOG_INFO, "[-NCP-]: Stack is %sup", is_stack_up ? "" : "not ");
 
@@ -2572,7 +2572,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 
 	} else if (key == SPINEL_PROP_NET_IF_UP) {
-		bool is_if_up;
+		bool is_if_up = false;
 		spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_BOOL_S, &is_if_up);
 		syslog(LOG_INFO, "[-NCP-]: Interface is %sup", is_if_up ? "" : "not ");
 

--- a/src/util/IPv6PacketMatcher.cpp
+++ b/src/util/IPv6PacketMatcher.cpp
@@ -454,7 +454,9 @@ IPv6PacketMatcher::match_inbound(const uint8_t* packet) const
 void
 nl::dump_outbound_ipv6_packet(const uint8_t* packet, ssize_t len, const char* extra, bool dropped)
 {
-	if(!(setlogmask(0)&LOG_MASK(LOG_INFO))) {
+	int logmask = setlogmask(0);
+	setlogmask(logmask);
+	if(!(logmask&LOG_MASK(LOG_INFO))) {
 		return;
 	}
 	char to_addr_cstr[INET6_ADDRSTRLEN] = "::";
@@ -504,7 +506,9 @@ nl::dump_outbound_ipv6_packet(const uint8_t* packet, ssize_t len, const char* ex
 void
 nl::dump_inbound_ipv6_packet(const uint8_t* packet, ssize_t len, const char* extra, bool dropped)
 {
-	if(!(setlogmask(0)&LOG_MASK(LOG_INFO))) {
+	int logmask = setlogmask(0);
+	setlogmask(logmask);
+	if(!(logmask&LOG_MASK(LOG_INFO))) {
 		return;
 	}
 	char to_addr_cstr[INET6_ADDRSTRLEN] = "::";

--- a/src/util/nlpt-select.c
+++ b/src/util/nlpt-select.c
@@ -40,6 +40,13 @@ fd_set_merge(const fd_set *src, fd_set *dest, int fd_count)
 	const int32_t* src_data = (const int32_t*)src->fds_bits;
 	int32_t* dest_data = (int32_t*)dest->fds_bits;
 
+	assert(fd_count >= 0);
+	assert(fd_count <= FD_SETSIZE);
+
+	if (fd_count > FD_SETSIZE) {
+		fd_count = FD_SETSIZE;
+	}
+
 	for (i = (fd_count+31)/32; i > 0 ; --i) {
 		*dest_data++ |= *src_data++;
 	}
@@ -96,7 +103,7 @@ _nlpt_cleanup_all(struct nlpt* nlpt)
 void
 _nlpt_cleanup_read_fd_source(struct nlpt* nlpt, int fd)
 {
-	if (fd >= 0) {
+	if ((fd >= 0) && (fd < FD_SETSIZE)) {
 		FD_CLR(fd, &nlpt->read_fds);
 		FD_CLR(fd, &nlpt->error_fds);
 	}
@@ -105,7 +112,7 @@ _nlpt_cleanup_read_fd_source(struct nlpt* nlpt, int fd)
 void
 _nlpt_cleanup_write_fd_source(struct nlpt* nlpt, int fd)
 {
-	if (fd >= 0) {
+	if ((fd >= 0) && (fd < FD_SETSIZE)) {
 		FD_CLR(fd, &nlpt->write_fds);
 		FD_CLR(fd, &nlpt->error_fds);
 	}
@@ -114,7 +121,7 @@ _nlpt_cleanup_write_fd_source(struct nlpt* nlpt, int fd)
 void
 _nlpt_setup_read_fd_source(struct nlpt* nlpt, int fd)
 {
-	if (fd >= 0) {
+	if ((fd >= 0) && (fd < FD_SETSIZE)) {
 		if (fd > nlpt->max_fd) {
 			nlpt->max_fd = fd;
 		}
@@ -126,7 +133,7 @@ _nlpt_setup_read_fd_source(struct nlpt* nlpt, int fd)
 void
 _nlpt_setup_write_fd_source(struct nlpt* nlpt, int fd)
 {
-	if (fd >= 0) {
+	if ((fd >= 0) && (fd < FD_SETSIZE)) {
 		if (fd > nlpt->max_fd) {
 			nlpt->max_fd = fd;
 		}

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -670,7 +670,9 @@ NCPInstanceBase::property_set_value(
 			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSyslogMask)) {
+#if !FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 			setlogmask(strtologmask(any_to_string(value).c_str(), setlogmask(0)));
+#endif
 			cb(0);
 
 		} else if (StatCollector::is_a_stat_property(key)) {

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -322,9 +322,6 @@ set_config_param(
 		ret = 0;
 		require(9600 <= baud, bail);
 		gSocketWrapperBaud = baud;
-	} else if (strcaseequal(key, kWPANTUNDProperty_DaemonSyslogMask)) {
-		setlogmask(strtologmask(value, setlogmask(0)));
-		ret = 0;
 #if !FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 #if HAVE_PWD_H
 	} else if (strcaseequal(key, kWPANTUNDProperty_ConfigDaemonPrivDropToUser)) {
@@ -335,6 +332,9 @@ set_config_param(
 		}
 		ret = 0;
 #endif // if HAVE_PWD_H
+	} else if (strcaseequal(key, kWPANTUNDProperty_DaemonSyslogMask)) {
+		setlogmask(strtologmask(value, setlogmask(0)));
+		ret = 0;
 	} else if (strcaseequal(key, kWPANTUNDProperty_ConfigDaemonChroot)) {
 		if (value[0] == 0) {
 			gChroot = NULL;
@@ -481,8 +481,10 @@ syslog_dump_select_info(int loglevel, fd_set *read_fd_set, fd_set *write_fd_set,
 		syslog(l, "SELECT:     %s: %s", #x, buffer.c_str()); \
 	} while (0)
 
+	int logmask = setlogmask(0);
+	setlogmask(logmask);
 	// Check the log level preemptively to avoid wasted CPU.
-	if((setlogmask(0)&LOG_MASK(loglevel))) {
+	if((logmask&LOG_MASK(loglevel))) {
 		syslog(loglevel, "SELECT: fd_count=%d cms_timeout=%d", fd_count, timeout);
 
 		DUMP_FD_SET(loglevel, read_fd_set);


### PR DESCRIPTION
[oss-fuzz-3565](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3565) describes an unreproducable (but frequently occuring) global buffer overflow discovered by fuzzing. The immediate cause of the overflow is the failure of `fd_set_merge()` to respect the size boundaries of an `fd_set`, which is limited to accounting to no more than `FD_SETSIZE` file descriptors.

However, the fact that we are getting anywhere close to the `FD_SETSIZE` file descriptor limit indicates that we may very well be leaking file descriptors. As such, this commit adds a quick file descriptor leak check, intended to help identify file descriptor leaks more quickly.

Such a file descriptor leak is likely to only be a practical problem for fuzzing efforts, since the normal instance of wpantund would only ever initialize once.