### PR TITLE
Add new wpan property "NCP:CCAFailureRate"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -279,6 +279,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 	properties.insert(kWPANTUNDProperty_NCPFrequency);
 	properties.insert(kWPANTUNDProperty_NCPRSSI);
 	properties.insert(kWPANTUNDProperty_NCPExtendedAddress);
+	properties.insert(kWPANTUNDProperty_NCPCCAFailureRate);
 
 	if (mCapabilities.count(SPINEL_CAP_ROLE_SLEEPY)) {
 		properties.insert(kWPANTUNDProperty_NCPSleepyPollInterval);
@@ -1212,6 +1213,9 @@ SpinelNCPInstance::property_get_value(
 				.finish()
 			);
 		}
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_NCPCCAFailureRate)) {
+		SIMPLE_SPINEL_GET(SPINEL_PROP_MAC_CCA_FAILURE_RATE, SPINEL_DATATYPE_UINT16_S);
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ChannelMonitorSampleInterval)) {
 		if (!mCapabilities.count(SPINEL_CAP_CHANNEL_MONITOR)) {

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -62,6 +62,7 @@
 #define kWPANTUNDProperty_NCPChannelMask                        "NCP:ChannelMask"
 #define kWPANTUNDProperty_NCPSleepyPollInterval                 "NCP:SleepyPollInterval"
 #define kWPANTUNDProperty_NCPRSSI                               "NCP:RSSI"
+#define kWPANTUNDProperty_NCPCCAFailureRate                     "NCP:CCAFailureRate"
 
 #define kWPANTUNDProperty_InterfaceUp                           "Interface:Up"
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1289,6 +1289,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_MAC_FIXED_RSS";
         break;
 
+    case SPINEL_PROP_MAC_CCA_FAILURE_RATE:
+        ret = "PROP_MAC_CCA_FAILURE_RATE";
+        break;
+
     case SPINEL_PROP_NET_SAVED:
         ret = "PROP_NET_SAVED";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -845,7 +845,17 @@ typedef enum
      * * `E`: Optional EUI64 address of node. Set default RSS if not included.
      * * `c`: Fixed RSS. OT_MAC_FILTER_FIXED_RSS_OVERRIDE_DISABLED(127) means not set.
      */
-    SPINEL_PROP_MAC_FIXED_RSS            = SPINEL_PROP_MAC_EXT__BEGIN + 8,
+    SPINEL_PROP_MAC_FIXED_RSS           = SPINEL_PROP_MAC_EXT__BEGIN + 8,
+
+    /// The CCA failure rate
+    /** Format: `S`
+     *
+     * This property provides the current CCA (Clear Channel Assessment) failure rate.
+     *
+     * Maximum value `0xffff` corresponding to 100% failure rate.
+     *
+     */
+    SPINEL_PROP_MAC_CCA_FAILURE_RATE    = SPINEL_PROP_MAC_EXT__BEGIN + 9,
 
     SPINEL_PROP_MAC_EXT__END            = 0x1400,
 
@@ -1685,7 +1695,7 @@ typedef enum
      *   'L': RxAddressFiltered    (The number of received packets filtered by address filter (whitelist or blacklist)).
      *   'L': RxDestAddrFiltered   (The number of received packets filtered by destination check).
      *   'L': RxDuplicated         (The number of received duplicated packets).
-     *   'L': RxErrNoFrame         (The number of received packets that do not contain contents).
+     *   'L': RxErrNoFrame         (The number of received packets with no or malformed content).
      *   'L': RxErrUnknownNeighbor (The number of received packets from unknown neighbor).
      *   'L': RxErrInvalidSrcAddr  (The number of received packets whose source address is invalid).
      *   'L': RxErrSec             (The number of received packets with security error).


### PR DESCRIPTION
The wpan property is mapped to newly added NCP spinel property
`SPINEL_PROP_MAC_CCA_FAILURE_RATE` which provides the CCA
(Clear Channel Assessment) failure rate. The value is provided
as a `uint16_t` with 0 mapping to 0% error rate, and 0xffff
indicating 100% failure rate.