### PR TITLE
New APIs for adding/removing on-mesh prefix

### DIFF
--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -132,12 +132,11 @@ DummyNCPControlInterface::data_poll(CallbackWithStatus cb)
 
 void
 DummyNCPControlInterface::add_on_mesh_prefix(
-	const struct in6_addr *prefix,
-	bool defaultRoute,
-	bool preferred,
-	bool slaac,
-	bool onMesh,
+	const struct in6_addr& prefix,
+	uint8_t prefix_len,
+	OnMeshPrefixFlags flags,
 	OnMeshPrefixPriority priority,
+	bool stable,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);
@@ -145,7 +144,8 @@ DummyNCPControlInterface::add_on_mesh_prefix(
 
 void
 DummyNCPControlInterface::remove_on_mesh_prefix(
-	const struct in6_addr *prefix,
+	const struct in6_addr& prefix,
+	uint8_t prefix_len,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -131,18 +131,18 @@ public:
 	);
 
 	virtual void add_on_mesh_prefix(
-		const struct in6_addr *prefix,
-		bool defaultRoute,
-		bool preferred,
-		bool slaac,
-		bool onMesh,
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
+		OnMeshPrefixFlags flags,
 		OnMeshPrefixPriority priority,
-		CallbackWithStatus cb = NilReturn()
+		bool stable,
+		CallbackWithStatus cb
 	);
 
 	virtual void remove_on_mesh_prefix(
-		const struct in6_addr *prefix,
-		CallbackWithStatus cb = NilReturn()
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
+		CallbackWithStatus cb
 	);
 
 	virtual void add_external_route(

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -190,50 +190,23 @@ SpinelNCPControlInterface::data_poll(CallbackWithStatus cb)
 
 void
 SpinelNCPControlInterface::add_on_mesh_prefix(
-	const struct in6_addr *prefix,
-	bool defaultRoute,
-	bool preferred,
-	bool slaac,
-	bool onMesh,
+	const struct in6_addr& prefix,
+	uint8_t prefix_len,
+	OnMeshPrefixFlags flags,
 	OnMeshPrefixPriority priority,
+	bool stable,
 	CallbackWithStatus cb
 ) {
-	uint8_t flags = 0;
-
-	require_action(prefix != NULL, bail, cb(kWPANTUNDStatus_InvalidArgument));
 	require_action(mNCPInstance->mEnabled, bail, cb(kWPANTUNDStatus_InvalidWhenDisabled));
 
-	switch (priority) {
-	case ROUTE_HIGH_PREFERENCE:
-		flags = (1 << SpinelNCPInstance::OnMeshPrefixEntry::kPreferenceOffset);
-		break;
-
-	case ROUTE_MEDIUM_PREFERENCE:
-		flags = 0;
-		break;
-
-	case ROUTE_LOW_PREFRENCE:
-		flags = (3 << SpinelNCPInstance::OnMeshPrefixEntry::kPreferenceOffset);
-		break;
-	}
-
-	if (defaultRoute) {
-		flags |= SpinelNCPInstance::OnMeshPrefixEntry::kFlagDefaultRoute;
-	}
-
-	if (preferred) {
-		flags |= SpinelNCPInstance::OnMeshPrefixEntry::kFlagPreferred;
-	}
-
-	if (slaac) {
-		flags |= SpinelNCPInstance::OnMeshPrefixEntry::kFlagSLAAC;
-	}
-
-	if (onMesh) {
-		flags |= SpinelNCPInstance::OnMeshPrefixEntry::kFlagOnMesh;
-	}
-
-	mNCPInstance->on_mesh_prefix_was_added(SpinelNCPInstance::kOriginUser, *prefix, 64, flags, true, cb);
+	mNCPInstance->on_mesh_prefix_was_added(
+		SpinelNCPInstance::kOriginUser,
+		prefix,
+		prefix_len,
+		SpinelNCPInstance::OnMeshPrefixEntry::encode_flag_set(flags, priority),
+		stable,
+		cb
+	);
 
 bail:
 	return;
@@ -241,13 +214,12 @@ bail:
 
 void
 SpinelNCPControlInterface::remove_on_mesh_prefix(
-	const struct in6_addr *prefix,
+	const struct in6_addr& prefix,
+	uint8_t prefix_len,
 	CallbackWithStatus cb
 ) {
-	require_action(prefix != NULL, bail, cb(kWPANTUNDStatus_InvalidArgument));
 	require_action(mNCPInstance->mEnabled, bail, cb(kWPANTUNDStatus_InvalidWhenDisabled));
-
-	mNCPInstance->on_mesh_prefix_was_removed(SpinelNCPInstance::kOriginUser, *prefix, 64, cb);
+	mNCPInstance->on_mesh_prefix_was_removed(SpinelNCPInstance::kOriginUser, prefix, prefix_len, cb);
 
 bail:
 	return;

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -133,18 +133,18 @@ public:
 	);
 
 	virtual void add_on_mesh_prefix(
-		const struct in6_addr *prefix,
-		bool defaultRoute,
-		bool preferred,
-		bool slaac,
-		bool onMesh,
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
+		OnMeshPrefixFlags flags,
 		OnMeshPrefixPriority priority,
-		CallbackWithStatus cb = NilReturn()
+		bool stable,
+		CallbackWithStatus cb
 	);
 
 	virtual void remove_on_mesh_prefix(
-		const struct in6_addr *prefix,
-		CallbackWithStatus cb = NilReturn()
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
+		CallbackWithStatus cb
 	);
 
 	virtual void add_external_route(

--- a/src/wpanctl/Makefile.am
+++ b/src/wpanctl/Makefile.am
@@ -58,6 +58,8 @@ wpanctl_SOURCES = \
 	tool-cmd-cd.c \
 	tool-cmd-poll.c \
 	tool-cmd-config-gateway.c \
+	tool-cmd-add-prefix.c \
+	tool-cmd-remove-prefix.c \
 	tool-cmd-host-did-wake.c \
 	tool-cmd-add-route.c \
 	tool-cmd-remove-route.c \
@@ -82,6 +84,8 @@ wpanctl_SOURCES = \
 	tool-cmd-cd.h \
 	tool-cmd-poll.h \
 	tool-cmd-config-gateway.h \
+	tool-cmd-add-prefix.h \
+	tool-cmd-remove-prefix.h \
 	tool-cmd-host-did-wake.h \
 	tool-cmd-add-route.h \
 	tool-cmd-remove-route.h \

--- a/src/wpanctl/tool-cmd-add-prefix.c
+++ b/src/wpanctl/tool-cmd-add-prefix.c
@@ -1,0 +1,295 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      This file implements "add-prefix" command in wpanctl.
+ *
+ */
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-cmd-add-prefix.h"
+#include "assert-macros.h"
+#include "args.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "string-utils.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+
+const char add_prefix_cmd_syntax[] = "[args] <prefix>";
+
+static const arg_list_item_t add_prefix_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'P', "priority", "(>0 for high, 0 for medium, <0 for low)", "Indicate prefix priority (default is 0 or medium)"},
+	{'l', "length", "in bits", "Set the prefix length (default is 64)"},
+	{'s', "stable", NULL, "Indicate the prefix is part of stable Network Data (default is off)"},
+	{'f', "preferred", NULL, "Set the prefix flag \"preferred\""},
+	{'a', "slaac", NULL, "Set the prefix flag \"SLAAC\""},
+	{'d', "dhcp", NULL, "Set the prefix flag \"dhcp\""},
+	{'c', "configure", NULL, "Set the prefix flag \"configure\""},
+	{'r', "default-route", NULL, "Set the prefix flag \"default-route\""},
+	{'o', "on-mesh", NULL, "Set the prefix flag \"on-mesh\""},
+	{0}
+};
+
+int tool_cmd_add_prefix(int argc, char* argv[])
+{
+	int ret = 0;
+	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	char dbus_path[DBUS_MAXIMUM_NAME_LENGTH + 1];
+	char dbus_interface_name[DBUS_MAXIMUM_NAME_LENGTH + 1];
+	const char* prefix_str = NULL;
+	uint16_t prefix_len_in_bits = 64;
+	int16_t priority = 0;
+	dbus_bool_t stable = FALSE;
+	dbus_bool_t preferred = FALSE;
+	dbus_bool_t slaac = FALSE;
+	dbus_bool_t dhcp = FALSE;
+	dbus_bool_t configure = FALSE;
+	dbus_bool_t default_route = FALSE;
+	dbus_bool_t on_mesh = FALSE;
+	uint8_t prefix_bytes[16] = {};
+	uint8_t *addr = prefix_bytes;
+	uint32_t preferred_lifetime = 0xFFFFFFFF;
+	uint32_t valid_lifetime = 0xFFFFFFFF;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h' },
+			{"timeout", required_argument, 0, 't'},
+			{"priority", required_argument, 0, 'P'},
+			{"length", required_argument, 0, 'l'},
+			{"stable", no_argument, 0, 's'},
+			{"preferred", no_argument, 0, 'f'},
+			{"slaac", no_argument, 0, 'a'},
+			{"dhcp", no_argument, 0, 'd'},
+			{"configure", no_argument, 0, 'c'},
+			{"default-route", no_argument, 0, 'r'},
+			{"on-mesh", no_argument, 0, 'o'},
+			{0, 0, 0, 0}
+		};
+
+		int c;
+		int option_index = 0;
+
+		c = getopt_long(argc, argv, "ht:P:l:sfadcro", long_options, &option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(add_prefix_option_list, argv[0], add_prefix_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+
+		case 'P':
+			priority = (int16_t) strtol(optarg, NULL, 0);
+			break;
+
+		case 'l':
+			prefix_len_in_bits = (uint16_t) strtol(optarg, NULL, 0);
+			break;
+
+		case 's':
+			stable = TRUE;
+			break;
+
+		case 'f':
+			preferred = TRUE;
+			break;
+
+		case 'a':
+			slaac = TRUE;
+			break;
+
+		case 'd':
+			dhcp = TRUE;
+			break;
+
+		case 'c':
+			configure = TRUE;
+			break;
+
+		case 'r':
+			default_route = TRUE;
+			break;
+
+		case 'o':
+			on_mesh = TRUE;
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		prefix_str = argv[optind];
+		optind++;
+	} else {
+		fprintf((stderr), "%s: No prefix argument given\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (optind < argc) {
+		fprintf(stderr, "%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	require_action(prefix_str != NULL, bail, ret = ERRORCODE_BADARG);
+
+	// The prefix could either be specified like an IPv6 address, or
+	// specified as a bunch of hex numbers. We use the presence of a
+	// colon (':') to differentiate.
+
+	if (strstr(prefix_str ,":")) {
+		int bits = inet_pton(AF_INET6, prefix_str ,prefix_bytes);
+
+		if (bits < 0) {
+			fprintf(stderr, "Bad Prefix \"%s\", errno=%d (%s)\n", prefix_str, errno, strerror(errno));
+			goto bail;
+		} else if (!bits) {
+			fprintf(stderr, "Bad prefix \"%s\"\n", prefix_str);
+			goto bail;
+		}
+	} else {
+		int length = parse_string_into_data(prefix_bytes, 8, prefix_str);
+		if (length <= 0) {
+			fprintf(stderr, "Bad prefix \"%s\"\n", prefix_str);
+			goto bail;
+		}
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(stderr,
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+
+	if (!connection) {
+		dbus_error_free(&error);
+		dbus_error_init(&error);
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	}
+
+	require_action_string(connection != NULL, bail, ret = ERRORCODE_ALLOC, error.message);
+
+	ret = lookup_dbus_name_from_interface(dbus_interface_name, gInterfaceName);
+	require(ret == 0, bail);
+
+	snprintf(dbus_path, sizeof(dbus_path), "%s/%s", WPANTUND_DBUS_PATH, gInterfaceName);
+
+	message = dbus_message_new_method_call(
+		dbus_interface_name,
+		dbus_path,
+		WPANTUND_DBUS_APIv1_INTERFACE,
+		WPANTUND_IF_CMD_CONFIG_GATEWAY
+	);
+
+	require_action(message != NULL, bail, ret = ERRORCODE_ALLOC);
+
+	addr = prefix_bytes;
+
+	dbus_message_append_args(
+		message,
+		DBUS_TYPE_BOOLEAN, &default_route,
+		DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 16,
+		DBUS_TYPE_UINT32, &preferred_lifetime,
+		DBUS_TYPE_UINT32, &valid_lifetime,
+		DBUS_TYPE_BOOLEAN, &preferred,
+		DBUS_TYPE_BOOLEAN, &slaac,
+		DBUS_TYPE_BOOLEAN, &on_mesh,
+		DBUS_TYPE_INT16, &priority,
+		DBUS_TYPE_BOOLEAN, &dhcp,
+		DBUS_TYPE_BOOLEAN, &configure,
+		DBUS_TYPE_BOOLEAN, &stable,
+		DBUS_TYPE_UINT16, &prefix_len_in_bits,
+		DBUS_TYPE_INVALID
+	);
+
+	reply = dbus_connection_send_with_reply_and_block(connection, message, timeout, &error);
+
+	if (!reply) {
+		fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+		ret = ERRORCODE_TIMEOUT;
+		goto bail;
+	}
+
+	if (dbus_message_get_args(reply, &error, DBUS_TYPE_INT32, &ret, DBUS_TYPE_INVALID) == FALSE) {
+		fprintf(stderr, "%s: error in parsing response from wpantund: %s\n", argv[0], error.message);
+		ret = ERRORCODE_BADCOMMAND;
+		goto bail;
+	}
+
+	if (ret == 0) {
+		char address_string[INET6_ADDRSTRLEN] = "::";
+		inet_ntop(AF_INET6, (const void *)&prefix_bytes, address_string, sizeof(address_string));
+		fprintf(
+			stderr,
+			"Successfully added prefix \"%s\" len:%d stable:%c [on-mesh:%c def-route:%c config:%c dhcp:%c slaac:%c pref:%c prio:%s]\n",
+			address_string,
+			prefix_len_in_bits,
+			stable ? '1' : '0',
+			on_mesh ? '1' : '0',
+			default_route ? '1' : '0',
+			configure ? '1' : '0',
+			dhcp ? '1' : '0',
+			slaac ? '1' : '0',
+			preferred ? '1' : '0',
+			priority > 0 ? "high" : (priority < 0 ? "low" : "med")
+		);
+
+	} else {
+		fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
+	}
+
+bail:
+
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-add-prefix.h
+++ b/src/wpanctl/tool-cmd-add-prefix.h
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      This file declares function related to "add-prefix" command
+ *      in wpanctl.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_ADD_PREFIX_H
+#define WPANCTL_TOOL_CMD_ADD_PREFIX_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_add_prefix(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/tool-cmd-config-gateway.c
+++ b/src/wpanctl/tool-cmd-config-gateway.c
@@ -92,8 +92,8 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 
 		switch (c) {
 		case 'h':
-			print_arg_list_help(config_gateway_option_list, argv[0],
-					    config_gateway_cmd_syntax);
+			print_arg_list_help(config_gateway_option_list, argv[0], config_gateway_cmd_syntax);
+			printf("%s is deprecated, use `add-prefix` and `remove-prefix`\n", argv[0]);
 			ret = ERRORCODE_HELP;
 			goto bail;
 

--- a/src/wpanctl/tool-cmd-remove-prefix.c
+++ b/src/wpanctl/tool-cmd-remove-prefix.c
@@ -1,0 +1,238 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      This file implements "remove-prefix" command in wpanctl.
+ *
+ */
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-cmd-remove-prefix.h"
+#include "assert-macros.h"
+#include "args.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "string-utils.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+
+const char remove_prefix_cmd_syntax[] = "[args] <prefix>";
+
+static const arg_list_item_t remove_prefix_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "timeout", "ms", "Set timeout period"},
+	{'l', "length", "in bits", "Set the prefix length (default is 64)"},
+	{0}
+};
+
+int tool_cmd_remove_prefix(int argc, char* argv[])
+{
+	int ret = 0;
+	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	char dbus_path[DBUS_MAXIMUM_NAME_LENGTH + 1];
+	char dbus_interface_name[DBUS_MAXIMUM_NAME_LENGTH + 1];
+	const char* prefix_str = NULL;
+	uint16_t prefix_len_in_bits = 64;
+	int16_t priority = 0;
+	dbus_bool_t stable = FALSE;
+	dbus_bool_t preferred = FALSE;
+	dbus_bool_t slaac = FALSE;
+	dbus_bool_t dhcp = FALSE;
+	dbus_bool_t configure = FALSE;
+	dbus_bool_t default_route = FALSE;
+	dbus_bool_t on_mesh = FALSE;
+	uint8_t prefix_bytes[16] = {};
+	uint8_t *addr = prefix_bytes;
+	uint32_t preferred_lifetime = 0;
+	uint32_t valid_lifetime = 0;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h' },
+			{"timeout", required_argument, 0, 't'},
+			{"length", required_argument, 0, 'l'},
+			{0, 0, 0, 0}
+		};
+
+		int c;
+		int option_index = 0;
+
+		c = getopt_long(argc, argv, "ht:l:", long_options, &option_index);
+
+		if (c == -1) {
+			break;
+		}
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(remove_prefix_option_list, argv[0], remove_prefix_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			timeout = strtol(optarg, NULL, 0);
+			break;
+
+		case 'l':
+			prefix_len_in_bits = (uint16_t) strtol(optarg, NULL, 0);
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		prefix_str = argv[optind];
+		optind++;
+	} else {
+		fprintf((stderr), "%s: No prefix argument given\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (optind < argc) {
+		fprintf(stderr, "%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	require_action(prefix_str != NULL, bail, ret = ERRORCODE_BADARG);
+
+	// The prefix could either be specified like an IPv6 address, or
+	// specified as a bunch of hex numbers. We use the presence of a
+	// colon (':') to differentiate.
+
+	if (strstr(prefix_str ,":")) {
+		int bits = inet_pton(AF_INET6, prefix_str ,prefix_bytes);
+
+		if (bits < 0) {
+			fprintf(stderr, "Bad Prefix \"%s\", errno=%d (%s)\n", prefix_str, errno, strerror(errno));
+			goto bail;
+		} else if (!bits) {
+			fprintf(stderr, "Bad prefix \"%s\"\n", prefix_str);
+			goto bail;
+		}
+	} else {
+		int length = parse_string_into_data(prefix_bytes, 8, prefix_str);
+		if (length <= 0) {
+			fprintf(stderr, "Bad prefix \"%s\"\n", prefix_str);
+			goto bail;
+		}
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(stderr,
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n", argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+
+	if (!connection) {
+		dbus_error_free(&error);
+		dbus_error_init(&error);
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+	}
+
+	require_action_string(connection != NULL, bail, ret = ERRORCODE_ALLOC, error.message);
+
+	ret = lookup_dbus_name_from_interface(dbus_interface_name, gInterfaceName);
+	require(ret == 0, bail);
+
+	snprintf(dbus_path, sizeof(dbus_path), "%s/%s", WPANTUND_DBUS_PATH, gInterfaceName);
+
+	message = dbus_message_new_method_call(
+		dbus_interface_name,
+		dbus_path,
+		WPANTUND_DBUS_APIv1_INTERFACE,
+		WPANTUND_IF_CMD_CONFIG_GATEWAY
+	);
+
+	require_action(message != NULL, bail, ret = ERRORCODE_ALLOC);
+
+	addr = prefix_bytes;
+
+	// Note that when removing a prefix the flags lifetime is
+	// set to zero. The flag bits do not matter but should be
+	// included in the DBus arguments since prefix len is
+	// required to identify the prefix being removed.
+
+	dbus_message_append_args(
+		message,
+		DBUS_TYPE_BOOLEAN, &default_route,
+		DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 16,
+		DBUS_TYPE_UINT32, &preferred_lifetime,
+		DBUS_TYPE_UINT32, &valid_lifetime,
+		DBUS_TYPE_BOOLEAN, &preferred,
+		DBUS_TYPE_BOOLEAN, &slaac,
+		DBUS_TYPE_BOOLEAN, &on_mesh,
+		DBUS_TYPE_INT16, &priority,
+		DBUS_TYPE_BOOLEAN, &dhcp,
+		DBUS_TYPE_BOOLEAN, &configure,
+		DBUS_TYPE_BOOLEAN, &stable,
+		DBUS_TYPE_UINT16, &prefix_len_in_bits,
+		DBUS_TYPE_INVALID
+	);
+
+	reply = dbus_connection_send_with_reply_and_block(connection, message, timeout, &error);
+
+	if (!reply) {
+		fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+		ret = ERRORCODE_TIMEOUT;
+		goto bail;
+	}
+
+	if (dbus_message_get_args(reply, &error, DBUS_TYPE_INT32, &ret, DBUS_TYPE_INVALID) == FALSE) {
+		fprintf(stderr, "%s: error in parsing response from wpantund: %s\n", argv[0], error.message);
+		ret = ERRORCODE_BADCOMMAND;
+		goto bail;
+	}
+
+	if (ret == 0) {
+		char address_string[INET6_ADDRSTRLEN] = "::";
+		inet_ntop(AF_INET6, (const void *)&prefix_bytes, address_string, sizeof(address_string));
+		fprintf(stderr,	"Successfully removed prefix \"%s\" len:%d\n", address_string, prefix_len_in_bits);
+	} else {
+		fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
+	}
+
+bail:
+
+	if (connection) {
+		dbus_connection_unref(connection);
+	}
+
+	if (message) {
+		dbus_message_unref(message);
+	}
+
+	if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-remove-prefix.h
+++ b/src/wpanctl/tool-cmd-remove-prefix.h
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *    Description:
+ *      This file declares function related to "remove-prefix" command
+ *      in wpanctl.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_REMOVE_PREFIX_H
+#define WPANCTL_TOOL_CMD_REMOVE_PREFIX_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_remove_prefix(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/wpanctl-cmds.h
+++ b/src/wpanctl/wpanctl-cmds.h
@@ -40,6 +40,8 @@
 #include "tool-cmd-cd.h"
 #include "tool-cmd-poll.h"
 #include "tool-cmd-config-gateway.h"
+#include "tool-cmd-add-prefix.h"
+#include "tool-cmd-remove-prefix.h"
 #include "tool-cmd-add-route.h"
 #include "tool-cmd-remove-route.h"
 #include "tool-cmd-peek.h"
@@ -93,8 +95,18 @@
 	}, \
 	{ \
 		"config-gateway", \
-		"Configure gateway", \
+		"Configure gateway (deprecated, use `add-prefix` and `remove-prefix`)", \
 		&tool_cmd_config_gateway \
+	}, \
+	{ \
+		"add-prefix", \
+		"Add prefix", \
+		&tool_cmd_add_prefix \
+	}, \
+	{ \
+		"remove-prefix", \
+		"Remove prefix", \
+		&tool_cmd_remove_prefix \
 	}, \
 	{ \
 		"add-route", \

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -34,6 +34,7 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/any.hpp>
 #include <list>
+#include <set>
 #include <arpa/inet.h>
 #include "time-utils.h"
 
@@ -78,6 +79,17 @@ public:
 		PREFIX_MEDIUM_PREFERENCE = 0,
 		PREFIX_HIGH_PREFERENCE = 1,
 	};
+
+	enum PrefixFlag {
+		PREFIX_FLAG_PREFERRED,
+		PREFIX_FLAG_SLAAC,
+		PREFIX_FLAG_DHCP,
+		PREFIX_FLAG_CONFIGURE,
+		PREFIX_FLAG_DEFAULT_ROUTE,
+		PREFIX_FLAG_ON_MESH,
+	};
+
+	typedef std::set<PrefixFlag> OnMeshPrefixFlags;
 
 public:
 	// ========================================================================
@@ -147,17 +159,17 @@ public:
 	) = 0;
 
 	virtual void add_on_mesh_prefix(
-		const struct in6_addr *prefix,
-		bool defaultRoute,
-		bool preferred,
-		bool slaac,
-		bool onMesh,
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
+		OnMeshPrefixFlags flags,
 		OnMeshPrefixPriority priority,
+		bool stable,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 	virtual void remove_on_mesh_prefix(
-		const struct in6_addr *prefix,
+		const struct in6_addr& prefix,
+		uint8_t prefix_len,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 

--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -192,6 +192,54 @@ NCPInstanceBase::on_mesh_prefix_flags_to_string(uint8_t flags, bool detailed)
 	return c_string;
 }
 
+uint8_t
+NCPInstanceBase::OnMeshPrefixEntry::encode_flag_set(
+	NCPControlInterface::OnMeshPrefixFlags prefix_flag_set,
+	NCPControlInterface::OnMeshPrefixPriority priority
+) {
+	uint8_t flags = 0;
+
+	switch (priority) {
+	case NCPControlInterface::PREFIX_HIGH_PREFERENCE:
+		flags |= kPreferenceHigh;
+		break;
+
+	case NCPControlInterface::PREFIX_MEDIUM_PREFERENCE:
+		flags |= kPreferenceMedium;
+		break;
+
+	case NCPControlInterface::PREFIX_LOW_PREFRENCE:
+		flags |= kPreferenceLow;
+		break;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_ON_MESH)) {
+		flags |= kFlagOnMesh;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_DEFAULT_ROUTE)) {
+		flags |= kFlagDefaultRoute;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_CONFIGURE)) {
+		flags |= kFlagConfigure;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_DHCP)) {
+		flags |= kFlagDHCP;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_SLAAC)) {
+		flags |= kFlagSLAAC;
+	}
+
+	if (prefix_flag_set.count(NCPControlInterface::PREFIX_FLAG_PREFERRED)) {
+		flags |= kFlagPreferred;
+	}
+
+	return flags;
+}
+
 std::string
 NCPInstanceBase::OnMeshPrefixEntry::get_description(const struct in6_addr &address, bool align) const
 {

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -388,6 +388,11 @@ protected:
 
 		std::string get_description(const struct in6_addr &preifx, bool align = false) const;
 
+		static uint8_t encode_flag_set(
+			NCPControlInterface::OnMeshPrefixFlags prefix_flags,
+			NCPControlInterface::OnMeshPrefixPriority priority
+		);
+
 	private:
 		uint8_t mFlags;
 		uint8_t mPrefixLen;


### PR DESCRIPTION
This commit contains the following changes:
- It updates the `NCPControlInterface::add_on_mesh_prefix()` to
  accept a `std::set<PrefixFlag>` along with `stable` status and
  prefix length.
- It updates the control interface implementation for Spinel and Dummy
  plugins to adopt the new on-mesh prefix API.
- It updates DBus API implementations (v0 and v1) to use the new
  control interface API
- It extends the DBus `CONFIG_GATEWAY` method to allow for new
  arguments (flag info, stable status, prefix_len) to be provided
  while keeping it backward compatible with earlier pattern.
- It adds two new `wpanctl` commands `add-prefix`/`remove-prefix`
  which allow user to fully specify all prefix flags and options.