### PR TITLE
Add new property "Thread:AddressCacheTable"

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -478,6 +478,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 		properties.insert(kWPANTUNDProperty_NetworkPartitionId);
 		properties.insert(kWPANTUNDProperty_ThreadActiveDataset);
 		properties.insert(kWPANTUNDProperty_ThreadPendingDataset);
+		properties.insert(kWPANTUNDProperty_ThreadAddressCacheTable);
 
 		if (mCapabilities.count(SPINEL_CAP_ERROR_RATE_TRACKING)) {
 			properties.insert(kWPANTUNDProperty_ThreadNeighborTableErrorRates);
@@ -1004,6 +1005,72 @@ convert_string_to_spinel_mcu_power_state(const char *str, spinel_mcu_power_state
 		ret = kWPANTUNDStatus_InvalidArgument;
 	}
 
+	return ret;
+}
+
+static int
+unpack_address_cache_table(const uint8_t *data_in, spinel_size_t data_len, boost::any& value, bool as_val_map)
+{
+	std::list<std::string> result_as_string;
+	std::list<ValueMap> result_as_val_map;
+	int ret = kWPANTUNDStatus_Ok;
+
+	while (data_len > 0)
+	{
+		spinel_ssize_t len;
+		struct in6_addr *target_address = NULL;
+		uint16_t target_rloc16;
+		uint8_t age;
+
+		len = spinel_datatype_unpack(
+			data_in,
+			data_len,
+			SPINEL_DATATYPE_STRUCT_S(
+				SPINEL_DATATYPE_IPv6ADDR_S
+				SPINEL_DATATYPE_UINT16_S
+				SPINEL_DATATYPE_UINT8_S
+			),
+			&target_address,
+			&target_rloc16,
+			&age
+		);
+
+		require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+
+		if (!as_val_map) {
+			char c_string[100];
+
+			snprintf(
+				c_string,
+				sizeof(c_string),
+				"%s -> 0x%04x, age:%d",
+				in6_addr_to_string(*target_address).c_str(),
+				target_rloc16,
+				age
+			);
+
+			result_as_string.push_back(std::string(c_string));
+		} else {
+			ValueMap entry;
+
+			entry[kWPANTUNDValueMapKey_AddressCacheTable_Address] = boost::any(in6_addr_to_string(*target_address));
+			entry[kWPANTUNDValueMapKey_AddressCacheTable_RLOC16]  = boost::any(target_rloc16);
+			entry[kWPANTUNDValueMapKey_AddressCacheTable_Age]     = boost::any(age);
+
+			result_as_val_map.push_back(entry);
+		}
+
+		data_in += len;
+		data_len -= len;
+	}
+
+	if (as_val_map) {
+		value = result_as_val_map;
+	} else {
+		value = result_as_string;
+	}
+
+bail:
 	return ret;
 }
 
