### PR TITLE
Include <string.h> explicitly in string utils header. Fixes build with uclibc

### DIFF
--- a/src/util/string-utils.h
+++ b/src/util/string-utils.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <sys/cdefs.h>
+#include <string.h>
 
 #define strcaseequal(x, y)   (strcasecmp(x, y) == 0)
 #define strncaseequal(x, y, n)   (strncasecmp(x, y, n) == 0)


### PR DESCRIPTION
I tried to add and build wpantund package in Buildroot environment and it failed, complaining about standard C library string functions not declared (strlen(), strcasecmp() and others). I'm not sure exactly which build settings trigger these errors, most probably because uclibc was used instead of glibc. But anyway including <string.h> explicitly fixes this issue.