### PR TITLE
Add new wpan property "Thread:NeighborTable:ErrorRates"

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.h
@@ -43,6 +43,7 @@ public:
 		kChildTableAddresses,          // Get the child table addresses (including registered IPv6 addresses)
 		kNeighborTable,                // Get the neighbor table
 		kRouterTable,                  // Get the router table
+		kNeighborTableErrorRates,      // Get the neighbor's (frame/message) error rates
 	};
 
 	enum ResultFormat
@@ -100,6 +101,10 @@ public:
 		// Child info addresses only
 		std::list<struct in6_addr> mIPv6Addresses;
 
+		// Neighbor info error rate only
+		uint16_t mFrameErrorRate;
+		uint16_t mMessageErrorRate;
+
 	public:
 		TableEntry(void);
 
@@ -123,6 +128,7 @@ public:
 	static int parse_child_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& child_info);
 	static int parse_child_addresses_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& child_addr_info);
 	static int parse_neighbor_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& neighbor_info);
+	static int parse_neighbor_error_rates_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& neighbor_err_rates_info);
 	static int parse_router_entry(const uint8_t *data_in, spinel_size_t data_len, TableEntry& router_info);
 
 	// Parse the spinel child/neighbor/router table property and updates the passed-in `Table`
@@ -130,6 +136,7 @@ public:
 	static int parse_child_table(const uint8_t *data_in, spinel_size_t data_len, Table& child_table);
 	static int parse_child_addresses_table(const uint8_t *data_in, spinel_size_t data_len, Table& child_addr_table);
 	static int parse_neighbor_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_table);
+	static int prase_neighbor_error_rates_table(const uint8_t *data_in, spinel_size_t data_len, Table& neighbor_err_rate_table);
 	static int parse_router_table(const uint8_t *data_in, spinel_size_t data_len, Table& router_table);
 
 private:

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -100,6 +100,8 @@
 #define kWPANTUNDProperty_ThreadChildTableAddresses             "Thread:ChildTable:Addresses"
 #define kWPANTUNDProperty_ThreadNeighborTable                   "Thread:NeighborTable"
 #define kWPANTUNDProperty_ThreadNeighborTableAsValMap           "Thread:NeighborTable:AsValMap"
+#define kWPANTUNDProperty_ThreadNeighborTableErrorRates         "Thread:NeighborTable:ErrorRates"
+#define kWPANTUNDProperty_ThreadNeighborTableErrorRatesAsValMap "Thread:NeighborTable:ErrorRates:AsValMap"
 #define kWPANTUNDProperty_ThreadRouterTable                     "Thread:RouterTable"
 #define kWPANTUNDProperty_ThreadRouterTableAsValMap             "Thread:RouterTable:AsValMap"
 #define kWPANTUNDProperty_ThreadNetworkDataVersion              "Thread:NetworkDataVersion"
@@ -280,6 +282,8 @@
 #define kWPANTUNDValueMapKey_NetworkTopology_LinkFrameCounter   "LinkFrameCounter"
 #define kWPANTUNDValueMapKey_NetworkTopology_MleFrameCounter    "MleFrameCounter"
 #define kWPANTUNDValueMapKey_NetworkTopology_IsChild            "IsChild"
+#define kWPANTUNDValueMapKey_NetworkTopology_FrameErrorRate     "FrameErrorRate"
+#define kWPANTUNDValueMapKey_NetworkTopology_MessageErrorRate   "MessageErrorRate"
 
 #define kWPANTUNDValueMapKey_Scan_Period                        "Scan:Period"
 #define kWPANTUNDValueMapKey_Scan_ChannelMask                   "Scan:ChannelMask"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1537,6 +1537,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_CHILD_TABLE_ADDRESSES";
         break;
 
+    case SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES:
+        ret = "PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES";
+        break;
+
     case SPINEL_PROP_IPV6_LL_ADDR:
         ret = "PROP_IPV6_LL_ADDR";
         break;
@@ -2130,6 +2134,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_CHANNEL_MONITOR:
         ret = "CAP_CHANNEL_MONITOR";
+        break;
+
+    case SPINEL_CAP_ERROR_RATE_TRACKING:
+        ret = "CAP_ERROR_RATE_TRACKING";
         break;
 
     case SPINEL_CAP_THREAD_COMMISSIONER:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -418,6 +418,7 @@ enum
     SPINEL_CAP_MAC_RAW                  = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
     SPINEL_CAP_OOB_STEERING_DATA        = (SPINEL_CAP_OPENTHREAD__BEGIN + 2),
     SPINEL_CAP_CHANNEL_MONITOR          = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
