### PR TITLE
Properties to control how off-mesh-routes are managed on primary interface

### DIFF
--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -853,11 +853,13 @@ NCPInstanceBase::should_add_route_on_interface(const IPv6Prefix &route, uint32_t
 
 	// The route should be added on host primary interface, if it
 	// is added by at least one other device within the network and,
-	// either it is not added by host/this-device or added but with
-	// a lower preference level.
+	//  (a) either it is not added by host/this-device, or
+	//  (b) if it is also added by device then
+	//      - filtering of self added routes is not enabled, and
+	//      - it is added at lower preference level.
 
 	if (route_added_by_others) {
-		if (!route_added_by_device || (preference_others > preference_device)) {
+		if (!route_added_by_device || (!mFilterSelfAutoAddedOffMeshRoutes && (preference_others > preference_device))) {
 			should_add = true;
 		}
 	}
@@ -888,6 +890,10 @@ NCPInstanceBase::refresh_routes_on_interface(void)
 {
 	bool did_remove = false;
 	uint32_t metric;
+
+	if (!mAutoAddOffMeshRoutesOnInterface) {
+		goto bail;
+	}
 
 	syslog(LOG_INFO, "Refreshing routes on primary interface");
 
@@ -941,4 +947,7 @@ NCPInstanceBase::refresh_routes_on_interface(void)
 			}
 		}
 	}
+
+bail:
+	return;
 }

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -75,6 +75,8 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mNodeTypeSupportsLegacy = false;
 	mSetDefaultRouteForAutoAddedPrefix = false;
 	mSetSLAACForAutoAddedPrefix = false;
+	mAutoAddOffMeshRoutesOnInterface = true;
+	mFilterSelfAutoAddedOffMeshRoutes = true;
 	mTerminateOnFault = false;
 	mWasBusy = false;
 	mNCPIsMisbehaving = false;
@@ -397,6 +399,12 @@ NCPInstanceBase::property_get_value(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix)) {
 		cb(0, boost::any(mSetSLAACForAutoAddedPrefix));
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface)) {
+		cb(0, boost::any(mAutoAddOffMeshRoutesOnInterface));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded)) {
+		cb(0, boost::any(mFilterSelfAutoAddedOffMeshRoutes));
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
 		if (buffer_is_nonzero(mNCPV6Prefix, sizeof(mNCPV6Prefix))) {
 			struct in6_addr addr (mNCPMeshLocalAddress);
@@ -617,6 +625,14 @@ NCPInstanceBase::property_set_value(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6SetSLAACForAutoAddedPrefix)) {
 			mSetSLAACForAutoAddedPrefix = any_to_bool(value);
+			cb(0);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface)) {
+			mAutoAddOffMeshRoutesOnInterface = any_to_bool(value);
+			cb(0);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded)) {
+			mFilterSelfAutoAddedOffMeshRoutes = any_to_bool(value);
 			cb(0);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -479,6 +479,33 @@ protected:
 	bool mSetDefaultRouteForAutoAddedPrefix;
 	bool mSetSLAACForAutoAddedPrefix;
 
+	// This boolean flag determines whether wpantund should manage the routes
+	// on the primary interface. When set to `true` wpantund will add/remove
+	// off-mesh routes provided by devices within the network on the host
+	// interface. By default it is enabled (`true`).
+	//
+	bool mAutoAddOffMeshRoutesOnInterface;
+
+	// This boolean flag controls how the off-mesh-routes are managed
+	// on the primary interface (this is applicable only if the
+	// `mAutoAddOffMeshRoutesOnInterface` is enabled).
+	//
+	// This impacts the behavior where the same off-mesh route is provided
+	// by multiple devices within the network including the device itself.
+	//
+	// When set to `true`, self-added off-mesh-routes are always filtered
+	// and never added on the host interface (independent of the priority
+	// levels at which they are added).
+	//
+	// If it is set to `false`, then the priority of routes are considered
+	// and the off-mesh-route is added on the interface if another device
+	// within the network provides the same route at a higher preference
+	// level than the self added one.
+	//
+	// By default this is enabled (`true`).
+	//
+	bool mFilterSelfAutoAddedOffMeshRoutes;
+
 private:
 	NCPState mNCPState;
 	bool mIsInitializingNCP;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -48,6 +48,8 @@
 #define kWPANTUNDProperty_DaemonAutoDeepSleep                   "Daemon:AutoDeepSleep"
 #define kWPANTUNDProperty_DaemonFaultReason                     "Daemon:FaultReason"
 #define kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix   "Daemon:SetDefaultRouteForAutoAddedPrefix"
+#define kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface  "Daemon:OffMeshRoute:AutoAddOnInterface"
+#define kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded "Daemon:OffMeshRoute:FilterSelfAutoAdded"
 
 #define kWPANTUNDProperty_NCPVersion                            "NCP:Version"
 #define kWPANTUNDProperty_NCPState                              "NCP:State"


### PR DESCRIPTION
This commit adds two new `wpantund` daemon configuration properties:

- `"Daemon:OffMeshRoute:AutoAddOnInterface"` - This boolean property determines whether `wpantund` should manage the routes on the primary interface. When set to `true` wpantund will add/remove off-mesh routes provided by devices within the network on the host interface. Otherwise, it is expected the routes would be managed externally. By default this feature is enabled (`true`).

- `"Daemon:OffMeshRoute:FilterSelfAutoAdded"` - This boolean property controls how the off-mesh-routes are managed on the primary interface (this is applicable only if the `AutoAddOnInterface` feature is enabled). 
This property impacts the behavior where the same off-mesh route is provided by multiple devices within the network including the device itself. When set to `true`, self-added off-mesh routes are always filtered  and never added on the interface (independent of the priority levels at which they are added by device or others). If it is set to `false`,  then priority of routes are considered and the off-mesh-route is  added on the interface if another device within the network provides the same route at a higher preference level than the self added one.  By default this is enabled (`true`).