### PR TITLE
add mesh local prefix setting support

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2039,6 +2039,30 @@ SpinelNCPInstance::property_set_value(
 				);
 			}
 
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
+			struct in6_addr address = any_to_ipv6(value);
+			char address_str[INET6_ADDRSTRLEN] = "::";
+
+			inet_ntop(AF_INET6, (const void *)&address, address_str, sizeof(address_str));
+
+			fprintf(stderr, "Using prefix \"%s\"\n", address_str);
+
+			Data command =
+				SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
+					SPINEL_PROP_IPV6_ML_PREFIX,
+					address.s6_addr,
+					8
+				);
+
+			mSettings[kWPANTUNDProperty_IPv6MeshLocalPrefix] = SettingsEntry(command);
+
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(command)
+				.finish()
+			);
+
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadCommissionerEnabled)) {
 			bool isEnabled = any_to_bool(value);
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2040,14 +2040,14 @@ SpinelNCPInstance::property_set_value(
 			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
-			struct in6_addr address = any_to_ipv6(value);
+			struct in6_addr addr = any_to_ipv6(value);
 
 			Data command =
 				SpinelPackData(
-					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_IPv6ADDR_S SPINEL_DATATYPE_UINT8_S),
 					SPINEL_PROP_IPV6_ML_PREFIX,
-					address.s6_addr,
-					8
+					&addr,
+					64
 				);
 
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2041,11 +2041,6 @@ SpinelNCPInstance::property_set_value(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
 			struct in6_addr address = any_to_ipv6(value);
-			char address_str[INET6_ADDRSTRLEN] = "::";
-
-			inet_ntop(AF_INET6, (const void *)&address, address_str, sizeof(address_str));
-
-			fprintf(stderr, "Using prefix \"%s\"\n", address_str);
 
 			Data command =
 				SpinelPackData(
@@ -2054,8 +2049,6 @@ SpinelNCPInstance::property_set_value(
 					address.s6_addr,
 					8
 				);
-
-			mSettings[kWPANTUNDProperty_IPv6MeshLocalPrefix] = SettingsEntry(command);
 
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -317,9 +317,9 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 	}
 
-	if (mOptions.count(kWPANTUNDProperty_IPv6MeshLocalAddress)) {
+	if (mOptions.count(kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
 		{
-			struct in6_addr addr = any_to_ipv6(mOptions[kWPANTUNDProperty_IPv6MeshLocalAddress]);
+			struct in6_addr addr = any_to_ipv6(mOptions[kWPANTUNDProperty_IPv6MeshLocalPrefix]);
 			mNextCommand = SpinelPackData(
 				SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_IPv6ADDR_S SPINEL_DATATYPE_UINT8_S),
 				SPINEL_PROP_IPV6_ML_PREFIX,
@@ -333,9 +333,9 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 		ret = mNextCommandRet;
 
 		require_noerr(ret, on_error);
-	} else if (mOptions.count(kWPANTUNDProperty_IPv6MeshLocalPrefix)) {
+	} else if (mOptions.count(kWPANTUNDProperty_IPv6MeshLocalAddress)) {
 		{
-			struct in6_addr addr = any_to_ipv6(mOptions[kWPANTUNDProperty_IPv6MeshLocalPrefix]);
+			struct in6_addr addr = any_to_ipv6(mOptions[kWPANTUNDProperty_IPv6MeshLocalAddress]);
 			mNextCommand = SpinelPackData(
 				SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_IPv6ADDR_S SPINEL_DATATYPE_UINT8_S),
 				SPINEL_PROP_IPV6_ML_PREFIX,


### PR DESCRIPTION
Add support to explicitly configure mesh local prefix.

I am not very clear why configuring the network parameters again when forming the network, but, one issue when adding `IPv6:MeshLocalPrefix` set operation is that it would be replaced by the one coming from XPANID because mesh local prefix would be configured again when configuring XPANID again during forming (see https://github.com/openthread/openthread/blob/master/src/core/api/thread_api.cpp#L83). So another change in this PR is to prefer the mesh local prefix explicitly configured by property to the one from mesh local address.

@abtink, please help to evaluate if it has any possible issue I didn't notice. Thanks.