### PR TITLE
Update spinel header files

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1382,7 +1382,7 @@ SpinelNCPInstance::property_get_value(
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(
-					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY)
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY)
 				)
 				.set_reply_unpacker(boost::bind(unpack_channel_monitor_channel_quality, _1, _2, _3, false))
 				.finish()
@@ -1396,7 +1396,7 @@ SpinelNCPInstance::property_get_value(
 			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
 				.set_callback(cb)
 				.add_command(
-					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY)
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY)
 				)
 				.set_reply_unpacker(boost::bind(unpack_channel_monitor_channel_quality, _1, _2, _3, true))
 				.finish()

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1209,8 +1209,8 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_CHANNEL_MONITOR_SAMPLE_COUNT";
         break;
 
-    case SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY:
-        ret = "PROP_CHANNEL_MONITOR_CHANNEL_QUALITY";
+    case SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY:
+        ret = "PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY";
         break;
 
     case SPINEL_PROP_MAC_SCAN_STATE:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -768,7 +768,7 @@ typedef enum
     SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT
                                         = SPINEL_PROP_PHY_EXT__BEGIN + 9,
 
-    /// Channel monitoring channel quality
+    /// Channel monitoring channel occupancy
     /** Format: `A(t(CU))` (read-only)
      *
      * Required capability: SPINEL_CAP_CHANNEL_MONITOR
@@ -776,9 +776,9 @@ typedef enum
      * Data per item is:
      *
      *  `C`: Channel
-     *  `U`: Channel quality indicator
+     *  `U`: Channel occupancy indicator
      *
-     * The channel quality value represents the average rate/percentage of
+     * The channel occupancy value represents the average rate/percentage of
      * RSSI samples that were above RSSI threshold ("bad" RSSI samples) within
      * (approximately) sample window latest RSSI samples.
      *
@@ -786,7 +786,7 @@ typedef enum
      * threshold (i.e. 100% of samples were "bad").
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY
+    SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY
                                         = SPINEL_PROP_PHY_EXT__BEGIN + 10,
 
     SPINEL_PROP_PHY_EXT__END            = 0x1300,


### PR DESCRIPTION
This commit updates "spinel.h", and "spinel.c" files from OpenThread
(commit b76f72e1ac85). It also addresses the spinel property name
change to `SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY` from
`SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_QUALITY`. The spinel property
key and its encoding remain unchanged (this is only a name change).