@@ -1747,6 +1814,26 @@ SpinelNCPInstance::property_get_value(
 				SpinelNCPTaskGetNetworkTopology::kResultFormat_ValueMapArray
 			)
 		));
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadAddressCacheTable)) {
+		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE)
+				)
+				.set_reply_unpacker(boost::bind(unpack_address_cache_table, _1, _2, _3, /* as_val_map */ false))
+				.finish()
+			);
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadAddressCacheTableAsValMap)) {
+		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+				.set_callback(cb)
+				.add_command(
+					SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_GET, SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE)
+				)
+				.set_reply_unpacker(boost::bind(unpack_address_cache_table, _1, _2, _3, /* as_val_map */ true))
+				.finish()
+			);
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_OpenThreadMsgBufferCounters)) {
 		start_new_task(boost::shared_ptr<SpinelNCPTask>(
@@ -3780,6 +3867,21 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		}
 		syslog(LOG_INFO, "[-NCP-] Router: Total %d router%s", num_router, (num_router > 1) ? "s" : "");
 
+
+	} else if (key == SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE) {
+		boost::any value;
+		if ((unpack_address_cache_table(value_data_ptr, value_data_len, value, false) == kWPANTUNDStatus_Ok)
+			&& (value.type() == typeid(std::list<std::string>))
+		) {
+			std::list<std::string> list = boost::any_cast<std::list<std::string> >(value);
+			int num_entries = 0;
+
+			for (std::list<std::string>::iterator it = list.begin(); it != list.end(); it++) {
+				num_entries++;
+				syslog(LOG_INFO, "[-NCP-] AddressCache: %02d %s", num_entries, it->c_str());
+			}
+			syslog(LOG_INFO, "[-NCP-] AddressCache: Total %d entr%s", num_entries, (num_entries > 1) ? "ies" : "y");
+		}
 
 	} else if (key == SPINEL_PROP_NET_PARTITION_ID) {
 		uint32_t paritition_id = 0;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -125,6 +125,8 @@
 #define kWPANTUNDProperty_ThreadActiveDatasetAsValMap           "Thread:ActiveDataset:AsValMap"
 #define kWPANTUNDProperty_ThreadPendingDataset                  "Thread:PendingDataset"
 #define kWPANTUNDProperty_ThreadPendingDatasetAsValMap          "Thread:PendingDataset:AsValMap"
+#define kWPANTUNDProperty_ThreadAddressCacheTable               "Thread:AddressCacheTable"
+#define kWPANTUNDProperty_ThreadAddressCacheTableAsValMap       "Thread:AddressCacheTable:AsValMap"
 
 #define kWPANTUNDProperty_DatasetActiveTimestamp                "Dataset:ActiveTimestamp"
 #define kWPANTUNDProperty_DatasetPendingTimestamp               "Dataset:PendingTimestamp"
@@ -288,6 +290,10 @@
 
 #define kWPANTUNDValueMapKey_ChannelMonitor_Channel             "Channel"
 #define kWPANTUNDValueMapKey_ChannelMonitor_Quality             "Quality"
+
+#define kWPANTUNDValueMapKey_AddressCacheTable_Address          "Address"
+#define kWPANTUNDValueMapKey_AddressCacheTable_RLOC16           "RLOC16"
+#define kWPANTUNDValueMapKey_AddressCacheTable_Age              "Age"
 
 #define kWPANTUNDValueMapKey_NetworkTopology_ExtAddress         "ExtAddress"
 #define kWPANTUNDValueMapKey_NetworkTopology_RLOC16             "RLOC16"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1545,6 +1545,10 @@ spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES";
         break;
 
+    case SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE:
+        ret = "PROP_THREAD_ADDRESS_CACHE_TABLE";
+        break;
+
     case SPINEL_PROP_IPV6_LL_ADDR:
         ret = "PROP_IPV6_LL_ADDR";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1416,6 +1416,21 @@ typedef enum
     SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES
                                         = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
 
+    /// EID (Endpoint Identifier) IPv6 Address Cache Table
+    /** Format `A(t(6SC))`
+     *
+     * This property provides Thread EID address cache table.
+     *
+     * Data per item is:
+     *
+     *  `6` : Target IPv6 address
+     *  `S` : RLOC16 of target
+     *  `C` : Age (order of use, 0 indicates most recently used entry)
+     *
+     */
+    SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE
+                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 35,
+
     SPINEL_PROP_THREAD_EXT__END         = 0x1600,
 
     SPINEL_PROP_IPV6__BEGIN             = 0x60,


### PR DESCRIPTION
This commit adds support to get the Thread EID IPv6 address cache
table. New wpantund property "Thread:AddressCacheTable" is added
which is mapped to spinel property `THREAD_ADDRESS_CACHE_TABLE`.

When a `VALUE_IS` update is received from NCP for the spinel
property `THREAD_ADDRESS_CACHE_TABLE`, the cache table info is
added to the logs.

-----
PR in OpenThread: https://github.com/openthread/openthread/pull/2788.

```
$ Node1.wpanctl('get -v Thread:AddressCacheTable')
[
	"fdf6:64b8:62e7:0:f635:590d:53bb:10b3 -> 0x4c02, age:0"
	"fdf6:64b8:62e7:0:6d8b:f045:eb1f:adb8 -> 0x4c00, age:1"
	"fdf6:64b8:62e7:0:d18:18a4:6e89:5c00 -> 0x4c00, age:2"
]

$ Node1.wpanctl('get -v Thread:AddressCacheTable:AsValMap')
[
	[
		"Address" => "fdf6:64b8:62e7:0:f635:590d:53bb:10b3"
		"Age" => 0x00
		"RLOC16" => 0x4C02
	]
	[
		"Address" => "fdf6:64b8:62e7:0:6d8b:f045:eb1f:adb8"
		"Age" => 0x01
		"RLOC16" => 0x4C00
	]
	[
		"Address" => "fdf6:64b8:62e7:0:d18:18a4:6e89:5c00"
		"Age" => 0x02
		"RLOC16" => 0x4C00
	]
]

$ Node3.wpanctl('get -v Thread:AddressCacheTable')
[]
$ Node3.wpanctl('get -v Thread:AddressCacheTable:AsValMap')
[]
```
Here how the address cache table is added in the wpantund logs:

```
wpantund[132673]: property_get_value: key: "Thread:AddressCacheTable"
wpantund[132673]: [->NCP] CMD_PROP_VALUE_GET(PROP_THREAD_ADDRESS_CACHE_TABLE) tid:1
wpantund[132673]: NCP is now BUSY.
wpantund[132673]: [NCP->] CMD_PROP_VALUE_IS(PROP_THREAD_ADDRESS_CACHE_TABLE) tid:1
wpantund[132673]: [-NCP-] AddressCache: 01 fdf6:64b8:62e7:0:f635:590d:53bb:10b3 -> 0x4c02, age:0
wpantund[132673]: [-NCP-] AddressCache: 02 fdf6:64b8:62e7:0:6d8b:f045:eb1f:adb8 -> 0x4c00, age:1
wpantund[132673]: [-NCP-] AddressCache: 03 fdf6:64b8:62e7:0:d18:18a4:6e89:5c00 -> 0x4c00, age:2
wpantund[132673]: [-NCP-] AddressCache: Total 3 entries


wpantund[132675]: property_get_value: key: "Thread:AddressCacheTable"
wpantund[132675]: [->NCP] CMD_PROP_VALUE_GET(PROP_THREAD_ADDRESS_CACHE_TABLE) tid:1
wpantund[132675]: NCP is now BUSY.
wpantund[132675]: [NCP->] CMD_PROP_VALUE_IS(PROP_THREAD_ADDRESS_CACHE_TABLE) tid:1
wpantund[132675]: [-NCP-] AddressCache: Total 0 entry
```