### PR TITLE
Add config option "Daemon:IPv6:FilterUserAddedLinkLocal"

### DIFF
--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -488,6 +488,16 @@ void
 NCPInstanceBase::unicast_address_was_added(Origin origin, const struct in6_addr &address, uint8_t prefix_len,
 	uint32_t valid_lifetime, uint32_t preferred_lifetime)
 {
+	if (((origin == kOriginPrimaryInterface) || (origin == kOriginUser))
+	    && mFilterUserAddedLinkLocalIPv6Address
+	    && IN6_IS_ADDR_LINKLOCAL(&address)) {
+
+		syslog(LOG_INFO, "UnicastAddresses: Skipping user/interface added link-local IPv6 address %s",
+		       in6_addr_to_string(address).c_str());
+
+		goto bail;
+	}
+
 	if (!mUnicastAddresses.count(address)) {
 		UnicastAddressEntry entry(origin, prefix_len, valid_lifetime, preferred_lifetime);
 
@@ -504,6 +514,9 @@ NCPInstanceBase::unicast_address_was_added(Origin origin, const struct in6_addr 
 			add_address_on_ncp_and_update_prefixes(address, entry);
 		}
 	}
+
+bail:
+	return;
 }
 
 void

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -74,6 +74,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mNodeType = UNKNOWN;
 	mNodeTypeSupportsLegacy = false;
 	mAutoUpdateInterfaceIPv6AddrsOnNCP = true;
+	mFilterUserAddedLinkLocalIPv6Address = true;
 	mSetDefaultRouteForAutoAddedPrefix = false;
 	mSetSLAACForAutoAddedPrefix = false;
 	mAutoAddOffMeshRoutesOnInterface = true;
@@ -388,6 +389,9 @@ NCPInstanceBase::property_get_value(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP)) {
 		cb(0, boost::any(mAutoUpdateInterfaceIPv6AddrsOnNCP));
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6FilterUserAddedLinkLocal)) {
+		cb(0, boost::any(mFilterUserAddedLinkLocalIPv6Address));
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix)) {
 		cb(0, boost::any(mSetDefaultRouteForAutoAddedPrefix));
 
@@ -625,6 +629,10 @@ NCPInstanceBase::property_set_value(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP)) {
 			mAutoUpdateInterfaceIPv6AddrsOnNCP = any_to_bool(value);
+			cb(0);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonIPv6FilterUserAddedLinkLocal)) {
+			mFilterUserAddedLinkLocalIPv6Address = any_to_bool(value);
 			cb(0);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix)) {

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -481,6 +481,12 @@ protected:
 	//
 	bool mAutoUpdateInterfaceIPv6AddrsOnNCP;
 
+	// This boolean flag indicates whether wpantund should skip adding
+	// user (or interface) originated link-local IPv6 addresses on NCP.
+	// By default this is enabled. It can be changed using a configuration
+	// wpantund property "Daemon:IPv6:FilterUserAddedLinkLocal"
+	bool mFilterUserAddedLinkLocalIPv6Address;
+
 	// When an unicast address is added on interface, the related on-mesh prefix
 	// is updated on NCP if `mDefaultRouteForAutoAddedPrefix` is true the prefix
 	// is added with flag "DefaultRoute" set.

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -48,6 +48,7 @@
 #define kWPANTUNDProperty_DaemonAutoDeepSleep                   "Daemon:AutoDeepSleep"
 #define kWPANTUNDProperty_DaemonFaultReason                     "Daemon:FaultReason"
 #define kWPANTUNDProperty_DaemonIPv6AutoUpdateIntfaceAddrOnNCP  "Daemon:IPv6:AutoUpdateInterfaceAddrsOnNCP"
+#define kWPANTUNDProperty_DaemonIPv6FilterUserAddedLinkLocal    "Daemon:IPv6:FilterUserAddedLinkLocal"
 #define kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix   "Daemon:SetDefaultRouteForAutoAddedPrefix"
 #define kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface  "Daemon:OffMeshRoute:AutoAddOnInterface"
 #define kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded "Daemon:OffMeshRoute:FilterSelfAutoAdded"


### PR DESCRIPTION
This commit adds a new configuration option to determine whether
wpantund should skip adding user (or interface) originated link-local
IPv6 addresses on NCP. By default this feature is enabled. The
behavior can  be changed using wpantund configuration property
"Daemon:IPv6:FilterUserAddedLinkLocal".