### PR TITLE
Add new property to get all NCP MAC counters

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -310,36 +310,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 	}
 
 	if (mCapabilities.count(SPINEL_CAP_COUNTERS)) {
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_TOTAL");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_UNICAST");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_BROADCAST");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_ACK_REQ");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_ACKED");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_NO_ACK_REQ");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_DATA");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_DATA_POLL");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_BEACON");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_BEACON_REQ");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_OTHER");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_PKT_RETRY");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_ERR_CCA");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_ERR_ABORT");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_TOTAL");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_UNICAST");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_BROADCAST");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_DATA");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_DATA_POLL");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_BEACON");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_BEACON_REQ");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_OTHER");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_FILT_WL");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_PKT_FILT_DA");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_EMPTY");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_UKWN_NBR");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_NVLD_SADDR");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_SECURITY");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_BAD_FCS");
-		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "RX_ERR_OTHER");
+		properties.insert(kWPANTUNDProperty_NCPCounterAllMac);
 		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_IP_SEC_TOTAL");
 		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_IP_INSEC_TOTAL");
 		properties.insert(kWPANTUNDProperty_Spinel_CounterPrefix "TX_IP_DROPPED");
@@ -604,6 +575,113 @@ unpack_channel_monitor_channel_quality(const uint8_t *data_in, spinel_size_t dat
 
 		data_in += len;
 		data_len -= len;
+	}
+
+	if (as_val_map) {
+		value = result_as_val_map;
+	} else {
+		value = result_as_string;
+	}
+
+bail:
+	return ret;
+}
+
+static int
+unpack_ncp_counters_all_mac(const uint8_t *data_in, spinel_size_t data_len, boost::any& value, bool as_val_map)
+{
+	std::list<std::string> result_as_string;
+	ValueMap result_as_val_map;
+	int ret = kWPANTUNDStatus_Ok;
+	spinel_ssize_t len;
+
+	const char *tx_counter_names[] = {
+		kWPANTUNDValueMapKey_Counter_TxTotal,
+		kWPANTUNDValueMapKey_Counter_TxUnicast,
+		kWPANTUNDValueMapKey_Counter_TxBroadcast,
+		kWPANTUNDValueMapKey_Counter_TxAckRequested,
+		kWPANTUNDValueMapKey_Counter_TxAcked,
+		kWPANTUNDValueMapKey_Counter_TxNoAckRequested,
+		kWPANTUNDValueMapKey_Counter_TxData,
+		kWPANTUNDValueMapKey_Counter_TxDataPoll,
+		kWPANTUNDValueMapKey_Counter_TxBeacon,
+		kWPANTUNDValueMapKey_Counter_TxBeaconRequest,
+		kWPANTUNDValueMapKey_Counter_TxOther,
+		kWPANTUNDValueMapKey_Counter_TxRetry,
+		kWPANTUNDValueMapKey_Counter_TxErrCca,
+		kWPANTUNDValueMapKey_Counter_TxErrAbort,
+		kWPANTUNDValueMapKey_Counter_TxErrBusyChannel,
+		NULL
+	};
+
+	const char *rx_counter_names[] = {
+		kWPANTUNDValueMapKey_Counter_RxTotal,
+		kWPANTUNDValueMapKey_Counter_RxUnicast,
+		kWPANTUNDValueMapKey_Counter_RxBroadcast,
+		kWPANTUNDValueMapKey_Counter_RxData,
+		kWPANTUNDValueMapKey_Counter_RxDataPoll,
+		kWPANTUNDValueMapKey_Counter_RxBeacon,
+		kWPANTUNDValueMapKey_Counter_RxBeaconRequest,
+		kWPANTUNDValueMapKey_Counter_RxOther,
+		kWPANTUNDValueMapKey_Counter_RxAddressFiltered,
+		kWPANTUNDValueMapKey_Counter_RxDestAddrFiltered,
+		kWPANTUNDValueMapKey_Counter_RxDuplicated,
+		kWPANTUNDValueMapKey_Counter_RxErrNoFrame,
+		kWPANTUNDValueMapKey_Counter_RxErrUnknownNeighbor,
+		kWPANTUNDValueMapKey_Counter_RxErrInvalidSrcAddr,
+		kWPANTUNDValueMapKey_Counter_RxErrSec,
+		kWPANTUNDValueMapKey_Counter_RxErrFcs,
+		kWPANTUNDValueMapKey_Counter_RxErrOther,
+		NULL
+	};
+
+	for (int struct_index = 0; struct_index < 2; struct_index++)
+	{
+		const char **counter_names;
+		const uint8_t *struct_in = NULL;
+		unsigned int struct_len = 0;
+		spinel_size_t len;
+
+		counter_names = (struct_index == 0) ? tx_counter_names : rx_counter_names;
+
+		len = spinel_datatype_unpack(
+			data_in,
+			data_len,
+			SPINEL_DATATYPE_DATA_WLEN_S,
+			&struct_in,
+			&struct_len
+		);
+
+		require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+
+		data_in += len;
+		data_len -= len;
+
+		while (*counter_names != NULL) {
+			uint32_t counter_value;
+
+			len = spinel_datatype_unpack(
+				struct_in,
+				struct_len,
+				SPINEL_DATATYPE_UINT32_S,
+				&counter_value
+			);
+
+			require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+
+			struct_in  += len;
+			struct_len -= len;
+
+			if (!as_val_map) {
+				char c_string[200];
+				snprintf(c_string, sizeof(c_string), "%-20s = %d", *counter_names, counter_value);
+				result_as_string.push_back(std::string(c_string));
+			} else {
+				result_as_val_map[*counter_names] = counter_value;
+			}
+
+			counter_names++;
+		}
 	}
 
 	if (as_val_map) {
@@ -1408,6 +1486,34 @@ SpinelNCPInstance::property_get_value(
 		std::list<std::string> help_string;
 		get_dataset_command_help(help_string);
 		cb(kWPANTUNDStatus_Ok, boost::any(help_string));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPCounterAllMac)) {
+		if (!mCapabilities.count(SPINEL_CAP_COUNTERS)) {
+			cb(kWPANTUNDStatus_FeatureNotSupported, boost::any(std::string("Channel Monitoring Feature Not Supported")));
+		} else {
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CNTR_ALL_MAC_COUNTERS)
+				)
+				.set_reply_unpacker(boost::bind(unpack_ncp_counters_all_mac, _1, _2, _3, /* as_val_map */ false))
+				.finish()
+			);
+		}
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPCounterAllMacAsValMap)) {
+		if (!mCapabilities.count(SPINEL_CAP_COUNTERS)) {
+			cb(kWPANTUNDStatus_FeatureNotSupported, boost::any(std::string("Channel Monitoring Feature Not Supported")));
+		} else {
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CNTR_ALL_MAC_COUNTERS)
+				)
+				.set_reply_unpacker(boost::bind(unpack_ncp_counters_all_mac, _1, _2, _3, /* as_val_map */ true))
+				.finish()
+			);
+		}
 
 	} else if (strncaseequal(key.c_str(), kWPANTUNDProperty_Spinel_CounterPrefix, sizeof(kWPANTUNDProperty_Spinel_CounterPrefix)-1)) {
 		int cntr_key = 0;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -152,6 +152,9 @@
 #define kWPANTUNDProperty_OpenThreadDebugTestAssert             "OpenThread:Debug:TestAssert"
 #define kWPANTUNDProperty_OpenThreadDebugTestWatchdog           "OpenThread:Debug:TestWatchdog"
 
+#define kWPANTUNDProperty_NCPCounterAllMac                      "NCP:Counter:AllMac"
+#define kWPANTUNDProperty_NCPCounterAllMacAsValMap              "NCP:Counter:AllMac:AsValMap"
+
 #define kWPANTUNDProperty_DebugIPv6GlobalIPAddressList          "Debug:IPv6:GlobalIPAddressList"
 
 #define kWPANTUNDProperty_MACWhitelistEnabled                   "MAC:Whitelist:Enabled"
@@ -283,5 +286,38 @@
 #define kWPANTUNDValueMapKey_Scan_JoinerFalg                    "Scan:JoinerFlag"
 #define kWPANTUNDValueMapKey_Scan_EnableFiltering               "Scan:EnableFiltering"
 #define kWPANTUNDValueMapKey_Scan_PANIDFilter                   "Scan:PANID"
+
+#define kWPANTUNDValueMapKey_Counter_TxTotal                    "TxTotal"              // Number of transmissions
+#define kWPANTUNDValueMapKey_Counter_TxUnicast                  "TxUnicast"            // Number of unicast transmissions
+#define kWPANTUNDValueMapKey_Counter_TxBroadcast                "TxBroadcast"          // Number of broadcast transmissions
+#define kWPANTUNDValueMapKey_Counter_TxAckRequested             "TxAckRequested"       // Number of transmissions with ack request
+#define kWPANTUNDValueMapKey_Counter_TxAcked                    "TxAcked"              // Number of transmissions that were acked
+#define kWPANTUNDValueMapKey_Counter_TxNoAckRequested           "TxNoAckRequested"     // Number of transmissions without ack request
+#define kWPANTUNDValueMapKey_Counter_TxData                     "TxData"               // Number of transmitted data
+#define kWPANTUNDValueMapKey_Counter_TxDataPoll                 "TxDataPoll"           // Number of transmitted data poll
+#define kWPANTUNDValueMapKey_Counter_TxBeacon                   "TxBeacon"             // Number of transmitted beacon
+#define kWPANTUNDValueMapKey_Counter_TxBeaconRequest            "TxBeaconRequest"      // Number of transmitted beacon request
+#define kWPANTUNDValueMapKey_Counter_TxOther                    "TxOther"              // Number of transmitted other types of frames
+#define kWPANTUNDValueMapKey_Counter_TxRetry                    "TxRetry"              // Number of retransmission times
+#define kWPANTUNDValueMapKey_Counter_TxErrCca                   "TxErrCca"             // Number of CCA failure times
+#define kWPANTUNDValueMapKey_Counter_TxErrAbort                 "TxErrAbort"           // Number of frame transmission failures due to abort error
+#define kWPANTUNDValueMapKey_Counter_TxErrBusyChannel           "TxErrBusyChannel"     // Number of frames that were dropped due to a busy channel
+#define kWPANTUNDValueMapKey_Counter_RxTotal                    "RxTotal"              // Number of received packets
+#define kWPANTUNDValueMapKey_Counter_RxUnicast                  "RxUnicast"            // Number of unicast packets received
+#define kWPANTUNDValueMapKey_Counter_RxBroadcast                "RxBroadcast"          // Number of broadcast packets received
+#define kWPANTUNDValueMapKey_Counter_RxData                     "RxData"               // Number of received data
+#define kWPANTUNDValueMapKey_Counter_RxDataPoll                 "RxDataPoll"           // Number of received data poll
+#define kWPANTUNDValueMapKey_Counter_RxBeacon                   "RxBeacon"             // Number of received beacon
+#define kWPANTUNDValueMapKey_Counter_RxBeaconRequest            "RxBeaconRequest"      // Number of received beacon request
+#define kWPANTUNDValueMapKey_Counter_RxOther                    "RxOther"              // Number of received other types of frames
+#define kWPANTUNDValueMapKey_Counter_RxAddressFiltered          "RxAddressFiltered"    // Number of received packets filtered by address filter (whitelist or blacklist)
+#define kWPANTUNDValueMapKey_Counter_RxDestAddrFiltered         "RxDestAddrFiltered"   // Number of received packets filtered by destination check
+#define kWPANTUNDValueMapKey_Counter_RxDuplicated               "RxDuplicated"         // Number of received duplicated packets
+#define kWPANTUNDValueMapKey_Counter_RxErrNoFrame               "RxErrNoFrame"         // Number of received packets that do not contain contents
+#define kWPANTUNDValueMapKey_Counter_RxErrUnknownNeighbor       "RxErrUnknownNeighbor" // Number of received packets from unknown neighbor
+#define kWPANTUNDValueMapKey_Counter_RxErrInvalidSrcAddr        "RxErrInvalidSrcAddr"  // Number of received packets whose source address is invalid
+#define kWPANTUNDValueMapKey_Counter_RxErrSec                   "RxErrSec"             // Number of received packets with security error
+#define kWPANTUNDValueMapKey_Counter_RxErrFcs                   "RxErrFcs"             // Number of received packets with FCS error
+#define kWPANTUNDValueMapKey_Counter_RxErrOther                 "RxErrOther"           // Number of received packets with other error
 
 #endif

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1785,6 +1785,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_MSG_BUFFER_COUNTERS";
         break;
 
+    case SPINEL_PROP_CNTR_ALL_MAC_COUNTERS:
+        ret = "PROP_CNTR_ALL_MAC_COUNTERS";
+        break;
+
     case SPINEL_PROP_NEST_STREAM_MFG:
         ret = "PROP_NEST_STREAM_MFG";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -683,11 +683,16 @@ typedef enum
     SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL
                                         = SPINEL_PROP_PHY_EXT__BEGIN + 6,
 
-    /// Channel monitoring RSS threshold
+    /// Channel monitoring RSSI threshold
     /** Format: `c` (read-only)
      *  Units: dBm
      *
      * Required capability: SPINEL_CAP_CHANNEL_MONITOR
+     *
+     * This value specifies the threshold used by channel monitoring module.
+     * Channel monitoring maintains the average rate of RSSI samples that
+     * are above the threshold within (approximately) a pre-specified number
+     * of samples (sample window).
      *
      */
     SPINEL_PROP_CHANNEL_MONITOR_RSSI_THRESHOLD
@@ -702,7 +707,7 @@ typedef enum
      * The averaging sample window length (in units of number of channel
      * samples) used by channel monitoring module. Channel monitoring will
      * sample all channels every sample interval. It maintains the average rate
-     * of RSS samples that are above the RSS threshold within (approximately)
+     * of RSSI samples that are above the RSSI threshold within (approximately)
      * the sample window.
      *
      */
@@ -715,8 +720,9 @@ typedef enum
      *
      * Required capability: SPINEL_CAP_CHANNEL_MONITOR
      *
-     * Total number of RSS samples taken so far by channel monitoring
-     * module.
+     * Total number of RSSI samples (per channel) taken by the channel
+     * monitoring module since its start (since Thread network interface
+     * was enabled).
      *
      */
     SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT
@@ -733,10 +739,10 @@ typedef enum
      *  `U`: Channel quality indicator
      *
      * The channel quality value represents the average rate/percentage of
-     * RSS samples that were above RSS threshold ("bad" RSS samples) within
+     * RSSI samples that were above RSSI threshold ("bad" RSSI samples) within
      * (approximately) sample window latest RSSI samples.
      *
-     * Max value of `0xffff` indicates all RSS samples were above RSS
+     * Max value of `0xffff` indicates all RSSI samples were above RSSI
      * threshold (i.e. 100% of samples were "bad").
      *
      */
@@ -1622,6 +1628,53 @@ typedef enum
      *      `S`, (CoapBuffers)            The number of buffers in the CoAP send queue.
      */
     SPINEL_PROP_MSG_BUFFER_COUNTERS     = SPINEL_PROP_CNTR__BEGIN + 400,
+
+    /// All MAC related counters.
+    /** Format: t(A(L))t(A(L))  (Read-only)
+     *
+     * The contents include two structs, first one corresponds to
+     * all transmit related MAC counters, second one provides the
+     * receive related counters.
+     *
+     * The transmit structure includes:
+     *
+     *   'L': TxTotal              (The total number of transmissions).
+     *   'L': TxUnicast            (The total number of unicast transmissions).
+     *   'L': TxBroadcast          (The total number of broadcast transmissions).
+     *   'L': TxAckRequested       (The number of transmissions with ack request).
+     *   'L': TxAcked              (The number of transmissions that were acked).
+     *   'L': TxNoAckRequested     (The number of transmissions without ack request).
+     *   'L': TxData               (The number of transmitted data).
+     *   'L': TxDataPoll           (The number of transmitted data poll).
+     *   'L': TxBeacon             (The number of transmitted beacon).
+     *   'L': TxBeaconRequest      (The number of transmitted beacon request).
+     *   'L': TxOther              (The number of transmitted other types of frames).
+     *   'L': TxRetry              (The number of retransmission times).
+     *   'L': TxErrCca             (The number of CCA failure times).
+     *   'L': TxErrAbort           (The number of frame transmission failures due to abort error).
+     *   'L': TxErrBusyChannel     (The number of frames that were dropped due to a busy channel).
+     *
+     * The receive structure includes:
+     *
+     *   'L': RxTotal              (The total number of received packets).
+     *   'L': RxUnicast            (The total number of unicast packets received).
+     *   'L': RxBroadcast          (The total number of broadcast packets received).
+     *   'L': RxData               (The number of received data).
+     *   'L': RxDataPoll           (The number of received data poll).
+     *   'L': RxBeacon             (The number of received beacon).
+     *   'L': RxBeaconRequest      (The number of received beacon request).
+     *   'L': RxOther              (The number of received other types of frames).
+     *   'L': RxAddressFiltered    (The number of received packets filtered by address filter (whitelist or blacklist)).
+     *   'L': RxDestAddrFiltered   (The number of received packets filtered by destination check).
+     *   'L': RxDuplicated         (The number of received duplicated packets).
+     *   'L': RxErrNoFrame         (The number of received packets that do not contain contents).
+     *   'L': RxErrUnknownNeighbor (The number of received packets from unknown neighbor).
+     *   'L': RxErrInvalidSrcAddr  (The number of received packets whose source address is invalid).
+     *   'L': RxErrSec             (The number of received packets with security error).
+     *   'L': RxErrFcs             (The number of received packets with FCS error).
+     *   'L': RxErrOther           (The number of received packets with other error).
+     */
+    SPINEL_PROP_CNTR_ALL_MAC_COUNTERS   =  SPINEL_PROP_CNTR__BEGIN + 401,
 
     SPINEL_PROP_CNTR__END               = 2048,
 


### PR DESCRIPTION
This commits adds support for two new wpantund properties "NCP:Counter:AllMac" and "NCP:Counter:AllMac:AsValMap" to get all the NCP MAC counters with a single property get. These are mapped to spinel property SPINEL_PROP_CNTR_ALL_MAC_COUNTERS.

---------------------

Related PR in OT: https://github.com/openthread/openthread/pull/2489

```
# Human readable version:
wpanctl:wpan1> get NCP:Counter:AllMac
NCP:Counter:AllMac = [
	"TxTotal              = 80"
	"TxUnicast            = 9"
	"TxBroadcast          = 71"
	"TxAckRequested       = 8"
	"TxAcked              = 8"
	"TxNoAckRequested     = 72"
	"TxData               = 80"
	"TxDataPoll           = 0"
	"TxBeacon             = 0"
	"TxBeaconRequest      = 0"
	"TxOther              = 0"
	"TxRetry              = 0"
	"TxErrCca             = 0"
	"TxErrAbort           = 0"
	"TxErrBusyChannel     = 0"
	"RxTotal              = 857"
	"RxUnicast            = 847"
	"RxBroadcast          = 0"
	"RxData               = 36"
	"RxDataPoll           = 807"
	"RxBeacon             = 0"
	"RxBeaconRequest      = 0"
	"RxOther              = 0"
	"RxAddressFiltered    = 0"
	"RxDestAddrFiltered   = 0"
	"RxDuplicated         = 0"
	"RxErrNoFrame         = 0"
	"RxErrUnknownNeighbor = 2"
	"RxErrInvalidSrcAddr  = 0"
	"RxErrSec             = 0"
	"RxErrFcs             = 0"
	"RxErrOther           = 12"
]

wpanctl:wpan1> get NCP:Counter:AllMac:AsValMap
NCP:Counter:AllMac:AsValMap = [
	"RxAddressFiltered" => 0
	"RxBeacon" => 0
	"RxBeaconRequest" => 0
	"RxBroadcast" => 0
	"RxData" => 36
	"RxDataPoll" => 865
	"RxDestAddrFiltered" => 0
	"RxDuplicated" => 0
	"RxErrFcs" => 0
	"RxErrInvalidSrcAddr" => 0
	"RxErrNoFrame" => 0
	"RxErrOther" => 12
	"RxErrSec" => 0
	"RxErrUnknownNeighbor" => 2
	"RxOther" => 0
	"RxTotal" => 915
	"RxUnicast" => 905
	"TxAckRequested" => 8
	"TxAcked" => 8
	"TxBeacon" => 0
	"TxBeaconRequest" => 0
	"TxBroadcast" => 73
	"TxData" => 82
	"TxDataPoll" => 0
	"TxErrAbort" => 0
	"TxErrBusyChannel" => 0
	"TxErrCca" => 0
	"TxNoAckRequested" => 74
	"TxOther" => 0
	"TxRetry" => 0
	"TxTotal" => 82
	"TxUnicast" => 9
]


````

