### PR TITLE
Fix and update for oss-fuzz-3565

### DIFF
--- a/etc/fuzz-corpus/wpantund-fuzz/oss-fuzz-3565
+++ b/etc/fuzz-corpus/wpantund-fuzz/oss-fuzz-3565
@@ -1,0 +1,2 @@
+0ConfiG:NCP:SocketPath "/dev/null"
+Config:NCP:SocketPath "/dev/null"

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -92,9 +92,15 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 
 		for(iter = settings.begin(); iter != settings.end(); iter++) {
 			if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_ConfigNCPHardResetPath)) {
+				if (mResetFD > 0) {
+					close_super_socket(mResetFD);
+				}
 				mResetFD = open_super_socket(iter->second.c_str());
 
 			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_ConfigNCPPowerPath)) {
+				if (mPowerFD > 0) {
+					close_super_socket(mPowerFD);
+				}
 				mPowerFD = open_super_socket(iter->second.c_str());
 
 			} else if (strcaseequal(iter->first.c_str(), kWPANTUNDProperty_ConfigNCPSocketPath)) {
@@ -197,8 +203,8 @@ NCPInstanceBase::setup_property_supported_by_class(const std::string& prop_name)
 
 NCPInstanceBase::~NCPInstanceBase()
 {
-	close(mPowerFD);
-	close(mResetFD);
+	close_super_socket(mPowerFD);
+	close_super_socket(mResetFD);
 }
 
 const std::string &


### PR DESCRIPTION
This commit fixes a bug in the previous diagnostic update that prevented the new code from properly identifying file descriptor leaks.

It also fixes the original file descriptor leak that led to [oss-fuzz-3565](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=3565) in the first place.

  