### PR TITLE
Fix problem with building wpantund.

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
@@ -669,7 +669,7 @@ bail:
 }
 
 ValueMap
-SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_valuemap(void)
+SpinelNCPTaskGetNetworkTopology::TableEntry::get_as_valuemap(void) const
 {
 	ValueMap entryMap;
 	uint64_t addr;

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
@@ -105,7 +105,7 @@ public:
 
 		void clear(void);
 		std::string get_as_string(void);
-		ValueMap get_as_valuemap(void);
+		ValueMap get_as_valuemap(void) const;
 	};
 
 	typedef std::list<TableEntry> Table;


### PR DESCRIPTION
This pull request solves problem with building latest wpantund on the RPi3 platform. During building the border router I've got an error which says that cannot bind bitfields variables with their names. e.g. ```SpinelNCPTaskGetNetworkTopology.cpp:698:83: error: cannot bind bitfield ((nl::wpantund::SpinelNCPtaskGetNetworkTopology::TableEntry*)this)->nl::wpantund::SpinelNCPTaskGetNetworkTopology::TableEntry::mRxOnWhenIdle to bool&```.