### PR TITLE
Add new wpan property "Thread:RouterSelectionJitter"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1300,6 +1300,9 @@ SpinelNCPInstance::property_get_value(
 		cb = boost::bind(convert_rloc16_to_router_id, cb, _1, _2);
 		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_RLOC16, SPINEL_DATATYPE_UINT16_S);
 
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadRouterSelectionJitter)) {
+		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER, SPINEL_DATATYPE_UINT8_S);
+
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadLeaderAddress)) {
 		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_LEADER_ADDR, SPINEL_DATATYPE_IPv6ADDR_S);
 
@@ -2460,6 +2463,19 @@ SpinelNCPInstance::property_set_value(
 					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
 					SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED,
 					isEnabled
+				))
+				.finish()
+			);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadRouterSelectionJitter)) {
+			uint8_t jitter = static_cast<uint8_t>(any_to_int(value));
+
+			start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_UINT8_S),
+					SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER,
+					jitter
 				))
 				.finish()
 			);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -94,6 +94,7 @@
 
 #define kWPANTUNDProperty_ThreadRLOC16                          "Thread:RLOC16"
 #define kWPANTUNDProperty_ThreadRouterID                        "Thread:RouterID"
+#define kWPANTUNDProperty_ThreadRouterSelectionJitter           "Thread:RouterSelectionJitter"
 #define kWPANTUNDProperty_ThreadLeaderAddress                   "Thread:Leader:Address"
 #define kWPANTUNDProperty_ThreadLeaderRouterID                  "Thread:Leader:RouterID"
 #define kWPANTUNDProperty_ThreadLeaderWeight                    "Thread:Leader:Weight"


### PR DESCRIPTION
This commit adds new wpan property to configure the jitter
for Router-Capable device to decide whether to become Router or
stay in REED role.