### PR TITLE
Enabling "toranj" test-framework on wpantund travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ compiler:
 before_install:
     - .travis/before_install.sh
 
+before_script:
+    - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+      fi
+
 script:
     - .travis/script.sh
 
@@ -41,4 +46,8 @@ matrix:
         - os: osx # See issue #245: "Travis macOS builds are failing"
     exclude:
         - os: osx
+          compiler: gcc
+    include:
+        - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1
+          os: linux
           compiler: gcc

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -25,6 +25,19 @@ die() {
 
 set -x
 
+[ "$BUILD_TARGET" != "toranj-test-framework" ] || {
+    ./bootstrap.sh || die
+    ./configure || die
+    sudo make -j 8 || die
+    sudo make install || die
+
+    git clone --depth=1 --branch=master https://github.com/openthread/openthread.git
+
+    cd openthread
+    ./tests/toranj/start.sh || die
+    exit 0
+}
+
 [ $TRAVIS_OS_NAME != linux ] || BUILD_CONFIGFLAGS="${BUILD_CONFIGFLAGS} --with-connman"
 
 [ -e configure ] || ./bootstrap.sh || die


### PR DESCRIPTION
This commit enables [`toranj`](https://github.com/openthread/openthread/blob/master/tests/toranj/README.md) tests to be run as part of wpantund travis CI.
