### PR TITLE
Allow auto-resume from wpan "offline:deep-sleep" state

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -579,7 +579,9 @@ SpinelNCPInstance::vprocess_event(int event, va_list args)
 	EH_WAIT_UNTIL(mTaskQueue.empty());
 
 	// If we are commissioned and autoResume is enabled
-	if (mAutoResume && mEnabled && (get_ncp_state() == COMMISSIONED)) {
+	if (mAutoResume && mEnabled && mIsCommissioned
+	    && !ncp_state_is_joining_or_joined(get_ncp_state()) && !ncp_state_is_initializing(get_ncp_state())
+	) {
 		syslog(LOG_NOTICE, "AutoResume is enabled. Trying to resume.");
 		EH_SPAWN(&mSubPT, vprocess_resume(event, args));
 	}


### PR DESCRIPTION
This commit fixes an issue with the auto-resume logic not starting
when the NCP starts with MCU in low-power (wpan state starting as
"offline:deep-sleep". It changes the test before starting the resume
process to explicitly check the `mIsCommisionned` flag and relax
the wpan state check to include any offline states.