### PR TITLE
Replace TMF proxy with UDP proxy

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -520,10 +520,6 @@ SpinelNCPInstance::get_supported_property_keys()const
 		properties.insert(kWPANTUNDProperty_ChannelManagerFavoredChannelMask);
 	}
 
-	if (mCapabilities.count(SPINEL_CAP_THREAD_UDP_PROXY)) {
-		properties.insert(kWPANTUNDProperty_UdpProxyEnabled);
-	}
-
 	if (mCapabilities.count(SPINEL_CAP_NEST_LEGACY_INTERFACE))
 	{
 		properties.insert(kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix);
@@ -1705,9 +1701,6 @@ SpinelNCPInstance::property_get_value(
 			SIMPLE_SPINEL_GET(SPINEL_PROP_JAM_DETECTED, SPINEL_DATATYPE_BOOL_S);
 		}
 
-	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_UdpProxyEnabled)) {
-		SIMPLE_SPINEL_GET(SPINEL_PROP_THREAD_UDP_PROXY_ENABLED, SPINEL_DATATYPE_BOOL_S);
-
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_JamDetectionEnable)) {
 		if (!mCapabilities.count(SPINEL_CAP_JAM_DETECT)) {
 			cb(kWPANTUNDStatus_FeatureNotSupported, boost::any(std::string("Jam Detection Feature Not Supported")));
@@ -2620,22 +2613,6 @@ SpinelNCPInstance::property_set_value(
 				.add_command(command)
 				.finish()
 			);
-		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_UdpProxyEnabled)) {
-			bool isEnabled = any_to_bool(value);
-			Data command = SpinelPackData(SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S), SPINEL_PROP_THREAD_UDP_PROXY_ENABLED, isEnabled);
-
-			mSettings[kWPANTUNDProperty_UdpProxyEnabled] = SettingsEntry(command, SPINEL_CAP_THREAD_UDP_PROXY);
-
-			if (!mCapabilities.count(SPINEL_CAP_THREAD_UDP_PROXY))
-			{
-				cb(kWPANTUNDStatus_FeatureNotSupported);
-			} else {
-				start_new_task(SpinelNCPTaskSendCommand::Factory(this)
-					.set_callback(cb)
-					.add_command(command)
-					.finish()
-				);
-			}
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_MACWhitelistEnabled)) {
 			bool isEnabled = any_to_bool(value);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -4125,7 +4125,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		__ASSERT_MACROS_check(ret > 0);
 
 		// Analyze the packet to determine if it should be dropped.
-		if ((ret > 0)) {
+		if (ret > 0) {
 			// append frame
 			data.append(frame_ptr, frame_len);
 			// pack the locator in big endian.

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -204,6 +204,8 @@
 #define kWPANTUNDProperty_ChannelManagerSupportedChannelMask    "ChannelManager:SupportedChannelMask"
 #define kWPANTUNDProperty_ChannelManagerFavoredChannelMask      "ChannelManager:FavoredChannelMask"
 
+#define kWPANTUNDProperty_TmfProxyEnabled                       "TmfProxy:Enabled"
+#define kWPANTUNDProperty_TmfProxyStream                        "TmfProxy:Stream"
 #define kWPANTUNDProperty_UdpProxyStream                        "UdpProxy:Stream"
 
 #define kWPANTUNDProperty_NestLabs_NetworkAllowingJoin          "com.nestlabs.internal:Network:AllowingJoin"

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -204,8 +204,8 @@
 #define kWPANTUNDProperty_ChannelManagerSupportedChannelMask    "ChannelManager:SupportedChannelMask"
 #define kWPANTUNDProperty_ChannelManagerFavoredChannelMask      "ChannelManager:FavoredChannelMask"
 
-#define kWPANTUNDProperty_TmfProxyEnabled                       "TmfProxy:Enabled"
-#define kWPANTUNDProperty_TmfProxyStream                        "TmfProxy:Stream"
+#define kWPANTUNDProperty_UdpProxyEnabled                       "UdpProxy:Enabled"
+#define kWPANTUNDProperty_UdpProxyStream                        "UdpProxy:Stream"
 
 #define kWPANTUNDProperty_NestLabs_NetworkAllowingJoin          "com.nestlabs.internal:Network:AllowingJoin"
 #define kWPANTUNDProperty_NestLabs_NetworkPassthruPort          "com.nestlabs.internal:Network:PassthruPort"

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -204,7 +204,6 @@
 #define kWPANTUNDProperty_ChannelManagerSupportedChannelMask    "ChannelManager:SupportedChannelMask"
 #define kWPANTUNDProperty_ChannelManagerFavoredChannelMask      "ChannelManager:FavoredChannelMask"
 
-#define kWPANTUNDProperty_UdpProxyEnabled                       "UdpProxy:Enabled"
 #define kWPANTUNDProperty_UdpProxyStream                        "UdpProxy:Stream"
 
 #define kWPANTUNDProperty_NestLabs_NetworkAllowingJoin          "com.nestlabs.internal:Network:AllowingJoin"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1485,12 +1485,12 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_COMMISSIONER_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_TMF_PROXY_ENABLED:
-        ret = "PROP_THREAD_TMF_PROXY_ENABLED";
+    case SPINEL_PROP_THREAD_UDP_PROXY_ENABLED:
+        ret = "PROP_THREAD_UDP_PROXY_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_TMF_PROXY_STREAM:
-        ret = "PROP_THREAD_TMF_PROXY_STREAM";
+    case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
+        ret = "PROP_THREAD_UDP_PROXY_STREAM";
         break;
 
     case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
@@ -2254,8 +2254,8 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "CAP_THREAD_COMMISSIONER";
         break;
 
-    case SPINEL_CAP_THREAD_TMF_PROXY:
-        ret = "CAP_THREAD_TMF_PROXY";
+    case SPINEL_CAP_THREAD_UDP_PROXY:
+        ret = "CAP_THREAD_UDP_PROXY";
         break;
 
     case SPINEL_CAP_THREAD_UDP_PROXY:

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1485,10 +1485,6 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_COMMISSIONER_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_UDP_PROXY_ENABLED:
-        ret = "PROP_THREAD_UDP_PROXY_ENABLED";
-        break;
-
     case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
         ret = "PROP_THREAD_UDP_PROXY_STREAM";
         break;

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1485,8 +1485,12 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_COMMISSIONER_ENABLED";
         break;
 
-    case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
-        ret = "PROP_THREAD_UDP_PROXY_STREAM";
+    case SPINEL_PROP_THREAD_TMF_PROXY_ENABLED:
+        ret = "PROP_THREAD_TMF_PROXY_ENABLED";
+        break;
+
+    case SPINEL_PROP_THREAD_TMF_PROXY_STREAM:
+        ret = "PROP_THREAD_TMF_PROXY_STREAM";
         break;
 
     case SPINEL_PROP_THREAD_UDP_PROXY_STREAM:
@@ -2250,8 +2254,8 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "CAP_THREAD_COMMISSIONER";
         break;
 
-    case SPINEL_CAP_THREAD_UDP_PROXY:
-        ret = "CAP_THREAD_UDP_PROXY";
+    case SPINEL_CAP_THREAD_TMF_PROXY:
+        ret = "CAP_THREAD_TMF_PROXY";
         break;
 
     case SPINEL_CAP_THREAD_UDP_PROXY:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1131,13 +1131,19 @@ typedef enum {
 
     /// Thread TMF proxy enable
     /** Format `b`
+     * Required capability: `SPINEL_CAP_THREAD_TMF_PROXY`
      *
-     * Default value is `false`.
+     * This property is deprecated.
+     *
      */
     SPINEL_PROP_THREAD_TMF_PROXY_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
 
     /// Thread TMF proxy stream
     /** Format `dSS`
+     * Required capability: `SPINEL_CAP_THREAD_TMF_PROXY`
+     *
+     * This property is deprecated. Please see `SPINEL_PROP_THREAD_UDP_PROXY_STREAM`.
+     *
      */
     SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
 
@@ -1397,6 +1403,7 @@ typedef enum {
 
     /// Thread UDP proxy stream
     /** Format `dS6S`
+     * Required capability: `SPINEL_CAP_THREAD_UDP_PROXY`
      *
      * This property helps exchange UDP packets with host.
      *

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -404,6 +404,7 @@ enum
 
 enum
 {
+<<<<<<< HEAD
     SPINEL_CAP_LOCK       = 1,
     SPINEL_CAP_NET_SAVE   = 2,
     SPINEL_CAP_HBO        = 3,
@@ -1139,7 +1140,7 @@ typedef enum {
     /// Thread TMF proxy stream
     /** Format `dSS`
      */
-    SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
+    SPINEL_PROP_THREAD_UDP_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
 
     /// Thread "joiner" flag used during discovery scan operation
     /** Format `b`

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -404,7 +404,6 @@ enum
 
 enum
 {
-<<<<<<< HEAD
     SPINEL_CAP_LOCK       = 1,
     SPINEL_CAP_NET_SAVE   = 2,
     SPINEL_CAP_HBO        = 3,
@@ -1140,7 +1139,7 @@ typedef enum {
     /// Thread TMF proxy stream
     /** Format `dSS`
      */
-    SPINEL_PROP_THREAD_UDP_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
+    SPINEL_PROP_THREAD_TMF_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 18,
 
     /// Thread "joiner" flag used during discovery scan operation
     /** Format `b`


### PR DESCRIPTION
This PR replaces TMF proxy with UDP proxy, which helps moving border agent into OpenThread. The changes in OpenThread can be reviewed at https://github.com/openthread/openthread/pull/2771