### PR TITLE
Add config option "Deamon::IPv6::AutoUpdateInterfaceAddrsOnNCP"

### DIFF
--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -500,7 +500,7 @@ NCPInstanceBase::unicast_address_was_added(Origin origin, const struct in6_addr 
 			mPrimaryInterface->add_address(&address, prefix_len);
 		}
 
-		if ((origin == kOriginPrimaryInterface) || (origin == kOriginUser)) {
+		if (((origin == kOriginPrimaryInterface) && mAutoUpdateInterfaceIPv6AddrsOnNCP) || (origin == kOriginUser)) {
 			add_address_on_ncp_and_update_prefixes(address, entry);
 		}
 	}

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -73,6 +73,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mRequestRouteRefresh = false;
 	mNodeType = UNKNOWN;
 	mNodeTypeSupportsLegacy = false;
+	mAutoUpdateInterfaceIPv6AddrsOnNCP = true;
 	mSetDefaultRouteForAutoAddedPrefix = false;
 	mSetSLAACForAutoAddedPrefix = false;
 	mAutoAddOffMeshRoutesOnInterface = true;
@@ -384,6 +385,9 @@ NCPInstanceBase::property_get_value(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonTerminateOnFault)) {
 		cb(0, boost::any(mTerminateOnFault));
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP)) {
+		cb(0, boost::any(mAutoUpdateInterfaceIPv6AddrsOnNCP));
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix)) {
 		cb(0, boost::any(mSetDefaultRouteForAutoAddedPrefix));
 
@@ -618,6 +622,10 @@ NCPInstanceBase::property_set_value(
 			if (mTerminateOnFault && (get_ncp_state() == FAULT)) {
 				reinitialize_ncp();
 			}
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP)) {
+			mAutoUpdateInterfaceIPv6AddrsOnNCP = any_to_bool(value);
+			cb(0);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix)) {
 			mSetDefaultRouteForAutoAddedPrefix = any_to_bool(value);

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -473,6 +473,14 @@ protected:
 	int mAutoDeepSleepTimeout; // In seconds
 	uint16_t mCommissionerPort;
 
+	// This boolean flag indicates whether wpantund would listen for
+	// unicast IPv6 address-added/removed events from the interface and
+	// then update the addresses on the NCP. By default this feature
+	// is enabled. It can be changed using a configuration wpantund
+	// property "Daemon:IPv6:AutoUpdateInterfaceAddrsOnNCP"
+	//
+	bool mAutoUpdateInterfaceIPv6AddrsOnNCP;
+
 	// When an unicast address is added on interface, the related on-mesh prefix
 	// is updated on NCP if `mDefaultRouteForAutoAddedPrefix` is true the prefix
 	// is added with flag "DefaultRoute" set.

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -47,6 +47,7 @@
 #define kWPANTUNDProperty_DaemonAutoFirmwareUpdate              "Daemon:AutoFirmwareUpdate"
 #define kWPANTUNDProperty_DaemonAutoDeepSleep                   "Daemon:AutoDeepSleep"
 #define kWPANTUNDProperty_DaemonFaultReason                     "Daemon:FaultReason"
+#define kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP  "Daemon:IPv6:AutoUpdateInterfaceAddrsOnNCP"
 #define kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix   "Daemon:SetDefaultRouteForAutoAddedPrefix"
 #define kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface  "Daemon:OffMeshRoute:AutoAddOnInterface"
 #define kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded "Daemon:OffMeshRoute:FilterSelfAutoAdded"


### PR DESCRIPTION
This commit adds a new configuration option to determine whether
wpantund should listen for unicast IPv6 address-added/removed events
from the primary interface and then update the addresses on the NCP.
By default this feature is enabled. It can be changed using a
corresponding configuration wpantund property.