### PR TITLE
Fix for minor file descriptor leak

### DIFF
--- a/src/util/SocketAdapter.cpp
+++ b/src/util/SocketAdapter.cpp
@@ -60,6 +60,12 @@ SocketAdapter::write(const void* data, size_t len)
 	return mParent ? mParent->write(data, len) : -EINVAL;
 }
 
+off_t
+SocketAdapter::lseek(off_t offset, int whence)
+{
+	return mParent ? mParent->lseek(offset, whence) : -EINVAL;
+}
+
 ssize_t
 SocketAdapter::read(void* data, size_t len)
 {

--- a/src/util/SocketAdapter.h
+++ b/src/util/SocketAdapter.h
@@ -36,6 +36,7 @@ public:
 
 	virtual ssize_t write(const void* data, size_t len);
 	virtual ssize_t read(void* data, size_t len);
+	virtual off_t lseek(off_t offset, int whence);
 	virtual bool can_read(void)const;
 	virtual bool can_write(void)const;
 	virtual int get_read_fd(void)const;

--- a/src/util/SocketWrapper.cpp
+++ b/src/util/SocketWrapper.cpp
@@ -58,6 +58,7 @@ SocketWrapper::can_write(void)const
 int
 SocketWrapper::set_log_level(int log_level)
 {
+	errno = ENOTSUP;
 	return -ENOTSUP;
 }
 
@@ -84,6 +85,13 @@ SocketWrapper::send_break(void)
 {
 }
 
+off_t
+SocketWrapper::lseek(off_t offset, int whence)
+{
+	errno = ENOTSUP;
+	return -ENOTSUP;
+}
+
 void
 SocketWrapper::reset(void)
 {
@@ -92,7 +100,8 @@ SocketWrapper::reset(void)
 int
 SocketWrapper::hibernate(void)
 {
-	return -1;
+	errno = ENOTSUP;
+	return -ENOTSUP;
 }
 
 bool

--- a/src/util/SocketWrapper.h
+++ b/src/util/SocketWrapper.h
@@ -46,6 +46,7 @@ public:
 	virtual ~SocketWrapper();
 	virtual ssize_t write(const void* data, size_t len) = 0;
 	virtual ssize_t read(void* data, size_t len) = 0;
+	virtual off_t lseek(off_t offset, int whence);
 	virtual bool can_read(void)const;
 	virtual bool can_write(void)const;
 	virtual int process(void) = 0;

--- a/src/util/UnixSocket.cpp
+++ b/src/util/UnixSocket.cpp
@@ -28,6 +28,8 @@
 #include <sys/file.h>
 #include <syslog.h>
 #include <poll.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 using namespace nl;
 
@@ -127,6 +129,12 @@ UnixSocket::read(void* data, size_t len)
 	}
 
 	return ret;
+}
+
+off_t
+UnixSocket::lseek(off_t offset, int whence)
+{
+	return ::lseek(mFDRead, offset, whence);
 }
 
 bool

--- a/src/util/UnixSocket.h
+++ b/src/util/UnixSocket.h
@@ -36,6 +36,7 @@ public:
 	virtual ~UnixSocket();
 	virtual ssize_t write(const void* data, size_t len);
 	virtual ssize_t read(void* data, size_t len);
+	virtual off_t lseek(off_t offset, int whence);
 	virtual bool can_read(void)const;
 	virtual bool can_write(void)const;
 	virtual int get_read_fd(void)const;

--- a/src/wpantund/NCPInstanceBase-AsyncIO.cpp
+++ b/src/wpantund/NCPInstanceBase-AsyncIO.cpp
@@ -37,7 +37,7 @@ using namespace wpantund;
 bool
 NCPInstanceBase::can_set_ncp_power(void)
 {
-	return mPowerFD >= 0;
+	return mPowerSocket != NULL;
 }
 
 int
