### PR TITLE
Add support to specify "stable" flag for off-mesh routes

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v0.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v0.cpp
@@ -728,6 +728,7 @@ DBusIPCAPI_v0::interface_add_route_handler(
 		IPV6_PREFIX_BYTES_TO_BITS(prefix_len),
 		domain_id,
 		priority,
+		true, // stable
 		boost::bind(&DBusIPCAPI_v0::CallbackWithStatus_Helper, this, _1, message)
 	);
 

--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -1337,6 +1337,7 @@ DBusIPCAPI_v1::interface_route_add_handler(
 	uint16_t domain_id(0);
 	int16_t priority_raw(0);
 	NCPControlInterface::ExternalRoutePriority priority(NCPControlInterface::ROUTE_MEDIUM_PREFERENCE);
+	dbus_bool_t stable(TRUE);
 	uint8_t prefix_len_in_bits(0);
 	struct in6_addr address = {};
 	bool did_succeed(false);
@@ -1347,8 +1348,21 @@ DBusIPCAPI_v1::interface_route_add_handler(
 		DBUS_TYPE_UINT16, &domain_id,
 		DBUS_TYPE_INT16, &priority_raw,
 		DBUS_TYPE_BYTE, &prefix_len_in_bits,
+		DBUS_TYPE_BOOLEAN, &stable,
 		DBUS_TYPE_INVALID
 	);
+
+	if (!did_succeed) {
+		// Check the syntax without the `stable` argument
+		did_succeed = dbus_message_get_args(
+			message, NULL,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &route_prefix, &prefix_len_in_bytes,
+			DBUS_TYPE_UINT16, &domain_id,
+			DBUS_TYPE_INT16, &priority_raw,
+			DBUS_TYPE_BYTE, &prefix_len_in_bits,
+			DBUS_TYPE_INVALID
+		);
+	}
 
 	if (!did_succeed) {
 		// Likely using the old syntax that doesn't include the prefix length in bits
@@ -1381,6 +1395,7 @@ DBusIPCAPI_v1::interface_route_add_handler(
 		prefix_len_in_bits,
 		domain_id,
 		priority,
+		stable,
 		boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper, this, _1, message)
 	);
 

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -157,6 +157,7 @@ DummyNCPControlInterface::add_external_route(
 	int prefix_len_in_bits,
 	int domain_id,
 	ExternalRoutePriority priority,
+	bool stable,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -150,6 +150,7 @@ public:
 		int prefix_len_in_bits,
 		int domain_id,
 		ExternalRoutePriority priority,
+		bool stable,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -231,6 +231,7 @@ SpinelNCPControlInterface::add_external_route(
 	int prefix_len,
 	int domain_id,
 	ExternalRoutePriority priority,
+	bool stable,
 	CallbackWithStatus cb
 ) {
 	require_action(route != NULL, bail, cb(kWPANTUNDStatus_InvalidArgument));
@@ -243,7 +244,7 @@ SpinelNCPControlInterface::add_external_route(
 		*route,
 		prefix_len,
 		priority,
-		true,     // stable
+		stable,
 		0,        // rlco16 (ignored for user added routes)
 		true,     // next_hop_is_host
 		cb

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -152,6 +152,7 @@ public:
 		int prefix_len,
 		int domain_id,
 		ExternalRoutePriority priority,
+		bool stable,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -178,13 +178,7 @@ public:
 		int prefix_len_in_bits,
 		int domain_id,
 		ExternalRoutePriority priority,
-		CallbackWithStatus cb = NilReturn()
-	) = 0;
-
-	virtual void joiner_add(
-		const char *psk,
-		uint32_t joiner_timeout,
-		const uint8_t *addr,
+		bool stable,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
@@ -192,6 +186,13 @@ public:
 		const struct in6_addr *prefix,
 		int prefix_len_in_bits,
 		int domain_id,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
+	virtual void joiner_add(
+		const char *psk,
+		uint32_t joiner_timeout,
+		const uint8_t *addr,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 


### PR DESCRIPTION
This commit contains the following changes:
- It updates the `NCPControlInterface::add_external_route` API to
  include the stable flag as an input argument
- It updates the implementation of the control interface API on
  Spinel and Dummy plugins to adopt the new model.
- It updates the DBUs API (v1) `ROUTE_ADD` to allow the stable
  flag as an argument, while staying backward compatible with
  previous format.
- It updates wpanctl `add-route` to allow adding a route prefixes
  with "stable" flag.
- It also updates `add-route` and `remove-route` wpanctl commands
  to specify the route prefix length in bits (instead of bytes).