### PR TITLE
Add support for new NCP log output model and spinel property

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -285,7 +285,7 @@ SpinelNCPInstance::ncp_to_driver_pump()
 				}
 
 				if (i == mInboundFrameSize) {
-					handle_ncp_log(mInboundFrame, mInboundFrameSize);
+					handle_ncp_debug_stream(mInboundFrame, mInboundFrameSize);
 				}
 
 				continue;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -145,6 +145,7 @@ protected:
 	void handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
+	void handle_ncp_log_stream(const uint8_t* data_ptr, int data_len);
 	void handle_ncp_spinel_value_is_OFF_MESH_ROUTE(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 
 	bool should_filter_address(const struct in6_addr &address, uint8_t prefix_len);
@@ -198,7 +199,7 @@ public:
 
 	virtual void reset_tasks(wpantund_status_t status = kWPANTUNDStatus_Canceled);
 
-	static void handle_ncp_log(const uint8_t* data_ptr, int data_len);
+	static void handle_ncp_debug_stream(const uint8_t* data_ptr, int data_len);
 
 	static std::string thread_mode_to_string(uint8_t mode);
 

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1593,6 +1593,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_STREAM_NET_INSECURE";
         break;
 
+    case SPINEL_PROP_STREAM_LOG:
+        ret = "PROP_STREAM_LOG";
+        break;
+
     case SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL:
         ret = "PROP_CHANNEL_MANAGER_NEW_CHANNEL";
         break;
@@ -2200,6 +2204,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_CHANNEL_MANAGER:
         ret = "CAP_CHANNEL_MANAGER";
+        break;
+
+    case SPINEL_CAP_OPENTHREAD_LOG_METADATA:
+        ret = "CAP_OPENTHREAD_LOG_METADATA";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -311,6 +311,27 @@ enum
     SPINEL_NCP_LOG_LEVEL_DEBUG          = 7,
 };
 
+enum
+{
+    SPINEL_NCP_LOG_REGION_NONE          = 0,
+    SPINEL_NCP_LOG_REGION_OT_API        = 1,
+    SPINEL_NCP_LOG_REGION_OT_MLE        = 2,
+    SPINEL_NCP_LOG_REGION_OT_ARP        = 3,
+    SPINEL_NCP_LOG_REGION_OT_NET_DATA   = 4,
+    SPINEL_NCP_LOG_REGION_OT_ICMP       = 5,
+    SPINEL_NCP_LOG_REGION_OT_IP6        = 6,
+    SPINEL_NCP_LOG_REGION_OT_MAC        = 7,
+    SPINEL_NCP_LOG_REGION_OT_MEM        = 8,
+    SPINEL_NCP_LOG_REGION_OT_NCP        = 9,
+    SPINEL_NCP_LOG_REGION_OT_MESH_COP   = 10,
+    SPINEL_NCP_LOG_REGION_OT_NET_DIAG   = 11,
+    SPINEL_NCP_LOG_REGION_OT_PLATFORM   = 12,
+    SPINEL_NCP_LOG_REGION_OT_COAP       = 13,
+    SPINEL_NCP_LOG_REGION_OT_CLI        = 14,
+    SPINEL_NCP_LOG_REGION_OT_CORE       = 15,
+    SPINEL_NCP_LOG_REGION_OT_UTIL       = 16,
+};
+
 typedef struct
 {
     uint8_t bytes[8];
@@ -439,6 +460,7 @@ enum
     SPINEL_CAP_CHANNEL_MONITOR          = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
     SPINEL_CAP_ERROR_RATE_TRACKING      = (SPINEL_CAP_OPENTHREAD__BEGIN + 4),
     SPINEL_CAP_CHANNEL_MANAGER          = (SPINEL_CAP_OPENTHREAD__BEGIN + 5),
+    SPINEL_CAP_OPENTHREAD_LOG_METADATA  = (SPINEL_CAP_OPENTHREAD__BEGIN + 6),
     SPINEL_CAP_OPENTHREAD__END          = 640,
 
     SPINEL_CAP_THREAD__BEGIN            = 1024,
@@ -1453,6 +1475,30 @@ typedef enum
     SPINEL_PROP_STREAM_RAW              = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
     SPINEL_PROP_STREAM_NET              = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
     SPINEL_PROP_STREAM_NET_INSECURE     = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
+
+    /// Log Stream
+    /** Format: `UD` (stream, read only)
+     *
+     * This property is a read-only streaming property which provides
+     * formatted log string from NCP. This property provides asynchronous
+     * `CMD_PROP_VALUE_IS` updates with a new log string and includes
+     * optional meta data.
+     *
+     *   `U`: The log string
+     *   `D`: Log metadata (optional).
+     *
+     * Any data after the log string is considered metadata and is OPTIONAL.
+     * Pretense of `SPINEL_CAP_OPENTHREAD_LOG_METADATA` capability
+     * indicates that OpenThread log metadata format is used as defined
+     * below:
+     *
+     *    `C`: Log level (as per definition in enumeration
+     *         `SPINEL_NCP_LOG_LEVEL_<level>`)
+     *    `i`: OpenThread Log region (as per definition in enumeration
+     *         `SPINEL_NCP_LOG_REGION_<region>).
+     *
+     */
+    SPINEL_PROP_STREAM_LOG              = SPINEL_PROP_STREAM__BEGIN + 4,
     SPINEL_PROP_STREAM__END             = 0x80,
 
     SPINEL_PROP_OPENTHREAD__BEGIN       = 0x1900,


### PR DESCRIPTION
This commit adds support for the new NCP log output model. It adds
support for the newly added spinel property `SPINEL_PROP_STREAM_LOG`
which provides streaming of formatted log string from NCP along with
an optional metadata structure. OpenThread log level and log region
are included as part of the metadata. `wpantund` parses the metadata
and appends a human-readable prefix string to the outputted log line
in syslog.

Related PR in OT: https://github.com/openthread/openthread/pull/2722