### PR TITLE
Enable setting of "NCP:ChannelMask"

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -437,7 +437,7 @@ SpinelNCPControlInterface::netscan_start(
 	const ValueMap& options,
 	CallbackWithStatus cb
 ) {
-	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
+	ChannelMask channel_mask(mNCPInstance->mSupportedChannelMask);
 	SpinelNCPTaskScan::ScanType scan_type;
 	int scan_period = 0; 			   // per channel in ms
 	bool joiner_flag = false;          // Scan for joiner only devices (used in discover scan).
@@ -503,7 +503,7 @@ SpinelNCPControlInterface::energyscan_start(
 	const ValueMap& options,
 	CallbackWithStatus cb
 ) {
-	ChannelMask channel_mask(mNCPInstance->get_default_channel_mask());
+	ChannelMask channel_mask(mNCPInstance->mSupportedChannelMask);
 
 	if (options.count(kWPANTUNDProperty_NCPChannelMask)) {
 		channel_mask = any_to_int(options.at(kWPANTUNDProperty_NCPChannelMask));

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -172,8 +172,6 @@ protected:
 	static RoutePreference convert_flags_to_route_preference(uint8_t flags);
 	static uint8_t convert_route_preference_to_flags(RoutePreference priority);
 
-	uint32_t get_default_channel_mask(void);
-
 private:
 	void update_node_type(NodeType node_type);
 	void update_link_local_address(struct in6_addr *addr);
@@ -285,6 +283,7 @@ private:
 	Data mNetworkPSKc;
 	Data mNetworkKey;
 	uint32_t mNetworkKeyIndex;
+	uint32_t mSupportedChannelMask;
 	bool mXPANIDWasExplicitlySet;
 	uint8_t mChannelManagerNewChannel;
 

--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -176,10 +176,10 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 			channel = any_to_int(mOptions[kWPANTUNDProperty_NCPChannel]);
 
 			// Make sure the channel is the supported channel set.
-			if (mInstance->mSupprotedChannels.find(channel) == mInstance->mSupprotedChannels.end()) {
+			if ((mInstance->mSupportedChannelMask & (1U << channel)) == 0) {
 				syslog(LOG_ERR, "Channel %d is not supported by NCP. Supported channels mask is %08x",
 					channel,
-					mInstance->get_default_channel_mask()
+					mInstance->mSupportedChannelMask
 				);
 				ret = kWPANTUNDStatus_InvalidArgument;
 				goto on_error;
@@ -187,21 +187,23 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 
 		} else {
 			uint32_t mask;
-			uint32_t default_mask = mInstance->get_default_channel_mask();
 
 			if (mOptions.count(kWPANTUNDProperty_NCPChannelMask)) {
 				mask = any_to_int(mOptions[kWPANTUNDProperty_NCPChannelMask]);
 			} else {
-				mask = default_mask;
+				mask = mInstance->mSupportedChannelMask;
 			}
 
-			if ((mask & default_mask) == 0) {
-				syslog(LOG_ERR,	"Invalid channel mask 0x%08x. Supported channels mask is 0x%08x", mask, default_mask);
+			if ((mask & mInstance->mSupportedChannelMask) == 0) {
+				syslog(LOG_ERR, "Invalid channel mask 0x%08x. Supported channels mask is 0x%08x",
+					mask,
+					mInstance->mSupportedChannelMask
+				);
 				ret = kWPANTUNDStatus_InvalidArgument;
 				goto on_error;
 			}
 
-			mask &= default_mask;
+			mask &= mInstance->mSupportedChannelMask;
 
 			// Randomly pick a channel from the given channel mask for now.
 			do {

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -546,8 +546,6 @@ protected:
 
 	WPAN::NetworkInstance mCurrentNetworkInstance;
 
-	std::set<unsigned int> mSupprotedChannels;
-
 	NodeType mNodeType;
 
 	int mFailureCount;


### PR DESCRIPTION
This commit adds support in wpantund to set "NCP:ChannelMask".
It also updates how the supported channel mask is tracked by the
`SpinelNCPInstance` and used by `form` command tasks.

------

Related PR in OT: https://github.com/openthread/openthread/pull/2838