### PR TITLE
Add support for NCP MCU power state control and deep-sleep mode

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -52,6 +52,7 @@
 #include "SpinelNCPTaskLeave.h"
 #include "SpinelNCPTaskScan.h"
 #include "SpinelNCPTaskPeek.h"
+#include "SpinelNCPTaskDeepSleep.h"
 #include "SpinelNCPTaskSendCommand.h"
 
 using namespace nl;
@@ -158,8 +159,7 @@ SpinelNCPControlInterface::host_did_wake(CallbackWithStatus cb)
 void
 SpinelNCPControlInterface::begin_low_power(CallbackWithStatus cb)
 {
-	// TODO: Writeme!
-	cb(kWPANTUNDStatus_FeatureNotImplemented);
+	property_set_value(kWPANTUNDProperty_NCPMCUPowerState , std::string(kWPANTUNDNCPMCUPowerState_LowPower), cb);
 }
 
 void

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -67,6 +67,7 @@
 #define kWPANTUNDProperty_NCPSleepyPollInterval                 "NCP:SleepyPollInterval"
 #define kWPANTUNDProperty_NCPRSSI                               "NCP:RSSI"
 #define kWPANTUNDProperty_NCPCCAFailureRate                     "NCP:CCAFailureRate"
+#define kWPANTUNDProperty_NCPMCUPowerState                      "NCP:MCUPowerState"
 
 #define kWPANTUNDProperty_InterfaceUp                           "Interface:Up"
 
@@ -253,6 +254,13 @@
 #define kWPANTUNDStateIsolated                                  "associated:no-parent"
 #define kWPANTUNDStateNetWake_Asleep                            "associated:netwake-asleep"
 #define kWPANTUNDStateNetWake_Waking                            "associated:netwake-waking"
+
+// ----------------------------------------------------------------------------
+
+// Values of the property kWPANTUNDProperty_NCPMCUPowerState
+#define kWPANTUNDNCPMCUPowerState_On                            "on"
+#define kWPANTUNDNCPMCUPowerState_LowPower                      "low-power"
+#define kWPANTUNDNCPMCUPowerState_Off                           "off"
 
 // ----------------------------------------------------------------------------
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1097,6 +1097,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_HOST_POWER_STATE";
         break;
 
+    case SPINEL_PROP_MCU_POWER_STATE:
+        ret = "PROP_MCU_POWER_STATE";
+        break;
+
     case SPINEL_PROP_GPIO_CONFIG:
         ret = "PROP_GPIO_CONFIG";
         break;
@@ -1569,6 +1573,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_IPV6_MULTICAST_ADDRESS_TABLE";
         break;
 
+    case SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE:
+        ret = "PROP_IPV6_ICMP_PING_OFFLOAD_MODE";
+        break;
+
     case SPINEL_PROP_STREAM_DEBUG:
         ret = "PROP_STREAM_DEBUG";
         break;
@@ -1857,6 +1865,28 @@ const char *spinel_net_role_to_cstr(uint8_t net_role)
     return ret;
 }
 
