### PR TITLE
Replace an unchecked strcpy with a better strncpy

### DIFF
--- a/src/connman-plugin/wpan-connman-plugin.c
+++ b/src/connman-plugin/wpan-connman-plugin.c
@@ -211,7 +211,7 @@ parse_prefix_string(const char *prefix_cstr, uint8_t *prefix)
 	memset(bytes, 0, sizeof(bytes));
 
 	// Create a copy of the prefix string so we can modify it.
-	strcpy(str, prefix_cstr);
+	strncpy(str, prefix_cstr, INET6_ADDRSTRLEN + 10);
 
 	// Search for "/64" and remove it from the str.
 	p = strchr(str, '/');


### PR DESCRIPTION
Issue flagged by the clang security checker.  Actual impact to product
is minimal -- the string being used as a source comes from dbus.  If
it was malicious it would be either because the attacker has a daemon
on the device already or because she has somehow hacked the pairing
flow into passing around a wrong network prefix.  At that point, a
buffer overrun and a resulting stack corruption would be the least of
our issues.  Nonetheless, it is best practice to check lengths so
that's what we're doing here.