### PR TITLE
Allow NCP reset to restart the initialization protothread earlier

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -400,9 +400,11 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 				event == EVENT_NCP_RESET,
 				on_error
 			);
-
-			mDriverState = INITIALIZING;
 		}
+
+		// This next line causes any resets received after this
+		// point to cause the control protothread to be restarted.
+		mDriverState = INITIALIZING;
 
 		// Get the protocol version
 		CONTROL_REQUIRE_PREP_TO_SEND_COMMAND_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);
@@ -428,10 +430,6 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 		// If we are "joining" at this point, then we must start over.
 		// This will cause a reset to occur.
 		require(!ncp_state_is_joining(get_ncp_state()), on_error);
-
-		// This next line causes any resets received after this
-		// point to cause the control protothread to be restarted.
-		mDriverState = INITIALIZING;
 
 		if (mIsPcapInProgress) {
 			CONTROL_REQUIRE_PREP_TO_SEND_COMMAND_WITHIN(NCP_DEFAULT_COMMAND_SEND_TIMEOUT, on_error);


### PR DESCRIPTION
This commit makes a change in the NCP initialization protothread  code
in `vprocess_init()` where the `mDriverState` is changed to
`INITIALIZING` (from `INITIALIZING_WAITING_FOR_RESET`) earlier in the
code and before sending a command to get the NCP protocol version.
This ensures that any received resets from NCP cause the protothread
to be restarted immediately.

This change addresses a delay issue with `wpantund` starting, where if
NCP is reset (e.g., by `spi-hdlc-adapter` process starting) while
wpantund is performing the NCP initialization, a wait time delay equal
to command response timeout (5 seconds) may be required for
initialization to restart.