### PR TITLE
Add autogenerated version file to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ doxygen.cfg
 src/wpantund/wpantund
 src/wpanctl/wpanctl
 .dirstamp
+src/version.c
 src/wpanctl/version.c
 wpantund.xcodeproj/project.xcworkspace/xcshareddata/wpan-tunnel-driver.xccheckout
 wpantund.xcodeproj/project.xcworkspace/xcshareddata/wpantund.xccheckout

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ src/wpanctl/wpanctl
 .dirstamp
 src/version.c
 src/wpanctl/version.c
+src/wpantund/version.c
 wpantund.xcodeproj/project.xcworkspace/xcshareddata/wpan-tunnel-driver.xccheckout
 wpantund.xcodeproj/project.xcworkspace/xcshareddata/wpantund.xccheckout
 .cproject


### PR DESCRIPTION
src/version.c isn't in gitignore, which can cause issues for automatic
syncs. The automatic sync fail will due to uncommitted changes even though
this file is generated by the build system and should be ignored.