### PR TITLE
Enable adding/removing multicast IPv6 addresses

### DIFF
--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -731,8 +731,26 @@ NCPInstanceBase::property_insert_value(
 	const boost::any& value,
 	CallbackWithStatus cb
 ) {
-	syslog(LOG_ERR, "property_insert_value: Property not supported or not insert-value capable \"%s\"", key.c_str());
-	cb(kWPANTUNDStatus_PropertyNotFound);
+	try {
+		if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MulticastAddresses)) {
+			struct in6_addr address = any_to_ipv6(value);
+			multicast_address_was_joined(kOriginUser, address, cb);
+
+		} else {
+			syslog(LOG_ERR, "property_insert_value: Property not supported or not insert-value capable \"%s\"", key.c_str());
+			cb(kWPANTUNDStatus_PropertyNotFound);
+		}
+	} catch (const boost::bad_any_cast &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_insert_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	} catch (const std::invalid_argument &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_insert_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	}
 }
 
 void
@@ -741,8 +759,26 @@ NCPInstanceBase::property_remove_value(
 	const boost::any& value,
 	CallbackWithStatus cb
 ) {
-	syslog(LOG_ERR, "property_remove_value: Property not supported or not remove-value capable \"%s\"", key.c_str());
-	cb(kWPANTUNDStatus_PropertyNotFound);
+	try {
+		if (strcaseequal(key.c_str(), kWPANTUNDProperty_IPv6MulticastAddresses)) {
+			struct in6_addr address = any_to_ipv6(value);
+			multicast_address_was_left(kOriginUser, address, cb);
+
+		} else {
+			syslog(LOG_ERR, "property_remove_value: Property not supported or not remove-value capable \"%s\"", key.c_str());
+			cb(kWPANTUNDStatus_PropertyNotFound);
+		}
+	} catch (const boost::bad_any_cast &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_remove_value: Bad type for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	} catch (const std::invalid_argument &x) {
+		// We will get a bad_any_cast exception if the property is of
+		// the wrong type.
+		syslog(LOG_ERR,"property_remove_value: Invalid argument for property \"%s\" (%s)", key.c_str(), x.what());
+		cb(kWPANTUNDStatus_InvalidArgument);
+	}
 }
 
 void

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -151,9 +151,9 @@ public:
 
 	void unicast_address_was_removed(Origin origin, const struct in6_addr &address);
 
-	void multicast_address_was_joined(Origin origin, const struct in6_addr &address);
+	void multicast_address_was_joined(Origin origin, const struct in6_addr &address, CallbackWithStatus cb = NilReturn());
 
-	void multicast_address_was_left(Origin origin, const struct in6_addr &address);
+	void multicast_address_was_left(Origin origin, const struct in6_addr &address, CallbackWithStatus cb = NilReturn());
 
 	int join_multicast_group(const std::string &group_name);
 
@@ -445,6 +445,7 @@ private:
 	void refresh_routes_on_interface(void);
 	bool should_add_route_on_interface(const IPv6Prefix &route, uint32_t &metric);
 	void check_ncp_entry_update_status(int status, std::string operation, CallbackWithStatus cb);
+	void check_multicast_address_add_status(int status, const struct in6_addr address, CallbackWithStatus cb);
 
 protected:
 


### PR DESCRIPTION
This commit adds new feature to allow user to add/remove multicast
IPv6 addresses by issuing insert/remove using the wpan property
"IPv6:MulticastAddresses". The multicast IPv6 address will be updated
on NCP and also on the primary network interface.