+const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_state_t mcu_power_state)
+{
+    const char *ret = "MCU_POWER_STATE_UNKNOWN";
+
+    switch (mcu_power_state)
+    {
+    case SPINEL_MCU_POWER_STATE_ON:
+        ret = "MCU_POWER_STATE_ON";
+        break;
+
+    case SPINEL_MCU_POWER_STATE_LOW_POWER:
+        ret = "MCU_POWER_STATE_LOW_POWER";
+        break;
+
+    case SPINEL_MCU_POWER_STATE_OFF:
+        ret = "MCU_POWER_STATE_OFF";
+        break;
+    }
+
+    return ret;
+}
+
 const char *spinel_status_to_cstr(spinel_status_t status)
 {
     const char *ret = "UNKNOWN";
@@ -2064,6 +2094,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "CAP_UNSOL_UPDATE_FILTER";
         break;
 
+    case SPINEL_CAP_MCU_POWER_STATE:
+        ret = "CAP_MCU_POWER_STATE";
+        break;
+
     case SPINEL_CAP_802_15_4_2003:
         ret = "CAP_802_15_4_2003";
         break;
@@ -2134,6 +2168,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_CHANNEL_MONITOR:
         ret = "CAP_CHANNEL_MONITOR";
+        break;
+
+    case SPINEL_CAP_CHANNEL_MANAGER:
+        ret = "CAP_CHANNEL_MANAGER";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -202,12 +202,30 @@ typedef enum
 
 typedef enum
 {
+    SPINEL_IPV6_ICMP_PING_OFFLOAD_DISABLED       = 0,
+    SPINEL_IPV6_ICMP_PING_OFFLOAD_UNICAST_ONLY   = 1,
+    SPINEL_IPV6_ICMP_PING_OFFLOAD_MULTICAST_ONLY = 2,
+    SPINEL_IPV6_ICMP_PING_OFFLOAD_ALL            = 3,
+} spinel_ipv6_icmp_ping_offload_mode_t;
+
+typedef enum
+{
     SPINEL_SCAN_STATE_IDLE              = 0,
     SPINEL_SCAN_STATE_BEACON            = 1,
     SPINEL_SCAN_STATE_ENERGY            = 2,
     SPINEL_SCAN_STATE_DISCOVER          = 3,
 } spinel_scan_state_t;
 
+typedef enum
+{
+    SPINEL_MCU_POWER_STATE_ON           = 0,
+    SPINEL_MCU_POWER_STATE_LOW_POWER    = 1,
+    SPINEL_MCU_POWER_STATE_OFF          = 2,
+} spinel_mcu_power_state_t;
+
+// The `spinel_power_state_t` enumeration and `POWER_STATE`
+// property are deprecated. Please use `MCU_POWER_STATE`
+// instead.
 typedef enum
 {
     SPINEL_POWER_STATE_OFFLINE          = 0,
@@ -389,6 +407,7 @@ enum
     SPINEL_CAP_TRNG                     = 10,
     SPINEL_CAP_CMD_MULTI                = 11,
     SPINEL_CAP_UNSOL_UPDATE_FILTER      = 12,
+    SPINEL_CAP_MCU_POWER_STATE          = 13,
 
     SPINEL_CAP_802_15_4__BEGIN          = 16,
     SPINEL_CAP_802_15_4_2003            = (SPINEL_CAP_802_15_4__BEGIN + 0),
@@ -419,6 +438,7 @@ enum
     SPINEL_CAP_OOB_STEERING_DATA        = (SPINEL_CAP_OPENTHREAD__BEGIN + 2),
     SPINEL_CAP_CHANNEL_MONITOR          = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
     SPINEL_CAP_ERROR_RATE_TRACKING      = (SPINEL_CAP_OPENTHREAD__BEGIN + 4),
+    SPINEL_CAP_CHANNEL_MANAGER          = (SPINEL_CAP_OPENTHREAD__BEGIN + 5),
     SPINEL_CAP_OPENTHREAD__END          = 640,
 
     SPINEL_CAP_THREAD__BEGIN            = 1024,
@@ -448,12 +468,13 @@ typedef enum
     SPINEL_PROP_VENDOR_ID               = 4,        ///< [i]
     SPINEL_PROP_CAPS                    = 5,        ///< capability list [A(i)]
     SPINEL_PROP_INTERFACE_COUNT         = 6,        ///< Interface count [C]
-    SPINEL_PROP_POWER_STATE             = 7,        ///< PowerState [C]
+    SPINEL_PROP_POWER_STATE             = 7,        ///< PowerState [C] (deprecated, use `MCU_POWER_STATE` instead).
     SPINEL_PROP_HWADDR                  = 8,        ///< PermEUI64 [E]
     SPINEL_PROP_LOCK                    = 9,        ///< PropLock [b]
     SPINEL_PROP_HBO_MEM_MAX             = 10,       ///< Max offload mem [S]
     SPINEL_PROP_HBO_BLOCK_MAX           = 11,       ///< Max offload block [S]
     SPINEL_PROP_HOST_POWER_STATE        = 12,       ///< Host MCU power state [C]
+    SPINEL_PROP_MCU_POWER_STATE         = 13,       ///< NCP's MCU power state [c]
 
     SPINEL_PROP_BASE_EXT__BEGIN         = 0x1000,
 
@@ -1411,6 +1432,20 @@ typedef enum
     SPINEL_PROP_IPV6_MULTICAST_ADDRESS_TABLE
                                         = SPINEL_PROP_IPV6__BEGIN + 6, ///< [A(t(6))]
 
+    /// IPv6 ICMP Ping Offload
+    /** Format: `C`
+     *
+     * Allow the NCP to directly respond to ICMP ping requests. If this is
+     * turned on, ping request ICMP packets will not be passed to the host.
+     *
+     * This property allows enabling responses sent to unicast only, multicast
+     * only, or both.
+     *
+     * Default value is `NET_IPV6_ICMP_PING_OFFLOAD_DISABLED`.
+     */
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE
+                                        = SPINEL_PROP_IPV6__BEGIN + 7, ///< [b]
+
     SPINEL_PROP_IPV6__END               = 0x70,
 
     SPINEL_PROP_STREAM__BEGIN           = 0x70,
@@ -1969,6 +2004,8 @@ SPINEL_API_EXTERN const char *spinel_next_packed_datatype(const char *pack_forma
 SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key);
 
 SPINEL_API_EXTERN const char *spinel_net_role_to_cstr(uint8_t net_role);
+
+SPINEL_API_EXTERN const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_state_t mcu_power_state);
 
 SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
 


### PR DESCRIPTION
This commit contains the following changes:

It adds support for getting/setting a new property "NCP:MCUPowerState"
in wpantund. This property is mapped to the recently added spinel
property `SPINEL_PROP_MCU_POWER_STATE` which can be used to control
the NCP's MCU power state (capability `SPINEL_CAP_MCU_POWER_STATE`
indicates support for this property and feature on NCP).

The `SpinelNCPTaskDeepSleep` and `SpinelNCPTaskWake` implementations
are updated to adopt/use the new spinel property (only when the NCP is
indicating its capability for this feature).

The commit also adds logic to manage wpantund state changes between
`OFFLINE` and `DEEP_SLEEP` based on changes to `MCU_POWER_STATE`.

Finally, `SpinelNCPControlInterface::begin_low_power()` is changed to
be an alias for setting the property "NCP:MCUPowerState" to low-
power.