@@ -45,18 +45,18 @@ NCPInstanceBase::set_ncp_power(bool power)
 {
 	ssize_t ret = -1;
 
-	if (mPowerFD >= 0) {
+	if (can_set_ncp_power()) {
 		// Since controlling the power such a low-level
 		// operation, we break with our usual "no blocking calls"
 		// rule here for code clarity and to avoid
 		// unnecessary complexity.
 
-		IGNORE_RETURN_VALUE( lseek(mPowerFD, 0, SEEK_SET));
+		IGNORE_RETURN_VALUE( mPowerSocket->lseek(0, SEEK_SET));
 
 		if (power) {
-			ret = write(mPowerFD, static_cast<const void*>(&mPowerFD_PowerOn), 1);
+			ret = mPowerSocket->write(static_cast<const void*>(&mPowerSocket_PowerOn), 1);
 		} else {
-			ret = write(mPowerFD, static_cast<const void*>(&mPowerFD_PowerOff), 1);
+			ret = mPowerSocket->write(static_cast<const void*>(&mPowerSocket_PowerOff), 1);
 		}
 
 		require_string(ret >= 0, bail, strerror(errno));
@@ -66,7 +66,7 @@ NCPInstanceBase::set_ncp_power(bool power)
 		// fails. This happens when writing directly to GPIO
 		// files. We write the "\n" anyway to make it easier
 		// for non-GPIO sockets to parse.
-		IGNORE_RETURN_VALUE( write(mPowerFD, static_cast<const void*>("\n"), 1) );
+		IGNORE_RETURN_VALUE( mPowerSocket->write(static_cast<const void*>("\n"), 1) );
 	}
 
 	if (ret > 0) {
@@ -84,7 +84,7 @@ NCPInstanceBase::hard_reset_ncp(void)
 	NLPT_INIT(&mDriverToNCPPumpPT);
 	NLPT_INIT(&mNCPToDriverPumpPT);
 
-	if (mResetFD >= 0) {
+	if (mResetSocket != NULL) {
 		// Since hardware resets are such a low-level
 		// operation, we break with our usual "no blocking calls"
 		// rule here for code clarity and to avoid
@@ -92,9 +92,9 @@ NCPInstanceBase::hard_reset_ncp(void)
 
 		ssize_t wret = -1;
 
-		IGNORE_RETURN_VALUE( lseek(mResetFD, 0, SEEK_SET) );
+		IGNORE_RETURN_VALUE( mResetSocket->lseek(0, SEEK_SET) );
 
-		wret = write(mResetFD, static_cast<const void*>(&mResetFD_BeginReset), 1);
+		wret = mResetSocket->write(static_cast<const void*>(&mResetSocket_BeginReset), 1);
 
 		check_string(wret != -1, strerror(errno));
 
@@ -103,17 +103,17 @@ NCPInstanceBase::hard_reset_ncp(void)
 		// fails. This happens when writing directly to GPIO
 		// files. We write the "\n" anyway to make it easier
 		// for non-GPIO sockets to parse.
-		IGNORE_RETURN_VALUE( write(mResetFD, static_cast<const void*>("\n"), 1) );
+		IGNORE_RETURN_VALUE( mResetSocket->write(static_cast<const void*>("\n"), 1) );
 
 		usleep(20 * USEC_PER_MSEC);
 
-		IGNORE_RETURN_VALUE( lseek(mResetFD, 0, SEEK_SET) );
+		IGNORE_RETURN_VALUE( mResetSocket->lseek(0, SEEK_SET) );
 
-		wret = write(mResetFD, static_cast<const void*>(&mResetFD_EndReset), 1);
+		wret = mResetSocket->write(static_cast<const void*>(&mResetSocket_EndReset), 1);
 
 		check_string(wret != -1, strerror(errno));
 
-		IGNORE_RETURN_VALUE( write(mResetFD, static_cast<const void*>("\n"), 1) );
+		IGNORE_RETURN_VALUE( mResetSocket->write(static_cast<const void*>("\n"), 1) );
 	} else {
 		mSerialAdapter->reset();
 	}

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -524,13 +524,13 @@ private:
 	// ========================================================================
 	// MARK: Private Data
 
-	int mResetFD; //!^ File descriptor for resetting NCP.
-	char mResetFD_BeginReset; //!^ Value for entering reset
-	char mResetFD_EndReset; //!^ Value for leaving reset
+	boost::shared_ptr<SocketWrapper> mResetSocket;
+	char mResetSocket_BeginReset; //!^ Value for entering reset
+	char mResetSocket_EndReset; //!^ Value for leaving reset
 
-	int mPowerFD; //!^ File descriptor for controlling NCP power.
-	char mPowerFD_PowerOn; //!^ Value for the power being on.
-	char mPowerFD_PowerOff; //!^ Value for the power being off.
+	boost::shared_ptr<SocketWrapper> mPowerSocket;
+	char mPowerSocket_PowerOn; //!^ Value for the power being on.
+	char mPowerSocket_PowerOff; //!^ Value for the power being off.
 
 	bool mWasBusy;
 	cms_t mLastChangedBusy;

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -178,7 +178,7 @@ signal_SIGINT(int sig)
 
 	// Can't use syslog() because it isn't async signal safe.
 	// So we write to stderr
-	(void)write(STDERR_FILENO, message, sizeof(message)-1);
+	IGNORE_RETURN_VALUE(write(STDERR_FILENO, message, sizeof(message)-1));
 
 	// Restore the previous handler so that if we end up getting
 	// this signal again we peform the system default action.


### PR DESCRIPTION
[oss-fuzz-5238](https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5238) identified a minor file descriptor leak which was interrupting fuzzing efficiency (but would not affect normal operation). This commit addresses that leak.