### PR TITLE
Adding properties related to for Channel Monitoring feature

### DIFF
--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -169,6 +169,13 @@
 #define kWPANTUNDProperty_JamDetectionBusyPeriod                "JamDetection:BusyPeriod"
 #define kWPANTUNDProperty_JamDetectionDebugHistoryBitmap        "JamDetection:Debug:HistoryBitmap"
 
+#define kWPANTUNDProperty_ChannelMonitorSampleInterval          "ChannelMonitor:SampleInterval"
+#define kWPANTUNDProperty_ChannelMonitorRssiThreshold           "ChannelMonitor:RssiThreshold"
+#define kWPANTUNDProperty_ChannelMonitorSampleWindow            "ChannelMonitor:SampleWindow"
+#define kWPANTUNDProperty_ChannelMonitorSampleCount             "ChannelMonitor:SampleCount"
+#define kWPANTUNDProperty_ChannelMonitorChannelQuality          "ChannelMonitor:ChannelQuality"
+#define kWPANTUNDProperty_ChannelMonitorChannelQualityAsValMap  "ChannelMonitor:ChannelQuality:AsValMap"
+
 #define kWPANTUNDProperty_TmfProxyEnabled                       "TmfProxy:Enabled"
 #define kWPANTUNDProperty_TmfProxyStream                        "TmfProxy:Stream"
 
@@ -250,6 +257,9 @@
 
 #define kWPANTUNDValueMapKey_Whitelist_ExtAddress               "ExtAddress"
 #define kWPANTUNDValueMapKey_Whitelist_Rssi                     "FixedRssi"
+
+#define kWPANTUNDValueMapKey_ChannelMonitor_Channel             "Channel"
+#define kWPANTUNDValueMapKey_ChannelMonitor_Quality             "Quality"
 
 #define kWPANTUNDValueMapKey_NetworkTopology_ExtAddress         "ExtAddress"
 #define kWPANTUNDValueMapKey_NetworkTopology_RLOC16             "RLOC16"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1189,6 +1189,26 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_JAM_DETECT_HISTORY_BITMAP";
         break;
 
+    case SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL:
+        ret = "PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL";
+        break;
+
+    case SPINEL_PROP_CHANNEL_MONITOR_RSSI_THRESHOLD:
+        ret = "PROP_CHANNEL_MONITOR_RSSI_THRESHOLD";
+        break;
+
+    case SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_WINDOW:
+        ret = "PROP_CHANNEL_MONITOR_SAMPLE_WINDOW";
+        break;
+
+    case SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT:
+        ret = "PROP_CHANNEL_MONITOR_SAMPLE_COUNT";
+        break;
+
+    case SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY:
+        ret = "PROP_CHANNEL_MONITOR_CHANNEL_QUALITY";
+        break;
+
     case SPINEL_PROP_MAC_SCAN_STATE:
         ret = "PROP_MAC_SCAN_STATE";
         break;
@@ -2098,6 +2118,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_OOB_STEERING_DATA:
         ret = "CAP_OOB_STEERING_DATA";
+        break;
+
+    case SPINEL_CAP_CHANNEL_MONITOR:
+        ret = "CAP_CHANNEL_MONITOR";
         break;
 
     case SPINEL_CAP_THREAD_COMMISSIONER:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -399,6 +399,7 @@ enum
     SPINEL_CAP_MAC_WHITELIST            = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
     SPINEL_CAP_MAC_RAW                  = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
     SPINEL_CAP_OOB_STEERING_DATA        = (SPINEL_CAP_OPENTHREAD__BEGIN + 2),
+    SPINEL_CAP_CHANNEL_MONITOR          = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
     SPINEL_CAP_OPENTHREAD__END          = 640,
 
     SPINEL_CAP_THREAD__BEGIN            = 1024,
@@ -667,6 +668,81 @@ typedef enum
     SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP
                                         = SPINEL_PROP_PHY_EXT__BEGIN + 5,
 
+    /// Channel monitoring sample interval
+    /** Format: `L` (read-only)
+     *  Units: Milliseconds
+     *
+     * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     * If channel monitoring is enabled and active, every sample interval, a
+     * zero-duration Energy Scan is performed, collecting a single RSSI sample
+     * per channel. The RSSI samples are compared with a pre-specified RSSI
+     * threshold.
+     *
+     */
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 6,
+
+    /// Channel monitoring RSS threshold
+    /** Format: `c` (read-only)
+     *  Units: dBm
+     *
+     * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     */
+    SPINEL_PROP_CHANNEL_MONITOR_RSSI_THRESHOLD
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 7,
+
+    /// Channel monitoring sample window
+    /** Format: `L` (read-only)
+     *  Units: Number of samples
+     *
+     * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     * The averaging sample window length (in units of number of channel
+     * samples) used by channel monitoring module. Channel monitoring will
+     * sample all channels every sample interval. It maintains the average rate
+     * of RSS samples that are above the RSS threshold within (approximately)
+     * the sample window.
+     *
+     */
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_WINDOW
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 8,
+
+    /// Channel monitoring sample count
+    /** Format: `L` (read-only)
+     *  Units: Number of samples
+     *
+     * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     * Total number of RSS samples taken so far by channel monitoring
+     * module.
+     *
+     */
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 9,
+
+    /// Channel monitoring channel quality
+    /** Format: `A(t(CU))` (read-only)
+     *
+     * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     * Data per item is:
+     *
+     *  `C`: Channel
+     *  `U`: Channel quality indicator
+     *
+     * The channel quality value represents the average rate/percentage of
+     * RSS samples that were above RSS threshold ("bad" RSS samples) within
+     * (approximately) sample window latest RSSI samples.
+     *
+     * Max value of `0xffff` indicates all RSS samples were above RSS
+     * threshold (i.e. 100% of samples were "bad").
+     *
+     */
+    SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY
+                                        = SPINEL_PROP_PHY_EXT__BEGIN + 10,
+
     SPINEL_PROP_PHY_EXT__END            = 0x1300,
 
     SPINEL_PROP_MAC__BEGIN              = 0x30,
@@ -798,7 +874,7 @@ typedef enum
      *
      * Data per item is:
      *
-     *  `E`: Extended/long address
+     *  `E`: Extended address
      *  `S`: RLOC16
      *  `L`: Timeout (in seconds)
      *  `L`: Age (in seconds)
@@ -955,7 +1031,7 @@ typedef enum
      *
      * Data per item is:
      *
-     *  `E`: Extended/long address
+     *  `E`: Extended address
      *  `S`: RLOC16
      *  `L`: Age (in seconds)
      *  `C`: Link Quality In
@@ -1229,7 +1305,7 @@ typedef enum
      *
      * Data per item is:
      *
-     *  `E`: Extended/long address of the child
+     *  `E`: Extended address of the child
      *  `S`: RLOC16 of the child
      *  `A(6)`: List of IPv6 addresses registered by the child (if any)
      *


### PR DESCRIPTION
This commit adds support for new properties related to OpenThread's
Channel Monitoring feature. This feature allows the NCP to periodically
monitor all channels to help determine the cleaner channels (channels
with less interference).

Related PR in OpenThread: https://github.com/openthread/openthread/pull/2462