### PR TITLE
Remove extra `dbus_message_ref()` in DBus APIs methods

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v0.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v0.cpp
@@ -630,9 +630,6 @@ DBusIPCAPI_v0::interface_config_gateway_handler(
 	DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	dbus_bool_t defaultRoute = FALSE;
 	dbus_bool_t preferred = TRUE;
 	dbus_bool_t slaac = TRUE;
@@ -690,9 +687,6 @@ DBusIPCAPI_v0::interface_add_route_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	uint8_t *prefix = NULL;
 	struct in6_addr addr = {};
 	int prefix_len = 0;
@@ -741,9 +735,6 @@ DBusIPCAPI_v0::interface_remove_route_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	uint8_t *prefix = NULL;
 	struct in6_addr addr = {};
 	int prefix_len = 0;

--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -1268,9 +1268,6 @@ DBusIPCAPI_v1::interface_route_add_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	uint8_t *route_prefix(NULL);
 	int prefix_len_in_bytes(0);
 	uint16_t domain_id(0);
@@ -1336,7 +1333,6 @@ DBusIPCAPI_v1::interface_route_remove_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
 	uint8_t *route_prefix = NULL;
 	int prefix_len_in_bytes(0);
 	uint8_t prefix_len_in_bits(0);
@@ -1391,9 +1387,6 @@ DBusIPCAPI_v1::interface_joiner_add_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	const uint8_t* ext_addr = NULL;
 	int ext_addr_len = 0;
 	const char* psk = NULL;
@@ -1443,9 +1436,6 @@ DBusIPCAPI_v1::interface_peek_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	uint32_t address;
 	uint16_t count;
 	bool did_succeed = false;
@@ -1485,9 +1475,6 @@ DBusIPCAPI_v1::interface_poke_handler(
    DBusMessage *        message
 ) {
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
-
-	dbus_message_ref(message);
-
 	uint32_t address;
 	int count = 0;
 	uint8_t *bytes = NULL;


### PR DESCRIPTION
In some of `DBusIPCAPI_v1` or `DBusIPCAPI_v0` interface methods
`dbus_message_ref()` was called twice on the DBus `message`. This
commit removes the extra call.