+    SPINEL_CAP_ERROR_RATE_TRACKING      = (SPINEL_CAP_OPENTHREAD__BEGIN + 4),
     SPINEL_CAP_OPENTHREAD__END          = 640,
 
     SPINEL_CAP_THREAD__BEGIN            = 1024,
@@ -1346,6 +1347,32 @@ typedef enum
      */
     SPINEL_PROP_THREAD_CHILD_TABLE_ADDRESSES
                                         = SPINEL_PROP_THREAD_EXT__BEGIN + 33,
+
+    /// Neighbor Table Frame and Message Error Rates
+    /** Format: `A(t(ESSScc))`
+     *  Required capability: `CAP_ERROR_RATE_TRACKING`
+     *
+     * This property provides link quality related info including
+     * frame and (IPv6) message error rates for all neighbors.
+     *
+     * With regards to message error rate, note that a larger (IPv6)
+     * message can be fragmented and sent as multiple MAC frames. The
+     * message transmission is considered a failure, if any of its
+     * fragments fail after all MAC retry attempts.
+     *
+     * Data per item is:
+     *
+     *  `E`: Extended address of the neighbor
+     *  `S`: RLOC16 of the neighbor
+     *  `S`: Frame error rate (0 -> 0%, 0xffff -> 100%)
+     *  `S`: Message error rate (0 -> 0%, 0xffff -> 100%)
+     *  `c`: Average RSSI (in dBm)
+     *  `c`: Last RSSI (in dBm)
+     *
+     */
+    SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
+
     SPINEL_PROP_THREAD_EXT__END         = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN             = 0x60,


### PR DESCRIPTION
This commit adds new wpan property to get the message or frame error
rates of all neighbors from NCP. The value can be returned as a
human-readable string list, or as a `ValueMap` list.

Related PRs in OT: https://github.com/openthread/openthread/pull/2525 and https://github.com/openthread/openthread/pull/2520

Here is how the output would look like:
```
# As string list

wpanctl:wpan1> get Thread:NeighborTable:ErrorRates
Thread:NeighborTable:ErrorRates = [
	"3688BF2C2F0FC27F, RLOC16:0800, FrameErrRate:25.89%, MsgErrorRate:1.34%, AveRssi:-20, LastRssi:-20, "
	"3684CBF2F0E15EB4, RLOC16:7400, FrameErrRate:14.16%, MsgErrorRate:0.77%, AveRssi:-20, LastRssi:-20, "
	"028844B586722E36, RLOC16:8000, FrameErrRate:0.78%, MsgErrorRate:0.00%, AveRssi:-20, LastRssi:-20, "
]

# As value map

wpanctl:wpan1> get Thread:NeighborTable:ErrorRates:AsValMap
Thread:NeighborTable:ErrorRates:AsValMap = [
	[
		"AverageRssi" => -20
		"ExtAddress" => 0x3688BF2C2F0FC27F
		"FrameErrorRate" => 0x4248
		"LastRssi" => -20
		"MessageErrorRate" => 0x036F
		"RLOC16" => 0x0800
	]
	[
		"AverageRssi" => -20
		"ExtAddress" => 0x3684CBF2F0E15EB4
		"FrameErrorRate" => 0x243F
		"LastRssi" => -20
		"MessageErrorRate" => 0x01F8
		"RLOC16" => 0x7400
	]
	[
		"AverageRssi" => -20
		"ExtAddress" => 0x028844B586722E36
		"FrameErrorRate" => 0x01FC
		"LastRssi" => -20
		"MessageErrorRate" => 0x0000
		"RLOC16" => 0x8000
	]
]
```

And here is how the neighbor info is added in the logs:
````
wpantund[219418]: property_get_value: key: "Thread:NeighborTable:ErrorRates"
wpantund[219418]: [->NCP] CMD_PROP_VALUE_GET(PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES) tid:7
wpantund[219418]: NCP is now BUSY.
wpantund[219418]: [NCP->] CMD_PROP_VALUE_IS(PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES) tid:7
wpantund[219418]: [-NCP-] Neighbor: 01 3688BF2C2F0FC27F, RLOC16:0800, FrameErrRate:25.89%, MsgErrorRate:1.34%, AveRssi:-20, LastRssi:-20, 
wpantund[219418]: [-NCP-] Neighbor: 02 3684CBF2F0E15EB4, RLOC16:7400, FrameErrRate:14.16%, MsgErrorRate:0.77%, AveRssi:-20, LastRssi:-20, 
wpantund[219418]: [-NCP-] Neighbor: 03 028844B586722E36, RLOC16:8000, FrameErrRate:0.78%, MsgErrorRate:0.00%, AveRssi:-20, LastRssi:-20, 
wpantund[219418]: [-NCP-] Neighbor: Total 3 neighbors
````