### PR TITLE
Update spinel definition from OpenThread

### DIFF
--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -101,51 +101,55 @@ static int spinel_errno_workaround_;
 
 #ifndef assert_printf
 #if SPINEL_PLATFORM_DOESNT_IMPLEMENT_FPRINTF
-#define assert_printf(fmt, ...) \
-    printf(__FILE__ ":%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define assert_printf(fmt, ...) printf(__FILE__ ":%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else // if SPINEL_PLATFORM_DOESNT_IMPLEMENT_FPRINTF
-#define assert_printf(fmt, ...) \
-    fprintf(stderr, __FILE__ ":%d: " fmt "\n", __LINE__, __VA_ARGS__)
+#define assert_printf(fmt, ...) fprintf(stderr, __FILE__ ":%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #endif // else SPINEL_PLATFORM_DOESNT_IMPLEMENT_FPRINTF
 #endif
 
-
 #ifndef require_action
 #if SPINEL_PLATFORM_SHOULD_LOG_ASSERTS
-#define require_action(c, l, a) \
-    do { if (!(c)) { \
-        assert_printf("Requirement Failed (%s)", # c); \
-        a; \
-        goto l; \
-    } } while (0)
+#define require_action(c, l, a)                           \
+    do                                                    \
+    {                                                     \
+        if (!(c))                                         \
+        {                                                 \
+            assert_printf("Requirement Failed (%s)", #c); \
+            a;                                            \
+            goto l;                                       \
+        }                                                 \
+    } while (0)
 #else // if DEBUG
 #define require_action(c, l, a) \
-    do { if (!(c)) { \
-        a; \
-        goto l; \
-    } } while (0)
+    do                          \
+    {                           \
+        if (!(c))               \
+        {                       \
+            a;                  \
+            goto l;             \
+        }                       \
+    } while (0)
 #endif // else DEBUG
 #endif // ifndef require_action
 
 #ifndef require
-#define require(c, l)   require_action(c, l, {})
+#define require(c, l) require_action(c, l, {})
 #endif
 
-
-typedef struct {
+typedef struct
+{
     va_list obj;
 } va_list_obj;
 
-#define SPINEL_MAX_PACK_LENGTH         32767
+#define SPINEL_MAX_PACK_LENGTH 32767
 
 // ----------------------------------------------------------------------------
 // MARK: -
 
-spinel_ssize_t
-spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int *value_ptr)
+spinel_ssize_t spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int *value_ptr)
 {
-    spinel_ssize_t ret = 0;
-    unsigned int value = 0;
+    spinel_ssize_t ret   = 0;
+    unsigned int   value = 0;
 
     int i = 0;
 
@@ -162,8 +166,7 @@ spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int 
         ret += sizeof(uint8_t);
         bytes += sizeof(uint8_t);
         len -= sizeof(uint8_t);
-    }
-    while ((bytes[-1] & 0x80) == 0x80);
+    } while ((bytes[-1] & 0x80) == 0x80);
 
     if ((ret > 0) && (value_ptr != NULL))
     {
@@ -173,8 +176,7 @@ spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len, unsigned int 
     return ret;
 }
 
-spinel_ssize_t
-spinel_packed_uint_size(unsigned int value)
+spinel_ssize_t spinel_packed_uint_size(unsigned int value)
 {
     spinel_ssize_t ret;
 
@@ -202,8 +204,7 @@ spinel_packed_uint_size(unsigned int value)
     return ret;
 }
 
-spinel_ssize_t
-spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value)
+spinel_ssize_t spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value)
 {
     const spinel_ssize_t encoded_size = spinel_packed_uint_size(value);
 
@@ -214,7 +215,7 @@ spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value)
         for (i = 0; i != encoded_size - 1; ++i)
         {
             *bytes++ = (value & 0x7F) | 0x80;
-            value = (value >> 7);
+            value    = (value >> 7);
         }
 
         *bytes++ = (value & 0x7F);
@@ -223,8 +224,7 @@ spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value)
     return encoded_size;
 }
 
-const char *
-spinel_next_packed_datatype(const char *pack_format)
+const char *spinel_next_packed_datatype(const char *pack_format)
 {
     int depth = 0;
 
@@ -246,14 +246,16 @@ spinel_next_packed_datatype(const char *pack_format)
 
             break;
         }
-    }
-    while ((depth > 0) && *pack_format != 0);
+    } while ((depth > 0) && *pack_format != 0);
 
     return pack_format;
 }
 
-static spinel_ssize_t
-spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, va_list_obj *args)
+static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
+                                               const uint8_t *data_ptr,
+                                               spinel_size_t  data_len,
+                                               const char *   pack_format,
+                                               va_list_obj *  args)
 {
     spinel_ssize_t ret = 0;
 
@@ -440,7 +442,7 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
 
         case SPINEL_DATATYPE_UINT_PACKED_C:
         {
-            unsigned int *arg_ptr = va_arg(args->obj, unsigned int *);
+            unsigned int * arg_ptr = va_arg(args->obj, unsigned int *);
             spinel_ssize_t pui_len = spinel_packed_uint_decode(data_ptr, data_len, arg_ptr);
 
             // Range check
@@ -473,7 +475,7 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
 
             if (in_place)
             {
-                char *arg = va_arg(args->obj, char *);
+                char * arg     = va_arg(args->obj, char *);
                 size_t len_arg = va_arg(args->obj, size_t);
                 if (arg)
                 {
@@ -499,16 +501,15 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
         case SPINEL_DATATYPE_DATA_C:
         case SPINEL_DATATYPE_DATA_WLEN_C:
         {
-            spinel_ssize_t pui_len = 0;
-            uint16_t block_len = 0;
-            const uint8_t *block_ptr = data_ptr;
-            void *arg_ptr = va_arg(args->obj, void *);
-            unsigned int *block_len_ptr = va_arg(args->obj, unsigned int *);
-            char nextformat = *spinel_next_packed_datatype(pack_format);
+            spinel_ssize_t pui_len       = 0;
+            uint16_t       block_len     = 0;
+            const uint8_t *block_ptr     = data_ptr;
+            void *         arg_ptr       = va_arg(args->obj, void *);
+            unsigned int * block_len_ptr = va_arg(args->obj, unsigned int *);
+            char           nextformat    = *spinel_next_packed_datatype(pack_format);
 
-            if ( (pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C)
-              || ( (nextformat != 0) && (nextformat != ')') )
-            ) {
+            if ((pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C) || ((nextformat != 0) && (nextformat != ')')))
+            {
                 pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
                 block_ptr += pui_len;
 
@@ -518,20 +519,19 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
             else
             {
                 block_len = (uint16_t)data_len;
-                pui_len = 0;
+                pui_len   = 0;
             }
 
             require_action((spinel_ssize_t)data_len >= (block_len + pui_len), bail, (ret = -1, errno = EOVERFLOW));
 
             if (in_place)
             {
-                require_action(NULL != block_len_ptr && *block_len_ptr >= block_len,
-                        bail, (ret = -1, errno = EINVAL));
+                require_action(NULL != block_len_ptr && *block_len_ptr >= block_len, bail, (ret = -1, errno = EINVAL));
                 memcpy(arg_ptr, block_ptr, block_len);
             }
             else
             {
-                const uint8_t **block_ptr_ptr =  (const uint8_t **)arg_ptr;
+                const uint8_t **block_ptr_ptr = (const uint8_t **)arg_ptr;
                 if (NULL != block_ptr_ptr)
                 {
                     *block_ptr_ptr = block_ptr;
@@ -550,19 +550,17 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
             break;
         }
 
-
         case 'T':
         case SPINEL_DATATYPE_STRUCT_C:
         {
-            spinel_ssize_t pui_len = 0;
-            uint16_t block_len = 0;
+            spinel_ssize_t pui_len    = 0;
+            uint16_t       block_len  = 0;
             spinel_ssize_t actual_len = 0;
-            const uint8_t *block_ptr = data_ptr;
-            char nextformat = *spinel_next_packed_datatype(pack_format);
+            const uint8_t *block_ptr  = data_ptr;
+            char           nextformat = *spinel_next_packed_datatype(pack_format);
 
-            if ( (pack_format[0] == SPINEL_DATATYPE_STRUCT_C)
-              || ( (nextformat != 0) && (nextformat != ')') )
-            ) {
+            if ((pack_format[0] == SPINEL_DATATYPE_STRUCT_C) || ((nextformat != 0) && (nextformat != ')')))
+            {
                 pui_len = spinel_datatype_unpack(data_ptr, data_len, SPINEL_DATATYPE_UINT16_S, &block_len);
                 block_ptr += pui_len;
 
@@ -572,7 +570,7 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
             else
             {
                 block_len = (uint16_t)data_len;
-                pui_len = 0;
+                pui_len   = 0;
             }
 
             require_action((spinel_ssize_t)data_len >= (block_len + pui_len), bail, (ret = -1, errno = EOVERFLOW));
@@ -603,7 +601,7 @@ spinel_datatype_vunpack_(bool in_place, const uint8_t *data_ptr, spinel_size_t d
         case SPINEL_DATATYPE_ARRAY_C:
         default:
             // Unsupported Type!
-            ret = -1;
+            ret   = -1;
             errno = EINVAL;
             goto bail;
         }
@@ -615,11 +613,13 @@ bail:
     return ret;
 }
 
-spinel_ssize_t
-spinel_datatype_unpack_in_place(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, ...)
+spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_ptr,
+                                               spinel_size_t  data_len,
+                                               const char *   pack_format,
+                                               ...)
 {
     spinel_ssize_t ret;
-    va_list_obj args;
+    va_list_obj    args;
     va_start(args.obj, pack_format);
 
     ret = spinel_datatype_vunpack_(true, data_ptr, data_len, pack_format, &args);
@@ -628,11 +628,10 @@ spinel_datatype_unpack_in_place(const uint8_t *data_ptr, spinel_size_t data_len,
     return ret;
 }
 
-spinel_ssize_t
-spinel_datatype_unpack(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, ...)
+spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, ...)
 {
     spinel_ssize_t ret;
-    va_list_obj args;
+    va_list_obj    args;
     va_start(args.obj, pack_format);
 
     ret = spinel_datatype_vunpack_(false, data_ptr, data_len, pack_format, &args);
@@ -641,11 +640,13 @@ spinel_datatype_unpack(const uint8_t *data_ptr, spinel_size_t data_len, const ch
     return ret;
 }
 
-spinel_ssize_t
-spinel_datatype_vunpack_in_place(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, va_list args)
+spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_ptr,
+                                                spinel_size_t  data_len,
+                                                const char *   pack_format,
+                                                va_list        args)
 {
     spinel_ssize_t ret;
-    va_list_obj args_obj;
+    va_list_obj    args_obj;
     va_copy(args_obj.obj, args);
 
     ret = spinel_datatype_vunpack_(true, data_ptr, data_len, pack_format, &args_obj);
@@ -654,11 +655,13 @@ spinel_datatype_vunpack_in_place(const uint8_t *data_ptr, spinel_size_t data_len
     return ret;
 }
 
-spinel_ssize_t
-spinel_datatype_vunpack(const uint8_t *data_ptr, spinel_size_t data_len, const char *pack_format, va_list args)
+spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_ptr,
+                                       spinel_size_t  data_len,
+                                       const char *   pack_format,
+                                       va_list        args)
 {
     spinel_ssize_t ret;
-    va_list_obj args_obj;
+    va_list_obj    args_obj;
     va_copy(args_obj.obj, args);
 
     ret = spinel_datatype_vunpack_(false, data_ptr, data_len, pack_format, &args_obj);
@@ -667,8 +670,10 @@ spinel_datatype_vunpack(const uint8_t *data_ptr, spinel_size_t data_len, const c
     return ret;
 }
 
-static spinel_ssize_t
-spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char *pack_format, va_list_obj *args)
+static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_ptr,
+                                             spinel_size_t data_len_max,
+                                             const char *  pack_format,
+                                             va_list_obj * args)
 {
     spinel_ssize_t ret = 0;
 
@@ -855,11 +860,14 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
 
         case SPINEL_DATATYPE_UINT_PACKED_C:
         {
-            uint32_t arg = va_arg(args->obj, uint32_t);
+            uint32_t       arg = va_arg(args->obj, uint32_t);
             spinel_ssize_t encoded_size;
 
             // Range Check
-            require_action(arg < SPINEL_MAX_UINT_PACKED, bail, {ret = -1; errno = EINVAL;});
+            require_action(arg < SPINEL_MAX_UINT_PACKED, bail, {
+                ret   = -1;
+                errno = EINVAL;
+            });
 
             encoded_size = spinel_packed_uint_encode(data_ptr, data_len_max, arg);
             ret += encoded_size;
@@ -879,8 +887,8 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
 
         case SPINEL_DATATYPE_UTF8_C:
         {
-            const char *string_arg = va_arg(args->obj, const char *);
-            size_t string_arg_len = 0;
+            const char *string_arg     = va_arg(args->obj, const char *);
+            size_t      string_arg_len = 0;
 
             if (string_arg)
             {
@@ -888,7 +896,7 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
             }
             else
             {
-                string_arg = "";
+                string_arg     = "";
                 string_arg_len = 1;
             }
 
@@ -912,16 +920,18 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
         case SPINEL_DATATYPE_DATA_WLEN_C:
         case SPINEL_DATATYPE_DATA_C:
         {
-            const uint8_t *arg = va_arg(args->obj, const uint8_t *);
-            uint32_t data_size_arg = va_arg(args->obj, uint32_t);
-            spinel_ssize_t size_len = 0;
-            char nextformat = *spinel_next_packed_datatype(pack_format);
+            const uint8_t *arg           = va_arg(args->obj, const uint8_t *);
+            uint32_t       data_size_arg = va_arg(args->obj, uint32_t);
+            spinel_ssize_t size_len      = 0;
+            char           nextformat    = *spinel_next_packed_datatype(pack_format);
 
-            if ( (pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C)
-              || ( (nextformat != 0) && (nextformat != ')') )
-            ) {
+            if ((pack_format[0] == SPINEL_DATATYPE_DATA_WLEN_C) || ((nextformat != 0) && (nextformat != ')')))
+            {
                 size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, data_size_arg);
-                require_action(size_len > 0, bail, {ret = -1; errno = EINVAL;});
+                require_action(size_len > 0, bail, {
+                    ret   = -1;
+                    errno = EINVAL;
+                });
             }
 
             ret += (spinel_size_t)size_len + data_size_arg;
@@ -948,10 +958,13 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
         case SPINEL_DATATYPE_STRUCT_C:
         {
             spinel_ssize_t struct_len = 0;
-            spinel_ssize_t size_len = 0;
-            char nextformat = *spinel_next_packed_datatype(pack_format);
+            spinel_ssize_t size_len   = 0;
+            char           nextformat = *spinel_next_packed_datatype(pack_format);
 
-            require_action(pack_format[1] == '(', bail, {ret = -1; errno = EINVAL;});
+            require_action(pack_format[1] == '(', bail, {
+                ret   = -1;
+                errno = EINVAL;
+            });
 
             // First we figure out the size of the struct
             {
@@ -961,11 +974,13 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
                 va_end(subargs.obj);
             }
 
-            if ( (pack_format[0] == SPINEL_DATATYPE_STRUCT_C)
-              || ( (nextformat != 0) && (nextformat != ')') )
-            ) {
+            if ((pack_format[0] == SPINEL_DATATYPE_STRUCT_C) || ((nextformat != 0) && (nextformat != ')')))
+            {
                 size_len = spinel_datatype_pack(data_ptr, data_len_max, SPINEL_DATATYPE_UINT16_S, struct_len);
-                require_action(size_len > 0, bail, {ret = -1; errno = EINVAL;});
+                require_action(size_len > 0, bail, {
+                    ret   = -1;
+                    errno = EINVAL;
+                });
             }
 
             ret += size_len + struct_len;
@@ -994,10 +1009,9 @@ spinel_datatype_vpack_(uint8_t *data_ptr, spinel_size_t data_len_max, const char
 
         default:
             // Unsupported Type!
-            ret = -1;
+            ret   = -1;
             errno = EINVAL;
             goto bail;
-
         }
     }
 
@@ -1005,10 +1019,9 @@ bail:
     return ret;
 }
 
-spinel_ssize_t
-spinel_datatype_pack(uint8_t *data_ptr, spinel_size_t data_len_max, const char *pack_format, ...)
+spinel_ssize_t spinel_datatype_pack(uint8_t *data_ptr, spinel_size_t data_len_max, const char *pack_format, ...)
 {
-    int ret;
+    int         ret;
     va_list_obj args;
     va_start(args.obj, pack_format);
 
@@ -1018,11 +1031,12 @@ spinel_datatype_pack(uint8_t *data_ptr, spinel_size_t data_len_max, const char *
     return ret;
 }
 
-
-spinel_ssize_t
-spinel_datatype_vpack(uint8_t *data_ptr, spinel_size_t data_len_max, const char *pack_format, va_list args)
+spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_ptr,
+                                     spinel_size_t data_len_max,
+                                     const char *  pack_format,
+                                     va_list       args)
 {
-    int ret;
+    int         ret;
     va_list_obj args_obj;
     va_copy(args_obj.obj, args);
 
@@ -1032,14 +1046,12 @@ spinel_datatype_vpack(uint8_t *data_ptr, spinel_size_t data_len_max, const char 
     return ret;
 }
 
-
 // ----------------------------------------------------------------------------
 // MARK: -
 
 // **** LCOV_EXCL_START ****
 
-const char *
-spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
+const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 {
     const char *ret = "UNKNOWN";
 
@@ -2224,6 +2236,7 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_OPENTHREAD_LOG_METADATA:
         ret = "CAP_OPENTHREAD_LOG_METADATA";
+        break;
 
     case SPINEL_CAP_TIME_SYNC:
         ret = "CAP_TIME_SYNC";
@@ -2260,22 +2273,22 @@ const char *spinel_capability_to_cstr(unsigned int capability)
     return ret;
 }
 
-// **** LCOV_EXCL_STOP ****
+    // **** LCOV_EXCL_STOP ****
 
-/* -------------------------------------------------------------------------- */
+    /* -------------------------------------------------------------------------- */
 
 #if SPINEL_SELF_TEST
 
-int
-main(void)
+int main(void)
 {
-    int ret = -1;
-    const spinel_eui64_t static_eui64 = { {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 } };
-    const char static_string[] = "static_string";
-    uint8_t buffer[1024];
-    ssize_t len;
+    int                  ret             = -1;
+    const spinel_eui64_t static_eui64    = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}};
+    const char           static_string[] = "static_string";
+    uint8_t              buffer[1024];
+    ssize_t              len;
 
-    len = spinel_datatype_pack(buffer, sizeof(buffer), "CiiLUE", 0x88, 9, 0xA3, 0xDEADBEEF, static_string, &static_eui64);
+    len =
+        spinel_datatype_pack(buffer, sizeof(buffer), "CiiLUE", 0x88, 9, 0xA3, 0xDEADBEEF, static_string, &static_eui64);
 
     if (len != 30)
     {
@@ -2305,11 +2318,11 @@ main(void)
     len = 30;
 
     {
-        uint8_t c = 0;
-        unsigned int i1 = 0;
-        unsigned int i2 = 0;
-        uint32_t l = 0;
-        const char *str = NULL;
+        uint8_t               c     = 0;
+        unsigned int          i1    = 0;
+        unsigned int          i2    = 0;
+        uint32_t              l     = 0;
+        const char *          str   = NULL;
         const spinel_eui64_t *eui64 = NULL;
 
         len = spinel_datatype_unpack(buffer, (spinel_size_t)len, "CiiLUE", &c, &i1, &i2, &l, &str, &eui64);
@@ -2358,14 +2371,15 @@ main(void)
     }
 
     {
-        uint8_t c = 0;
-        unsigned int i1 = 0;
-        unsigned int i2 = 0;
-        uint32_t l = 0;
-        char str[sizeof(static_string)];
+        uint8_t        c  = 0;
+        unsigned int   i1 = 0;
+        unsigned int   i2 = 0;
+        uint32_t       l  = 0;
+        char           str[sizeof(static_string)];
         spinel_eui64_t eui64 = {{0}};
 
-        len = spinel_datatype_unpack_in_place(buffer, (spinel_size_t)len, "CiiLUE", &c, &i1, &i2, &l, &str, sizeof(str), &eui64);
+        len = spinel_datatype_unpack_in_place(buffer, (spinel_size_t)len, "CiiLUE", &c, &i1, &i2, &l, &str, sizeof(str),
+                                              &eui64);
 
         if (len != 30)
         {
@@ -2414,7 +2428,8 @@ main(void)
 
     memset(buffer, 0xAA, sizeof(buffer));
 
-    len = spinel_datatype_pack(buffer, sizeof(buffer), "Cit(iL)UE", 0x88, 9, 0xA3, 0xDEADBEEF, static_string, &static_eui64);
+    len = spinel_datatype_pack(buffer, sizeof(buffer), "Cit(iL)UE", 0x88, 9, 0xA3, 0xDEADBEEF, static_string,
+                               &static_eui64);
 
     if (len != 32)
     {
@@ -2422,14 +2437,12 @@ main(void)
         goto bail;
     }
 
-
-
     {
-        uint8_t c = 0;
-        unsigned int i1 = 0;
-        unsigned int i2 = 0;
-        uint32_t l = 0;
-        const char *str = NULL;
+        uint8_t         c     = 0;
+        unsigned int    i1    = 0;
+        unsigned int    i2    = 0;
+        uint32_t        l     = 0;
+        const char *    str   = NULL;
         spinel_eui64_t *eui64 = NULL;
 
         len = spinel_datatype_unpack(buffer, (spinel_size_t)len, "Cit(iL)UE", &c, &i1, &i2, &l, &str, &eui64);
@@ -2478,14 +2491,15 @@ main(void)
     }
 
     {
-        uint8_t c = 0;
-        unsigned int i1 = 0;
-        unsigned int i2 = 0;
-        uint32_t l = 0;
-        char str[sizeof(static_string)];
+        uint8_t        c  = 0;
+        unsigned int   i1 = 0;
+        unsigned int   i2 = 0;
+        uint32_t       l  = 0;
+        char           str[sizeof(static_string)];
         spinel_eui64_t eui64 = {{0}};
 
-        len = spinel_datatype_unpack_in_place(buffer, (spinel_size_t)len, "Cit(iL)UE", &c, &i1, &i2, &l, &str, sizeof(str), &eui64);
+        len = spinel_datatype_unpack_in_place(buffer, (spinel_size_t)len, "Cit(iL)UE", &c, &i1, &i2, &l, &str,
+                                              sizeof(str), &eui64);
 
         if (len != 32)
         {

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -45,42 +45,42 @@
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
-# if defined(__GNUC__)
-#  define SPINEL_API_EXTERN             extern __attribute__ ((visibility ("default")))
-#  define SPINEL_API_NONNULL_ALL        __attribute__((nonnull))
-#  define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-# endif // ifdef __GNUC__
+#if defined(__GNUC__)
+#define SPINEL_API_EXTERN extern __attribute__((visibility("default")))
+#define SPINEL_API_NONNULL_ALL __attribute__((nonnull))
+#define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#endif // ifdef __GNUC__
 
-# if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-#  if defined(__cplusplus)
-#   define __BEGIN_DECLS   extern "C" {
-#   define __END_DECLS     }
-#  else // if defined(__cplusplus)
-#   define __BEGIN_DECLS
-#   define __END_DECLS
-#  endif // else defined(__cplusplus)
-# endif // if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
+#if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
+#if defined(__cplusplus)
+#define __BEGIN_DECLS extern "C" {
+#define __END_DECLS }
+#else // if defined(__cplusplus)
+#define __BEGIN_DECLS
+#define __END_DECLS
+#endif // else defined(__cplusplus)
+#endif // if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
 
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef SPINEL_API_EXTERN
-# define SPINEL_API_EXTERN              extern
+#define SPINEL_API_EXTERN extern
 #endif
 
 #ifndef SPINEL_API_NONNULL_ALL
-# define SPINEL_API_NONNULL_ALL
+#define SPINEL_API_NONNULL_ALL
 #endif
 
 #ifndef SPINEL_API_WARN_UNUSED_RESULT
-# define SPINEL_API_WARN_UNUSED_RESULT
+#define SPINEL_API_WARN_UNUSED_RESULT
 #endif
 
 // ----------------------------------------------------------------------------
 
-#define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR    4
-#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR    3
+#define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR 4
+#define SPINEL_PROTOCOL_VERSION_THREAD_MINOR 3
 
-#define SPINEL_FRAME_MAX_SIZE           1300
+#define SPINEL_FRAME_MAX_SIZE 1300
 
 /**
  * @def SPINEL_ENCRYPTER_EXTRA_DATA_SIZE
@@ -89,7 +89,7 @@
  *  needed by Spinel Encrypter.
  *
  */
-#define SPINEL_ENCRYPTER_EXTRA_DATA_SIZE  0
+#define SPINEL_ENCRYPTER_EXTRA_DATA_SIZE 0
 
 /**
  * @def SPINEL_FRAME_BUFFER_SIZE
@@ -98,44 +98,41 @@
  *  needed by Spinel Encrypter.
  *
  */
-#define SPINEL_FRAME_BUFFER_SIZE          (SPINEL_FRAME_MAX_SIZE + SPINEL_ENCRYPTER_EXTRA_DATA_SIZE)
+#define SPINEL_FRAME_BUFFER_SIZE (SPINEL_FRAME_MAX_SIZE + SPINEL_ENCRYPTER_EXTRA_DATA_SIZE)
 
 /// Macro for generating bit masks using bit index from the spec
-#define SPINEL_BIT_MASK(bit_index,field_bit_count)                                                      \
-                                        ( (1 << ((field_bit_count) - 1)) >> (bit_index) )
+#define SPINEL_BIT_MASK(bit_index, field_bit_count) ((1 << ((field_bit_count)-1)) >> (bit_index))
 
 // ----------------------------------------------------------------------------
 
 __BEGIN_DECLS
 
-typedef enum
-{
-    SPINEL_STATUS_OK                    = 0, ///< Operation has completed successfully.
-    SPINEL_STATUS_FAILURE               = 1, ///< Operation has failed for some undefined reason.
+typedef enum {
+    SPINEL_STATUS_OK      = 0, ///< Operation has completed successfully.
+    SPINEL_STATUS_FAILURE = 1, ///< Operation has failed for some undefined reason.
 
-    SPINEL_STATUS_UNIMPLEMENTED         = 2, ///< Given operation has not been implemented.
-    SPINEL_STATUS_INVALID_ARGUMENT      = 3, ///< An argument to the operation is invalid.
-    SPINEL_STATUS_INVALID_STATE         = 4, ///< This operation is invalid for the current device state.
-    SPINEL_STATUS_INVALID_COMMAND       = 5, ///< This command is not recognized.
-    SPINEL_STATUS_INVALID_INTERFACE     = 6, ///< This interface is not supported.
-    SPINEL_STATUS_INTERNAL_ERROR        = 7, ///< An internal runtime error has occured.
-    SPINEL_STATUS_SECURITY_ERROR        = 8, ///< A security/authentication error has occured.
-    SPINEL_STATUS_PARSE_ERROR           = 9, ///< A error has occured while parsing the command.
-    SPINEL_STATUS_IN_PROGRESS           = 10, ///< This operation is in progress.
-    SPINEL_STATUS_NOMEM                 = 11, ///< Operation prevented due to memory pressure.
-    SPINEL_STATUS_BUSY                  = 12, ///< The device is currently performing a mutually exclusive operation
-    SPINEL_STATUS_PROP_NOT_FOUND        = 13, ///< The given property is not recognized.
-    SPINEL_STATUS_DROPPED               = 14, ///< A/The packet was dropped.
-    SPINEL_STATUS_EMPTY                 = 15, ///< The result of the operation is empty.
-    SPINEL_STATUS_CMD_TOO_BIG           = 16, ///< The command was too large to fit in the internal buffer.
-    SPINEL_STATUS_NO_ACK                = 17, ///< The packet was not acknowledged.
-    SPINEL_STATUS_CCA_FAILURE           = 18, ///< The packet was not sent due to a CCA failure.
-    SPINEL_STATUS_ALREADY               = 19, ///< The operation is already in progress.
-    SPINEL_STATUS_ITEM_NOT_FOUND        = 20, ///< The given item could not be found.
-    SPINEL_STATUS_INVALID_COMMAND_FOR_PROP
-                                        = 21, ///< The given command cannot be performed on this property.
+    SPINEL_STATUS_UNIMPLEMENTED            = 2,  ///< Given operation has not been implemented.
+    SPINEL_STATUS_INVALID_ARGUMENT         = 3,  ///< An argument to the operation is invalid.
+    SPINEL_STATUS_INVALID_STATE            = 4,  ///< This operation is invalid for the current device state.
+    SPINEL_STATUS_INVALID_COMMAND          = 5,  ///< This command is not recognized.
+    SPINEL_STATUS_INVALID_INTERFACE        = 6,  ///< This interface is not supported.
+    SPINEL_STATUS_INTERNAL_ERROR           = 7,  ///< An internal runtime error has occured.
+    SPINEL_STATUS_SECURITY_ERROR           = 8,  ///< A security/authentication error has occured.
+    SPINEL_STATUS_PARSE_ERROR              = 9,  ///< A error has occured while parsing the command.
+    SPINEL_STATUS_IN_PROGRESS              = 10, ///< This operation is in progress.
+    SPINEL_STATUS_NOMEM                    = 11, ///< Operation prevented due to memory pressure.
+    SPINEL_STATUS_BUSY                     = 12, ///< The device is currently performing a mutually exclusive operation
+    SPINEL_STATUS_PROP_NOT_FOUND           = 13, ///< The given property is not recognized.
+    SPINEL_STATUS_DROPPED                  = 14, ///< A/The packet was dropped.
+    SPINEL_STATUS_EMPTY                    = 15, ///< The result of the operation is empty.
+    SPINEL_STATUS_CMD_TOO_BIG              = 16, ///< The command was too large to fit in the internal buffer.
+    SPINEL_STATUS_NO_ACK                   = 17, ///< The packet was not acknowledged.
+    SPINEL_STATUS_CCA_FAILURE              = 18, ///< The packet was not sent due to a CCA failure.
+    SPINEL_STATUS_ALREADY                  = 19, ///< The operation is already in progress.
+    SPINEL_STATUS_ITEM_NOT_FOUND           = 20, ///< The given item could not be found.
+    SPINEL_STATUS_INVALID_COMMAND_FOR_PROP = 21, ///< The given command cannot be performed on this property.
 
-    SPINEL_STATUS_JOIN__BEGIN           = 104,
+    SPINEL_STATUS_JOIN__BEGIN = 104,
 
     /// Generic failure to associate with other peers.
     /**
@@ -145,7 +142,7 @@ typedef enum
      *
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_FAILURE          = SPINEL_STATUS_JOIN__BEGIN + 0,
+    SPINEL_STATUS_JOIN_FAILURE = SPINEL_STATUS_JOIN__BEGIN + 0,
 
     /// The node found other peers but was unable to decode their packets.
     /**
@@ -154,142 +151,136 @@ typedef enum
      *
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_SECURITY         = SPINEL_STATUS_JOIN__BEGIN + 1,
+    SPINEL_STATUS_JOIN_SECURITY = SPINEL_STATUS_JOIN__BEGIN + 1,
 
     /// The node was unable to find any other peers on the network.
     /**
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_NO_PEERS         = SPINEL_STATUS_JOIN__BEGIN + 2,
+    SPINEL_STATUS_JOIN_NO_PEERS = SPINEL_STATUS_JOIN__BEGIN + 2,
 
     /// The only potential peer nodes found are incompatible.
     /**
      *  \sa SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
      */
-    SPINEL_STATUS_JOIN_INCOMPATIBLE     = SPINEL_STATUS_JOIN__BEGIN + 3,
+    SPINEL_STATUS_JOIN_INCOMPATIBLE = SPINEL_STATUS_JOIN__BEGIN + 3,
 
-    SPINEL_STATUS_JOIN__END             = 112,
+    SPINEL_STATUS_JOIN__END = 112,
 
-    SPINEL_STATUS_RESET__BEGIN          = 112,
-    SPINEL_STATUS_RESET_POWER_ON        = SPINEL_STATUS_RESET__BEGIN + 0,
-    SPINEL_STATUS_RESET_EXTERNAL        = SPINEL_STATUS_RESET__BEGIN + 1,
-    SPINEL_STATUS_RESET_SOFTWARE        = SPINEL_STATUS_RESET__BEGIN + 2,
-    SPINEL_STATUS_RESET_FAULT           = SPINEL_STATUS_RESET__BEGIN + 3,
-    SPINEL_STATUS_RESET_CRASH           = SPINEL_STATUS_RESET__BEGIN + 4,
-    SPINEL_STATUS_RESET_ASSERT          = SPINEL_STATUS_RESET__BEGIN + 5,
-    SPINEL_STATUS_RESET_OTHER           = SPINEL_STATUS_RESET__BEGIN + 6,
-    SPINEL_STATUS_RESET_UNKNOWN         = SPINEL_STATUS_RESET__BEGIN + 7,
-    SPINEL_STATUS_RESET_WATCHDOG        = SPINEL_STATUS_RESET__BEGIN + 8,
-    SPINEL_STATUS_RESET__END            = 128,
+    SPINEL_STATUS_RESET__BEGIN   = 112,
+    SPINEL_STATUS_RESET_POWER_ON = SPINEL_STATUS_RESET__BEGIN + 0,
+    SPINEL_STATUS_RESET_EXTERNAL = SPINEL_STATUS_RESET__BEGIN + 1,
+    SPINEL_STATUS_RESET_SOFTWARE = SPINEL_STATUS_RESET__BEGIN + 2,
+    SPINEL_STATUS_RESET_FAULT    = SPINEL_STATUS_RESET__BEGIN + 3,
+    SPINEL_STATUS_RESET_CRASH    = SPINEL_STATUS_RESET__BEGIN + 4,
+    SPINEL_STATUS_RESET_ASSERT   = SPINEL_STATUS_RESET__BEGIN + 5,
+    SPINEL_STATUS_RESET_OTHER    = SPINEL_STATUS_RESET__BEGIN + 6,
+    SPINEL_STATUS_RESET_UNKNOWN  = SPINEL_STATUS_RESET__BEGIN + 7,
+    SPINEL_STATUS_RESET_WATCHDOG = SPINEL_STATUS_RESET__BEGIN + 8,
+    SPINEL_STATUS_RESET__END     = 128,
 
-    SPINEL_STATUS_VENDOR__BEGIN         = 15360,
-    SPINEL_STATUS_VENDOR__END           = 16384,
+    SPINEL_STATUS_VENDOR__BEGIN = 15360,
+    SPINEL_STATUS_VENDOR__END   = 16384,
 
-    SPINEL_STATUS_STACK_NATIVE__BEGIN   = 16384,
-    SPINEL_STATUS_STACK_NATIVE__END     = 81920,
+    SPINEL_STATUS_STACK_NATIVE__BEGIN = 16384,
+    SPINEL_STATUS_STACK_NATIVE__END   = 81920,
 
-    SPINEL_STATUS_EXPERIMENTAL__BEGIN   = 2000000,
-    SPINEL_STATUS_EXPERIMENTAL__END     = 2097152,
+    SPINEL_STATUS_EXPERIMENTAL__BEGIN = 2000000,
+    SPINEL_STATUS_EXPERIMENTAL__END   = 2097152,
 } spinel_status_t;
 
-typedef enum
-{
-    SPINEL_NET_ROLE_DETACHED            = 0,
-    SPINEL_NET_ROLE_CHILD               = 1,
-    SPINEL_NET_ROLE_ROUTER              = 2,
-    SPINEL_NET_ROLE_LEADER              = 3,
+typedef enum {
+    SPINEL_NET_ROLE_DETACHED = 0,
+    SPINEL_NET_ROLE_CHILD    = 1,
+    SPINEL_NET_ROLE_ROUTER   = 2,
+    SPINEL_NET_ROLE_LEADER   = 3,
 } spinel_net_role_t;
 
-typedef enum
-{
+typedef enum {
     SPINEL_IPV6_ICMP_PING_OFFLOAD_DISABLED       = 0,
     SPINEL_IPV6_ICMP_PING_OFFLOAD_UNICAST_ONLY   = 1,
     SPINEL_IPV6_ICMP_PING_OFFLOAD_MULTICAST_ONLY = 2,
     SPINEL_IPV6_ICMP_PING_OFFLOAD_ALL            = 3,
 } spinel_ipv6_icmp_ping_offload_mode_t;
 
-typedef enum
-{
-    SPINEL_SCAN_STATE_IDLE              = 0,
-    SPINEL_SCAN_STATE_BEACON            = 1,
-    SPINEL_SCAN_STATE_ENERGY            = 2,
-    SPINEL_SCAN_STATE_DISCOVER          = 3,
+typedef enum {
+    SPINEL_SCAN_STATE_IDLE     = 0,
+    SPINEL_SCAN_STATE_BEACON   = 1,
+    SPINEL_SCAN_STATE_ENERGY   = 2,
+    SPINEL_SCAN_STATE_DISCOVER = 3,
 } spinel_scan_state_t;
 
-typedef enum
-{
-    SPINEL_MCU_POWER_STATE_ON           = 0,
-    SPINEL_MCU_POWER_STATE_LOW_POWER    = 1,
-    SPINEL_MCU_POWER_STATE_OFF          = 2,
+typedef enum {
+    SPINEL_MCU_POWER_STATE_ON        = 0,
+    SPINEL_MCU_POWER_STATE_LOW_POWER = 1,
+    SPINEL_MCU_POWER_STATE_OFF       = 2,
 } spinel_mcu_power_state_t;
 
 // The `spinel_power_state_t` enumeration and `POWER_STATE`
 // property are deprecated. Please use `MCU_POWER_STATE`
 // instead.
-typedef enum
-{
-    SPINEL_POWER_STATE_OFFLINE          = 0,
-    SPINEL_POWER_STATE_DEEP_SLEEP       = 1,
-    SPINEL_POWER_STATE_STANDBY          = 2,
-    SPINEL_POWER_STATE_LOW_POWER        = 3,
-    SPINEL_POWER_STATE_ONLINE           = 4,
+typedef enum {
+    SPINEL_POWER_STATE_OFFLINE    = 0,
+    SPINEL_POWER_STATE_DEEP_SLEEP = 1,
+    SPINEL_POWER_STATE_STANDBY    = 2,
+    SPINEL_POWER_STATE_LOW_POWER  = 3,
+    SPINEL_POWER_STATE_ONLINE     = 4,
 } spinel_power_state_t;
 
-typedef enum
-{
-    SPINEL_HOST_POWER_STATE_OFFLINE     = 0,
-    SPINEL_HOST_POWER_STATE_DEEP_SLEEP  = 1,
-    SPINEL_HOST_POWER_STATE_RESERVED    = 2,
-    SPINEL_HOST_POWER_STATE_LOW_POWER   = 3,
-    SPINEL_HOST_POWER_STATE_ONLINE      = 4,
+typedef enum {
+    SPINEL_HOST_POWER_STATE_OFFLINE    = 0,
+    SPINEL_HOST_POWER_STATE_DEEP_SLEEP = 1,
+    SPINEL_HOST_POWER_STATE_RESERVED   = 2,
+    SPINEL_HOST_POWER_STATE_LOW_POWER  = 3,
+    SPINEL_HOST_POWER_STATE_ONLINE     = 4,
 } spinel_host_power_state_t;
 
 enum
 {
-    SPINEL_NET_FLAG_ON_MESH             = (1 << 0),
-    SPINEL_NET_FLAG_DEFAULT_ROUTE       = (1 << 1),
-    SPINEL_NET_FLAG_CONFIGURE           = (1 << 2),
-    SPINEL_NET_FLAG_DHCP                = (1 << 3),
-    SPINEL_NET_FLAG_SLAAC               = (1 << 4),
-    SPINEL_NET_FLAG_PREFERRED           = (1 << 5),
+    SPINEL_NET_FLAG_ON_MESH       = (1 << 0),
+    SPINEL_NET_FLAG_DEFAULT_ROUTE = (1 << 1),
+    SPINEL_NET_FLAG_CONFIGURE     = (1 << 2),
+    SPINEL_NET_FLAG_DHCP          = (1 << 3),
+    SPINEL_NET_FLAG_SLAAC         = (1 << 4),
+    SPINEL_NET_FLAG_PREFERRED     = (1 << 5),
 
-    SPINEL_NET_FLAG_PREFERENCE_OFFSET   = 6,
-    SPINEL_NET_FLAG_PREFERENCE_MASK     = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
+    SPINEL_NET_FLAG_PREFERENCE_OFFSET = 6,
+    SPINEL_NET_FLAG_PREFERENCE_MASK   = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
 };
 
 enum
 {
-    SPINEL_ROUTE_PREFERENCE_HIGH        = (1 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
-    SPINEL_ROUTE_PREFERENCE_MEDIUM      = (0 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
-    SPINEL_ROUTE_PREFERENCE_LOW         = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
+    SPINEL_ROUTE_PREFERENCE_HIGH   = (1 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
+    SPINEL_ROUTE_PREFERENCE_MEDIUM = (0 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
+    SPINEL_ROUTE_PREFERENCE_LOW    = (3 << SPINEL_NET_FLAG_PREFERENCE_OFFSET),
 };
 
 enum
 {
-    SPINEL_THREAD_MODE_FULL_NETWORK_DATA    = (1 << 0),
-    SPINEL_THREAD_MODE_FULL_FUNCTION_DEV    = (1 << 1),
-    SPINEL_THREAD_MODE_SECURE_DATA_REQUEST  = (1 << 2),
-    SPINEL_THREAD_MODE_RX_ON_WHEN_IDLE      = (1 << 3),
-};
-
-enum {
-    SPINEL_GPIO_FLAG_DIR_INPUT          = 0,
-    SPINEL_GPIO_FLAG_DIR_OUTPUT         = SPINEL_BIT_MASK(0, 8),
-    SPINEL_GPIO_FLAG_PULL_UP            = SPINEL_BIT_MASK(1, 8),
-    SPINEL_GPIO_FLAG_PULL_DOWN          = SPINEL_BIT_MASK(2, 8),
-    SPINEL_GPIO_FLAG_OPEN_DRAIN         = SPINEL_BIT_MASK(2, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_NONE       = 0,
-    SPINEL_GPIO_FLAG_TRIGGER_RISING     = SPINEL_BIT_MASK(3, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_FALLING    = SPINEL_BIT_MASK(4, 8),
-    SPINEL_GPIO_FLAG_TRIGGER_ANY        = SPINEL_GPIO_FLAG_TRIGGER_RISING
-                                        | SPINEL_GPIO_FLAG_TRIGGER_FALLING,
+    SPINEL_THREAD_MODE_FULL_NETWORK_DATA   = (1 << 0),
+    SPINEL_THREAD_MODE_FULL_FUNCTION_DEV   = (1 << 1),
+    SPINEL_THREAD_MODE_SECURE_DATA_REQUEST = (1 << 2),
+    SPINEL_THREAD_MODE_RX_ON_WHEN_IDLE     = (1 << 3),
 };
 
 enum
 {
-    SPINEL_PROTOCOL_TYPE_BOOTLOADER     = 0,
-    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP      = 2,
-    SPINEL_PROTOCOL_TYPE_THREAD         = 3,
+    SPINEL_GPIO_FLAG_DIR_INPUT       = 0,
+    SPINEL_GPIO_FLAG_DIR_OUTPUT      = SPINEL_BIT_MASK(0, 8),
+    SPINEL_GPIO_FLAG_PULL_UP         = SPINEL_BIT_MASK(1, 8),
+    SPINEL_GPIO_FLAG_PULL_DOWN       = SPINEL_BIT_MASK(2, 8),
+    SPINEL_GPIO_FLAG_OPEN_DRAIN      = SPINEL_BIT_MASK(2, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_NONE    = 0,
+    SPINEL_GPIO_FLAG_TRIGGER_RISING  = SPINEL_BIT_MASK(3, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_FALLING = SPINEL_BIT_MASK(4, 8),
+    SPINEL_GPIO_FLAG_TRIGGER_ANY     = SPINEL_GPIO_FLAG_TRIGGER_RISING | SPINEL_GPIO_FLAG_TRIGGER_FALLING,
+};
+
+enum
+{
+    SPINEL_PROTOCOL_TYPE_BOOTLOADER = 0,
+    SPINEL_PROTOCOL_TYPE_ZIGBEE_IP  = 2,
+    SPINEL_PROTOCOL_TYPE_THREAD     = 3,
 };
 
 enum
@@ -301,35 +292,35 @@ enum
 
 enum
 {
-    SPINEL_NCP_LOG_LEVEL_EMERG          = 0,
-    SPINEL_NCP_LOG_LEVEL_ALERT          = 1,
-    SPINEL_NCP_LOG_LEVEL_CRIT           = 2,
-    SPINEL_NCP_LOG_LEVEL_ERR            = 3,
-    SPINEL_NCP_LOG_LEVEL_WARN           = 4,
-    SPINEL_NCP_LOG_LEVEL_NOTICE         = 5,
-    SPINEL_NCP_LOG_LEVEL_INFO           = 6,
-    SPINEL_NCP_LOG_LEVEL_DEBUG          = 7,
+    SPINEL_NCP_LOG_LEVEL_EMERG  = 0,
+    SPINEL_NCP_LOG_LEVEL_ALERT  = 1,
+    SPINEL_NCP_LOG_LEVEL_CRIT   = 2,
+    SPINEL_NCP_LOG_LEVEL_ERR    = 3,
+    SPINEL_NCP_LOG_LEVEL_WARN   = 4,
+    SPINEL_NCP_LOG_LEVEL_NOTICE = 5,
+    SPINEL_NCP_LOG_LEVEL_INFO   = 6,
+    SPINEL_NCP_LOG_LEVEL_DEBUG  = 7,
 };
 
 enum
 {
-    SPINEL_NCP_LOG_REGION_NONE          = 0,
-    SPINEL_NCP_LOG_REGION_OT_API        = 1,
-    SPINEL_NCP_LOG_REGION_OT_MLE        = 2,
-    SPINEL_NCP_LOG_REGION_OT_ARP        = 3,
-    SPINEL_NCP_LOG_REGION_OT_NET_DATA   = 4,
-    SPINEL_NCP_LOG_REGION_OT_ICMP       = 5,
-    SPINEL_NCP_LOG_REGION_OT_IP6        = 6,
-    SPINEL_NCP_LOG_REGION_OT_MAC        = 7,
-    SPINEL_NCP_LOG_REGION_OT_MEM        = 8,
-    SPINEL_NCP_LOG_REGION_OT_NCP        = 9,
-    SPINEL_NCP_LOG_REGION_OT_MESH_COP   = 10,
-    SPINEL_NCP_LOG_REGION_OT_NET_DIAG   = 11,
-    SPINEL_NCP_LOG_REGION_OT_PLATFORM   = 12,
-    SPINEL_NCP_LOG_REGION_OT_COAP       = 13,
-    SPINEL_NCP_LOG_REGION_OT_CLI        = 14,
-    SPINEL_NCP_LOG_REGION_OT_CORE       = 15,
-    SPINEL_NCP_LOG_REGION_OT_UTIL       = 16,
+    SPINEL_NCP_LOG_REGION_NONE        = 0,
+    SPINEL_NCP_LOG_REGION_OT_API      = 1,
+    SPINEL_NCP_LOG_REGION_OT_MLE      = 2,
+    SPINEL_NCP_LOG_REGION_OT_ARP      = 3,
+    SPINEL_NCP_LOG_REGION_OT_NET_DATA = 4,
+    SPINEL_NCP_LOG_REGION_OT_ICMP     = 5,
+    SPINEL_NCP_LOG_REGION_OT_IP6      = 6,
+    SPINEL_NCP_LOG_REGION_OT_MAC      = 7,
+    SPINEL_NCP_LOG_REGION_OT_MEM      = 8,
+    SPINEL_NCP_LOG_REGION_OT_NCP      = 9,
+    SPINEL_NCP_LOG_REGION_OT_MESH_COP = 10,
+    SPINEL_NCP_LOG_REGION_OT_NET_DIAG = 11,
+    SPINEL_NCP_LOG_REGION_OT_PLATFORM = 12,
+    SPINEL_NCP_LOG_REGION_OT_COAP     = 13,
+    SPINEL_NCP_LOG_REGION_OT_CLI      = 14,
+    SPINEL_NCP_LOG_REGION_OT_CORE     = 15,
+    SPINEL_NCP_LOG_REGION_OT_UTIL     = 16,
 };
 
 typedef struct
@@ -357,149 +348,148 @@ typedef struct
     uint8_t bytes[16];
 } spinel_ipv6addr_t;
 
-typedef int spinel_ssize_t;
+typedef int          spinel_ssize_t;
 typedef unsigned int spinel_size_t;
-typedef uint8_t spinel_tid_t;
+typedef uint8_t      spinel_tid_t;
 typedef unsigned int spinel_cid_t;
 
 enum
 {
-    SPINEL_MD_FLAG_TX                   = 0x0001, //!< Packet was transmitted, not received.
-    SPINEL_MD_FLAG_BAD_FCS              = 0x0004, //!< Packet was received with bad FCS
-    SPINEL_MD_FLAG_DUPE                 = 0x0008, //!< Packet seems to be a duplicate
-    SPINEL_MD_FLAG_RESERVED             = 0xFFF2, //!< Flags reserved for future use.
+    SPINEL_MD_FLAG_TX       = 0x0001, //!< Packet was transmitted, not received.
+    SPINEL_MD_FLAG_BAD_FCS  = 0x0004, //!< Packet was received with bad FCS
+    SPINEL_MD_FLAG_DUPE     = 0x0008, //!< Packet seems to be a duplicate
+    SPINEL_MD_FLAG_RESERVED = 0xFFF2, //!< Flags reserved for future use.
 };
 
 enum
 {
-    SPINEL_CMD_NOOP                     = 0,
-    SPINEL_CMD_RESET                    = 1,
-    SPINEL_CMD_PROP_VALUE_GET           = 2,
-    SPINEL_CMD_PROP_VALUE_SET           = 3,
-    SPINEL_CMD_PROP_VALUE_INSERT        = 4,
-    SPINEL_CMD_PROP_VALUE_REMOVE        = 5,
-    SPINEL_CMD_PROP_VALUE_IS            = 6,
-    SPINEL_CMD_PROP_VALUE_INSERTED      = 7,
-    SPINEL_CMD_PROP_VALUE_REMOVED       = 8,
+    SPINEL_CMD_NOOP                = 0,
+    SPINEL_CMD_RESET               = 1,
+    SPINEL_CMD_PROP_VALUE_GET      = 2,
+    SPINEL_CMD_PROP_VALUE_SET      = 3,
+    SPINEL_CMD_PROP_VALUE_INSERT   = 4,
+    SPINEL_CMD_PROP_VALUE_REMOVE   = 5,
+    SPINEL_CMD_PROP_VALUE_IS       = 6,
+    SPINEL_CMD_PROP_VALUE_INSERTED = 7,
+    SPINEL_CMD_PROP_VALUE_REMOVED  = 8,
 
-    SPINEL_CMD_NET_SAVE                 = 9,
-    SPINEL_CMD_NET_CLEAR                = 10,
-    SPINEL_CMD_NET_RECALL               = 11,
+    SPINEL_CMD_NET_SAVE   = 9,
+    SPINEL_CMD_NET_CLEAR  = 10,
+    SPINEL_CMD_NET_RECALL = 11,
 
-    SPINEL_CMD_HBO_OFFLOAD              = 12,
-    SPINEL_CMD_HBO_RECLAIM              = 13,
-    SPINEL_CMD_HBO_DROP                 = 14,
-    SPINEL_CMD_HBO_OFFLOADED            = 15,
-    SPINEL_CMD_HBO_RECLAIMED            = 16,
-    SPINEL_CMD_HBO_DROPED               = 17,
+    SPINEL_CMD_HBO_OFFLOAD   = 12,
+    SPINEL_CMD_HBO_RECLAIM   = 13,
+    SPINEL_CMD_HBO_DROP      = 14,
+    SPINEL_CMD_HBO_OFFLOADED = 15,
+    SPINEL_CMD_HBO_RECLAIMED = 16,
+    SPINEL_CMD_HBO_DROPED    = 17,
 
-    SPINEL_CMD_PEEK                     = 18,
-    SPINEL_CMD_PEEK_RET                 = 19,
-    SPINEL_CMD_POKE                     = 20,
+    SPINEL_CMD_PEEK     = 18,
+    SPINEL_CMD_PEEK_RET = 19,
+    SPINEL_CMD_POKE     = 20,
 
-    SPINEL_CMD_PROP_VALUE_MULTI_GET     = 21,
-    SPINEL_CMD_PROP_VALUE_MULTI_SET     = 22,
-    SPINEL_CMD_PROP_VALUES_ARE          = 23,
+    SPINEL_CMD_PROP_VALUE_MULTI_GET = 21,
+    SPINEL_CMD_PROP_VALUE_MULTI_SET = 22,
+    SPINEL_CMD_PROP_VALUES_ARE      = 23,
 
-    SPINEL_CMD_NEST__BEGIN              = 15296,
-    SPINEL_CMD_NEST__END                = 15360,
+    SPINEL_CMD_NEST__BEGIN = 15296,
+    SPINEL_CMD_NEST__END   = 15360,
 
-    SPINEL_CMD_VENDOR__BEGIN            = 15360,
-    SPINEL_CMD_VENDOR__END              = 16384,
+    SPINEL_CMD_VENDOR__BEGIN = 15360,
+    SPINEL_CMD_VENDOR__END   = 16384,
 
-    SPINEL_CMD_EXPERIMENTAL__BEGIN      = 2000000,
-    SPINEL_CMD_EXPERIMENTAL__END        = 2097152,
+    SPINEL_CMD_EXPERIMENTAL__BEGIN = 2000000,
+    SPINEL_CMD_EXPERIMENTAL__END   = 2097152,
 };
 
 enum
 {
-    SPINEL_CAP_LOCK                     = 1,
-    SPINEL_CAP_NET_SAVE                 = 2,
-    SPINEL_CAP_HBO                      = 3,
-    SPINEL_CAP_POWER_SAVE               = 4,
+    SPINEL_CAP_LOCK       = 1,
+    SPINEL_CAP_NET_SAVE   = 2,
+    SPINEL_CAP_HBO        = 3,
+    SPINEL_CAP_POWER_SAVE = 4,
 
-    SPINEL_CAP_COUNTERS                 = 5,
-    SPINEL_CAP_JAM_DETECT               = 6,
+    SPINEL_CAP_COUNTERS   = 5,
+    SPINEL_CAP_JAM_DETECT = 6,
 
-    SPINEL_CAP_PEEK_POKE                = 7,
+    SPINEL_CAP_PEEK_POKE = 7,
 
-    SPINEL_CAP_WRITABLE_RAW_STREAM      = 8,
-    SPINEL_CAP_GPIO                     = 9,
-    SPINEL_CAP_TRNG                     = 10,
-    SPINEL_CAP_CMD_MULTI                = 11,
-    SPINEL_CAP_UNSOL_UPDATE_FILTER      = 12,
-    SPINEL_CAP_MCU_POWER_STATE          = 13,
+    SPINEL_CAP_WRITABLE_RAW_STREAM = 8,
+    SPINEL_CAP_GPIO                = 9,
+    SPINEL_CAP_TRNG                = 10,
+    SPINEL_CAP_CMD_MULTI           = 11,
+    SPINEL_CAP_UNSOL_UPDATE_FILTER = 12,
+    SPINEL_CAP_MCU_POWER_STATE     = 13,
 
-    SPINEL_CAP_802_15_4__BEGIN          = 16,
-    SPINEL_CAP_802_15_4_2003            = (SPINEL_CAP_802_15_4__BEGIN + 0),
-    SPINEL_CAP_802_15_4_2006            = (SPINEL_CAP_802_15_4__BEGIN + 1),
-    SPINEL_CAP_802_15_4_2011            = (SPINEL_CAP_802_15_4__BEGIN + 2),
-    SPINEL_CAP_802_15_4_PIB             = (SPINEL_CAP_802_15_4__BEGIN + 5),
-    SPINEL_CAP_802_15_4_2450MHZ_OQPSK   = (SPINEL_CAP_802_15_4__BEGIN + 8),
-    SPINEL_CAP_802_15_4_915MHZ_OQPSK    = (SPINEL_CAP_802_15_4__BEGIN + 9),
-    SPINEL_CAP_802_15_4_868MHZ_OQPSK    = (SPINEL_CAP_802_15_4__BEGIN + 10),
-    SPINEL_CAP_802_15_4_915MHZ_BPSK     = (SPINEL_CAP_802_15_4__BEGIN + 11),
-    SPINEL_CAP_802_15_4_868MHZ_BPSK     = (SPINEL_CAP_802_15_4__BEGIN + 12),
-    SPINEL_CAP_802_15_4_915MHZ_ASK      = (SPINEL_CAP_802_15_4__BEGIN + 13),
-    SPINEL_CAP_802_15_4_868MHZ_ASK      = (SPINEL_CAP_802_15_4__BEGIN + 14),
-    SPINEL_CAP_802_15_4__END            = 32,
+    SPINEL_CAP_802_15_4__BEGIN        = 16,
+    SPINEL_CAP_802_15_4_2003          = (SPINEL_CAP_802_15_4__BEGIN + 0),
+    SPINEL_CAP_802_15_4_2006          = (SPINEL_CAP_802_15_4__BEGIN + 1),
+    SPINEL_CAP_802_15_4_2011          = (SPINEL_CAP_802_15_4__BEGIN + 2),
+    SPINEL_CAP_802_15_4_PIB           = (SPINEL_CAP_802_15_4__BEGIN + 5),
+    SPINEL_CAP_802_15_4_2450MHZ_OQPSK = (SPINEL_CAP_802_15_4__BEGIN + 8),
+    SPINEL_CAP_802_15_4_915MHZ_OQPSK  = (SPINEL_CAP_802_15_4__BEGIN + 9),
+    SPINEL_CAP_802_15_4_868MHZ_OQPSK  = (SPINEL_CAP_802_15_4__BEGIN + 10),
+    SPINEL_CAP_802_15_4_915MHZ_BPSK   = (SPINEL_CAP_802_15_4__BEGIN + 11),
+    SPINEL_CAP_802_15_4_868MHZ_BPSK   = (SPINEL_CAP_802_15_4__BEGIN + 12),
+    SPINEL_CAP_802_15_4_915MHZ_ASK    = (SPINEL_CAP_802_15_4__BEGIN + 13),
+    SPINEL_CAP_802_15_4_868MHZ_ASK    = (SPINEL_CAP_802_15_4__BEGIN + 14),
+    SPINEL_CAP_802_15_4__END          = 32,
 
-    SPINEL_CAP_ROLE__BEGIN              = 48,
-    SPINEL_CAP_ROLE_ROUTER              = (SPINEL_CAP_ROLE__BEGIN + 0),
-    SPINEL_CAP_ROLE_SLEEPY              = (SPINEL_CAP_ROLE__BEGIN + 1),
-    SPINEL_CAP_ROLE__END                = 52,
+    SPINEL_CAP_ROLE__BEGIN = 48,
+    SPINEL_CAP_ROLE_ROUTER = (SPINEL_CAP_ROLE__BEGIN + 0),
+    SPINEL_CAP_ROLE_SLEEPY = (SPINEL_CAP_ROLE__BEGIN + 1),
+    SPINEL_CAP_ROLE__END   = 52,
 
-    SPINEL_CAP_NET__BEGIN               = 52,
-    SPINEL_CAP_NET_THREAD_1_0           = (SPINEL_CAP_NET__BEGIN + 0),
-    SPINEL_CAP_NET__END                 = 64,
+    SPINEL_CAP_NET__BEGIN     = 52,
+    SPINEL_CAP_NET_THREAD_1_0 = (SPINEL_CAP_NET__BEGIN + 0),
+    SPINEL_CAP_NET__END       = 64,
 
-    SPINEL_CAP_OPENTHREAD__BEGIN        = 512,
-    SPINEL_CAP_MAC_WHITELIST            = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
-    SPINEL_CAP_MAC_RAW                  = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
-    SPINEL_CAP_OOB_STEERING_DATA        = (SPINEL_CAP_OPENTHREAD__BEGIN + 2),
-    SPINEL_CAP_CHANNEL_MONITOR          = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
-    SPINEL_CAP_ERROR_RATE_TRACKING      = (SPINEL_CAP_OPENTHREAD__BEGIN + 4),
-    SPINEL_CAP_CHANNEL_MANAGER          = (SPINEL_CAP_OPENTHREAD__BEGIN + 5),
-    SPINEL_CAP_OPENTHREAD_LOG_METADATA  = (SPINEL_CAP_OPENTHREAD__BEGIN + 6),
-    SPINEL_CAP_TIME_SYNC                = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
-    SPINEL_CAP_OPENTHREAD__END          = 640,
+    SPINEL_CAP_OPENTHREAD__BEGIN       = 512,
+    SPINEL_CAP_MAC_WHITELIST           = (SPINEL_CAP_OPENTHREAD__BEGIN + 0),
+    SPINEL_CAP_MAC_RAW                 = (SPINEL_CAP_OPENTHREAD__BEGIN + 1),
+    SPINEL_CAP_OOB_STEERING_DATA       = (SPINEL_CAP_OPENTHREAD__BEGIN + 2),
+    SPINEL_CAP_CHANNEL_MONITOR         = (SPINEL_CAP_OPENTHREAD__BEGIN + 3),
+    SPINEL_CAP_ERROR_RATE_TRACKING     = (SPINEL_CAP_OPENTHREAD__BEGIN + 4),
+    SPINEL_CAP_CHANNEL_MANAGER         = (SPINEL_CAP_OPENTHREAD__BEGIN + 5),
+    SPINEL_CAP_OPENTHREAD_LOG_METADATA = (SPINEL_CAP_OPENTHREAD__BEGIN + 6),
+    SPINEL_CAP_TIME_SYNC               = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
+    SPINEL_CAP_OPENTHREAD__END         = 640,
 
-    SPINEL_CAP_THREAD__BEGIN            = 1024,
-    SPINEL_CAP_THREAD_COMMISSIONER      = (SPINEL_CAP_THREAD__BEGIN + 0),
-    SPINEL_CAP_THREAD_TMF_PROXY         = (SPINEL_CAP_THREAD__BEGIN + 1),
-    SPINEL_CAP_THREAD__END              = 1152,
+    SPINEL_CAP_THREAD__BEGIN       = 1024,
+    SPINEL_CAP_THREAD_COMMISSIONER = (SPINEL_CAP_THREAD__BEGIN + 0),
+    SPINEL_CAP_THREAD_TMF_PROXY    = (SPINEL_CAP_THREAD__BEGIN + 1),
+    SPINEL_CAP_THREAD__END         = 1152,
 
-    SPINEL_CAP_NEST__BEGIN              = 15296,
-    SPINEL_CAP_NEST_LEGACY_INTERFACE    = (SPINEL_CAP_NEST__BEGIN + 0),
-    SPINEL_CAP_NEST_LEGACY_NET_WAKE     = (SPINEL_CAP_NEST__BEGIN + 1),
-    SPINEL_CAP_NEST_TRANSMIT_HOOK       = (SPINEL_CAP_NEST__BEGIN + 2),
-    SPINEL_CAP_NEST__END                = 15360,
+    SPINEL_CAP_NEST__BEGIN           = 15296,
+    SPINEL_CAP_NEST_LEGACY_INTERFACE = (SPINEL_CAP_NEST__BEGIN + 0),
+    SPINEL_CAP_NEST_LEGACY_NET_WAKE  = (SPINEL_CAP_NEST__BEGIN + 1),
+    SPINEL_CAP_NEST_TRANSMIT_HOOK    = (SPINEL_CAP_NEST__BEGIN + 2),
+    SPINEL_CAP_NEST__END             = 15360,
 
-    SPINEL_CAP_VENDOR__BEGIN            = 15360,
-    SPINEL_CAP_VENDOR__END              = 16384,
+    SPINEL_CAP_VENDOR__BEGIN = 15360,
+    SPINEL_CAP_VENDOR__END   = 16384,
 
-    SPINEL_CAP_EXPERIMENTAL__BEGIN      = 2000000,
-    SPINEL_CAP_EXPERIMENTAL__END        = 2097152,
+    SPINEL_CAP_EXPERIMENTAL__BEGIN = 2000000,
+    SPINEL_CAP_EXPERIMENTAL__END   = 2097152,
 };
 
-typedef enum
-{
-    SPINEL_PROP_LAST_STATUS             = 0,        ///< status [i]
-    SPINEL_PROP_PROTOCOL_VERSION        = 1,        ///< major, minor [i,i]
-    SPINEL_PROP_NCP_VERSION             = 2,        ///< version string [U]
-    SPINEL_PROP_INTERFACE_TYPE          = 3,        ///< [i]
-    SPINEL_PROP_VENDOR_ID               = 4,        ///< [i]
-    SPINEL_PROP_CAPS                    = 5,        ///< capability list [A(i)]
-    SPINEL_PROP_INTERFACE_COUNT         = 6,        ///< Interface count [C]
-    SPINEL_PROP_POWER_STATE             = 7,        ///< PowerState [C] (deprecated, use `MCU_POWER_STATE` instead).
-    SPINEL_PROP_HWADDR                  = 8,        ///< PermEUI64 [E]
-    SPINEL_PROP_LOCK                    = 9,        ///< PropLock [b]
-    SPINEL_PROP_HBO_MEM_MAX             = 10,       ///< Max offload mem [S]
-    SPINEL_PROP_HBO_BLOCK_MAX           = 11,       ///< Max offload block [S]
-    SPINEL_PROP_HOST_POWER_STATE        = 12,       ///< Host MCU power state [C]
-    SPINEL_PROP_MCU_POWER_STATE         = 13,       ///< NCP's MCU power state [c]
+typedef enum {
+    SPINEL_PROP_LAST_STATUS      = 0,  ///< status [i]
+    SPINEL_PROP_PROTOCOL_VERSION = 1,  ///< major, minor [i,i]
+    SPINEL_PROP_NCP_VERSION      = 2,  ///< version string [U]
+    SPINEL_PROP_INTERFACE_TYPE   = 3,  ///< [i]
+    SPINEL_PROP_VENDOR_ID        = 4,  ///< [i]
+    SPINEL_PROP_CAPS             = 5,  ///< capability list [A(i)]
+    SPINEL_PROP_INTERFACE_COUNT  = 6,  ///< Interface count [C]
+    SPINEL_PROP_POWER_STATE      = 7,  ///< PowerState [C] (deprecated, use `MCU_POWER_STATE` instead).
+    SPINEL_PROP_HWADDR           = 8,  ///< PermEUI64 [E]
+    SPINEL_PROP_LOCK             = 9,  ///< PropLock [b]
+    SPINEL_PROP_HBO_MEM_MAX      = 10, ///< Max offload mem [S]
+    SPINEL_PROP_HBO_BLOCK_MAX    = 11, ///< Max offload block [S]
+    SPINEL_PROP_HOST_POWER_STATE = 12, ///< Host MCU power state [C]
+    SPINEL_PROP_MCU_POWER_STATE  = 13, ///< NCP's MCU power state [c]
 
-    SPINEL_PROP_BASE_EXT__BEGIN         = 0x1000,
+    SPINEL_PROP_BASE_EXT__BEGIN = 0x1000,
 
     /// GPIO Configuration
     /** Format: `A(CCU)`
@@ -544,7 +534,7 @@ typedef enum
      * configuration of GPIOs which are already exposed---it cannot be used
      * by the host to add additional GPIOs.
      */
-    SPINEL_PROP_GPIO_CONFIG             = SPINEL_PROP_BASE_EXT__BEGIN + 0,
+    SPINEL_PROP_GPIO_CONFIG = SPINEL_PROP_BASE_EXT__BEGIN + 0,
 
     /// GPIO State Bitmask
     /** Format: `D`
@@ -581,7 +571,7 @@ typedef enum
      *
      * When writing, unspecified bits are assumed to be zero.
      */
-    SPINEL_PROP_GPIO_STATE              = SPINEL_PROP_BASE_EXT__BEGIN + 2,
+    SPINEL_PROP_GPIO_STATE = SPINEL_PROP_BASE_EXT__BEGIN + 2,
 
     /// GPIO State Set-Only Bitmask
     /** Format: `D`
@@ -595,7 +585,7 @@ typedef enum
      * any bits for GPIOs which are not specified in `PROP_GPIO_CONFIG` MUST
      * be ignored.
      */
-    SPINEL_PROP_GPIO_STATE_SET          = SPINEL_PROP_BASE_EXT__BEGIN + 3,
+    SPINEL_PROP_GPIO_STATE_SET = SPINEL_PROP_BASE_EXT__BEGIN + 3,
 
     /// GPIO State Clear-Only Bitmask
     /** Format: `D`
@@ -609,17 +599,16 @@ typedef enum
      * any bits for GPIOs which are not specified in `PROP_GPIO_CONFIG` MUST
      * be ignored.
      */
-    SPINEL_PROP_GPIO_STATE_CLEAR        = SPINEL_PROP_BASE_EXT__BEGIN + 4,
+    SPINEL_PROP_GPIO_STATE_CLEAR = SPINEL_PROP_BASE_EXT__BEGIN + 4,
 
     /// 32-bit random number from TRNG, ready-to-use.
-    SPINEL_PROP_TRNG_32                 = SPINEL_PROP_BASE_EXT__BEGIN + 5,
+    SPINEL_PROP_TRNG_32 = SPINEL_PROP_BASE_EXT__BEGIN + 5,
 
     /// 16 random bytes from TRNG, ready-to-use.
-    SPINEL_PROP_TRNG_128                = SPINEL_PROP_BASE_EXT__BEGIN + 6,
+    SPINEL_PROP_TRNG_128 = SPINEL_PROP_BASE_EXT__BEGIN + 6,
 
     /// Raw samples from TRNG entropy source representing 32 bits of entropy.
-    SPINEL_PROP_TRNG_RAW_32             = SPINEL_PROP_BASE_EXT__BEGIN + 7,
-
+    SPINEL_PROP_TRNG_RAW_32 = SPINEL_PROP_BASE_EXT__BEGIN + 7,
 
     /// NCP Unsolicited update filter
     /** Format: `A(I)`
@@ -634,7 +623,7 @@ typedef enum
      * present in `PROP_UNSOL_UPDATE_LIST`. If such properties are added,
      * the NCP ignores the unsupported properties.
      */
-    SPINEL_PROP_UNSOL_UPDATE_FILTER     = SPINEL_PROP_BASE_EXT__BEGIN + 8,
+    SPINEL_PROP_UNSOL_UPDATE_FILTER = SPINEL_PROP_BASE_EXT__BEGIN + 8,
 
     /// List of properties capable of generating unsolicited value update.
     /** Format: `A(I)`
@@ -649,22 +638,22 @@ typedef enum
      * This property is intended to effectively behave as a constant
      * for a given NCP firmware.
      */
-    SPINEL_PROP_UNSOL_UPDATE_LIST       = SPINEL_PROP_BASE_EXT__BEGIN + 9,
+    SPINEL_PROP_UNSOL_UPDATE_LIST = SPINEL_PROP_BASE_EXT__BEGIN + 9,
 
-    SPINEL_PROP_BASE_EXT__END           = 0x1100,
+    SPINEL_PROP_BASE_EXT__END = 0x1100,
 
-    SPINEL_PROP_PHY__BEGIN              = 0x20,
-    SPINEL_PROP_PHY_ENABLED             = SPINEL_PROP_PHY__BEGIN + 0, ///< [b]
-    SPINEL_PROP_PHY_CHAN                = SPINEL_PROP_PHY__BEGIN + 1, ///< [C]
-    SPINEL_PROP_PHY_CHAN_SUPPORTED      = SPINEL_PROP_PHY__BEGIN + 2, ///< [A(C)]
-    SPINEL_PROP_PHY_FREQ                = SPINEL_PROP_PHY__BEGIN + 3, ///< kHz [L]
-    SPINEL_PROP_PHY_CCA_THRESHOLD       = SPINEL_PROP_PHY__BEGIN + 4, ///< dBm [c]
-    SPINEL_PROP_PHY_TX_POWER            = SPINEL_PROP_PHY__BEGIN + 5, ///< [c]
-    SPINEL_PROP_PHY_RSSI                = SPINEL_PROP_PHY__BEGIN + 6, ///< dBm [c]
-    SPINEL_PROP_PHY_RX_SENSITIVITY      = SPINEL_PROP_PHY__BEGIN + 7, ///< dBm [c]
-    SPINEL_PROP_PHY__END                = 0x30,
+    SPINEL_PROP_PHY__BEGIN         = 0x20,
+    SPINEL_PROP_PHY_ENABLED        = SPINEL_PROP_PHY__BEGIN + 0, ///< [b]
+    SPINEL_PROP_PHY_CHAN           = SPINEL_PROP_PHY__BEGIN + 1, ///< [C]
+    SPINEL_PROP_PHY_CHAN_SUPPORTED = SPINEL_PROP_PHY__BEGIN + 2, ///< [A(C)]
+    SPINEL_PROP_PHY_FREQ           = SPINEL_PROP_PHY__BEGIN + 3, ///< kHz [L]
+    SPINEL_PROP_PHY_CCA_THRESHOLD  = SPINEL_PROP_PHY__BEGIN + 4, ///< dBm [c]
+    SPINEL_PROP_PHY_TX_POWER       = SPINEL_PROP_PHY__BEGIN + 5, ///< [c]
+    SPINEL_PROP_PHY_RSSI           = SPINEL_PROP_PHY__BEGIN + 6, ///< dBm [c]
+    SPINEL_PROP_PHY_RX_SENSITIVITY = SPINEL_PROP_PHY__BEGIN + 7, ///< dBm [c]
+    SPINEL_PROP_PHY__END           = 0x30,
 
-    SPINEL_PROP_PHY_EXT__BEGIN          = 0x1200,
+    SPINEL_PROP_PHY_EXT__BEGIN = 0x1200,
 
     /// Signal Jamming Detection Enable
     /** Format: `b`
@@ -672,7 +661,7 @@ typedef enum
      * Indicates if jamming detection is enabled or disabled. Set to true
      * to enable jamming detection.
      */
-    SPINEL_PROP_JAM_DETECT_ENABLE       = SPINEL_PROP_PHY_EXT__BEGIN + 0,
+    SPINEL_PROP_JAM_DETECT_ENABLE = SPINEL_PROP_PHY_EXT__BEGIN + 0,
 
     /// Signal Jamming Detected Indicator
     /** Format: `b` (Read-Only)
@@ -682,7 +671,7 @@ typedef enum
      * When jamming detection is enabled, changes to the value of this
      * property are emitted asynchronously via `CMD_PROP_VALUE_IS`.
      */
-    SPINEL_PROP_JAM_DETECTED            = SPINEL_PROP_PHY_EXT__BEGIN + 1,
+    SPINEL_PROP_JAM_DETECTED = SPINEL_PROP_PHY_EXT__BEGIN + 1,
 
     /// Jamming detection RSSI threshold
     /** Format: `c`
@@ -692,8 +681,7 @@ typedef enum
      * dBm) above which the jamming detection will consider the
      * channel blocked.
      */
-    SPINEL_PROP_JAM_DETECT_RSSI_THRESHOLD
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 2,
+    SPINEL_PROP_JAM_DETECT_RSSI_THRESHOLD = SPINEL_PROP_PHY_EXT__BEGIN + 2,
 
     /// Jamming detection window size
     /** Format: `C`
@@ -702,7 +690,7 @@ typedef enum
      * This parameter describes the window period for signal jamming
      * detection.
      */
-    SPINEL_PROP_JAM_DETECT_WINDOW       = SPINEL_PROP_PHY_EXT__BEGIN + 3,
+    SPINEL_PROP_JAM_DETECT_WINDOW = SPINEL_PROP_PHY_EXT__BEGIN + 3,
 
     /// Jamming detection busy period
     /** Format: `C`
@@ -715,7 +703,7 @@ typedef enum
      * The behavior of the jamming detection feature when `PROP_JAM_DETECT_BUSY`
      * is larger than `PROP_JAM_DETECT_WINDOW` is undefined.
      */
-    SPINEL_PROP_JAM_DETECT_BUSY         = SPINEL_PROP_PHY_EXT__BEGIN + 4,
+    SPINEL_PROP_JAM_DETECT_BUSY = SPINEL_PROP_PHY_EXT__BEGIN + 4,
 
     /// Jamming detection history bitmap (for debugging)
     /** Format: `X` (read-only)
@@ -728,8 +716,7 @@ typedef enum
      * high signal level during the corresponding one second interval.
      *
      */
-    SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 5,
+    SPINEL_PROP_JAM_DETECT_HISTORY_BITMAP = SPINEL_PROP_PHY_EXT__BEGIN + 5,
 
     /// Channel monitoring sample interval
     /** Format: `L` (read-only)
@@ -743,8 +730,7 @@ typedef enum
      * threshold.
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 6,
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_INTERVAL = SPINEL_PROP_PHY_EXT__BEGIN + 6,
 
     /// Channel monitoring RSSI threshold
     /** Format: `c` (read-only)
@@ -758,8 +744,7 @@ typedef enum
      * of samples (sample window).
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_RSSI_THRESHOLD
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 7,
+    SPINEL_PROP_CHANNEL_MONITOR_RSSI_THRESHOLD = SPINEL_PROP_PHY_EXT__BEGIN + 7,
 
     /// Channel monitoring sample window
     /** Format: `L` (read-only)
@@ -774,8 +759,7 @@ typedef enum
      * the sample window.
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_WINDOW
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 8,
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_WINDOW = SPINEL_PROP_PHY_EXT__BEGIN + 8,
 
     /// Channel monitoring sample count
     /** Format: `L` (read-only)
@@ -788,8 +772,7 @@ typedef enum
      * was enabled).
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 9,
+    SPINEL_PROP_CHANNEL_MONITOR_SAMPLE_COUNT = SPINEL_PROP_PHY_EXT__BEGIN + 9,
 
     /// Channel monitoring channel occupancy
     /** Format: `A(t(CU))` (read-only)
@@ -809,26 +792,25 @@ typedef enum
      * threshold (i.e. 100% of samples were "bad").
      *
      */
-    SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY
-                                        = SPINEL_PROP_PHY_EXT__BEGIN + 10,
+    SPINEL_PROP_CHANNEL_MONITOR_CHANNEL_OCCUPANCY = SPINEL_PROP_PHY_EXT__BEGIN + 10,
 
-    SPINEL_PROP_PHY_EXT__END            = 0x1300,
+    SPINEL_PROP_PHY_EXT__END = 0x1300,
 
-    SPINEL_PROP_MAC__BEGIN              = 0x30,
-    SPINEL_PROP_MAC_SCAN_STATE          = SPINEL_PROP_MAC__BEGIN + 0,  ///< [C]
-    SPINEL_PROP_MAC_SCAN_MASK           = SPINEL_PROP_MAC__BEGIN + 1,  ///< [A(C)]
-    SPINEL_PROP_MAC_SCAN_PERIOD         = SPINEL_PROP_MAC__BEGIN + 2,  ///< ms-per-channel [S]
-    SPINEL_PROP_MAC_SCAN_BEACON         = SPINEL_PROP_MAC__BEGIN + 3,  ///< chan,rssi,mac_data,net_data [CcdD]
-    SPINEL_PROP_MAC_15_4_LADDR          = SPINEL_PROP_MAC__BEGIN + 4,  ///< [E]
-    SPINEL_PROP_MAC_15_4_SADDR          = SPINEL_PROP_MAC__BEGIN + 5,  ///< [S]
-    SPINEL_PROP_MAC_15_4_PANID          = SPINEL_PROP_MAC__BEGIN + 6,  ///< [S]
-    SPINEL_PROP_MAC_RAW_STREAM_ENABLED  = SPINEL_PROP_MAC__BEGIN + 7,  ///< [C]
-    SPINEL_PROP_MAC_PROMISCUOUS_MODE    = SPINEL_PROP_MAC__BEGIN + 8,  ///< [C]
-    SPINEL_PROP_MAC_ENERGY_SCAN_RESULT  = SPINEL_PROP_MAC__BEGIN + 9,  ///< chan,maxRssi [Cc]
-    SPINEL_PROP_MAC_DATA_POLL_PERIOD    = SPINEL_PROP_MAC__BEGIN + 10, ///< pollPeriod (in ms) [L]
-    SPINEL_PROP_MAC__END                = 0x40,
+    SPINEL_PROP_MAC__BEGIN             = 0x30,
+    SPINEL_PROP_MAC_SCAN_STATE         = SPINEL_PROP_MAC__BEGIN + 0,  ///< [C]
+    SPINEL_PROP_MAC_SCAN_MASK          = SPINEL_PROP_MAC__BEGIN + 1,  ///< [A(C)]
+    SPINEL_PROP_MAC_SCAN_PERIOD        = SPINEL_PROP_MAC__BEGIN + 2,  ///< ms-per-channel [S]
+    SPINEL_PROP_MAC_SCAN_BEACON        = SPINEL_PROP_MAC__BEGIN + 3,  ///< chan,rssi,mac_data,net_data [CcdD]
+    SPINEL_PROP_MAC_15_4_LADDR         = SPINEL_PROP_MAC__BEGIN + 4,  ///< [E]
+    SPINEL_PROP_MAC_15_4_SADDR         = SPINEL_PROP_MAC__BEGIN + 5,  ///< [S]
+    SPINEL_PROP_MAC_15_4_PANID         = SPINEL_PROP_MAC__BEGIN + 6,  ///< [S]
+    SPINEL_PROP_MAC_RAW_STREAM_ENABLED = SPINEL_PROP_MAC__BEGIN + 7,  ///< [C]
+    SPINEL_PROP_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_MAC__BEGIN + 8,  ///< [C]
+    SPINEL_PROP_MAC_ENERGY_SCAN_RESULT = SPINEL_PROP_MAC__BEGIN + 9,  ///< chan,maxRssi [Cc]
+    SPINEL_PROP_MAC_DATA_POLL_PERIOD   = SPINEL_PROP_MAC__BEGIN + 10, ///< pollPeriod (in ms) [L]
+    SPINEL_PROP_MAC__END               = 0x40,
 
-    SPINEL_PROP_MAC_EXT__BEGIN          = 0x1300,
+    SPINEL_PROP_MAC_EXT__BEGIN = 0x1300,
     /// MAC Whitelist
     /** Format: `A(t(Ec))`
      *
@@ -837,36 +819,34 @@ typedef enum
      * * `E`: EUI64 address of node
      * * `c`: Optional fixed RSSI. 127 means not set.
      */
-    SPINEL_PROP_MAC_WHITELIST           = SPINEL_PROP_MAC_EXT__BEGIN + 0,
+    SPINEL_PROP_MAC_WHITELIST = SPINEL_PROP_MAC_EXT__BEGIN + 0,
 
     /// MAC Whitelist Enabled Flag
     /** Format: `b`
      */
-    SPINEL_PROP_MAC_WHITELIST_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 1,
+    SPINEL_PROP_MAC_WHITELIST_ENABLED = SPINEL_PROP_MAC_EXT__BEGIN + 1,
 
     /// MAC Extended Address
     /** Format: `E`
      *
      *  Specified by Thread. Randomly-chosen, but non-volatile EUI-64.
      */
-    SPINEL_PROP_MAC_EXTENDED_ADDR       = SPINEL_PROP_MAC_EXT__BEGIN + 2,
+    SPINEL_PROP_MAC_EXTENDED_ADDR = SPINEL_PROP_MAC_EXT__BEGIN + 2,
 
     /// MAC Source Match Enabled Flag
     /** Format: `b`
      */
-    SPINEL_PROP_MAC_SRC_MATCH_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 3,
+    SPINEL_PROP_MAC_SRC_MATCH_ENABLED = SPINEL_PROP_MAC_EXT__BEGIN + 3,
 
     /// MAC Source Match Short Address List
     /** Format: `A(S)`
      */
-    SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES
-                                        = SPINEL_PROP_MAC_EXT__BEGIN + 4,
+    SPINEL_PROP_MAC_SRC_MATCH_SHORT_ADDRESSES = SPINEL_PROP_MAC_EXT__BEGIN + 4,
 
     /// MAC Source Match Extended Address List
     /** Format: `A(E)`
      */
-    SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES
-                                        = SPINEL_PROP_MAC_EXT__BEGIN + 5,
+    SPINEL_PROP_MAC_SRC_MATCH_EXTENDED_ADDRESSES = SPINEL_PROP_MAC_EXT__BEGIN + 5,
 
     /// MAC Blacklist
     /** Format: `A(t(E))`
@@ -875,12 +855,12 @@ typedef enum
      *
      * * `E`: EUI64 address of node
      */
-    SPINEL_PROP_MAC_BLACKLIST           = SPINEL_PROP_MAC_EXT__BEGIN + 6,
+    SPINEL_PROP_MAC_BLACKLIST = SPINEL_PROP_MAC_EXT__BEGIN + 6,
 
     /// MAC Blacklist Enabled Flag
     /** Format: `b`
      */
-    SPINEL_PROP_MAC_BLACKLIST_ENABLED   = SPINEL_PROP_MAC_EXT__BEGIN + 7,
+    SPINEL_PROP_MAC_BLACKLIST_ENABLED = SPINEL_PROP_MAC_EXT__BEGIN + 7,
 
     /// MAC Received Signal Strength Filter
     /** Format: `A(t(Ec))`
@@ -890,7 +870,7 @@ typedef enum
      * * `E`: Optional EUI64 address of node. Set default RSS if not included.
      * * `c`: Fixed RSS. OT_MAC_FILTER_FIXED_RSS_OVERRIDE_DISABLED(127) means not set.
      */
-    SPINEL_PROP_MAC_FIXED_RSS           = SPINEL_PROP_MAC_EXT__BEGIN + 8,
+    SPINEL_PROP_MAC_FIXED_RSS = SPINEL_PROP_MAC_EXT__BEGIN + 8,
 
     /// The CCA failure rate
     /** Format: `S`
@@ -900,21 +880,20 @@ typedef enum
      * Maximum value `0xffff` corresponding to 100% failure rate.
      *
      */
-    SPINEL_PROP_MAC_CCA_FAILURE_RATE    = SPINEL_PROP_MAC_EXT__BEGIN + 9,
+    SPINEL_PROP_MAC_CCA_FAILURE_RATE = SPINEL_PROP_MAC_EXT__BEGIN + 9,
 
-    SPINEL_PROP_MAC_EXT__END            = 0x1400,
+    SPINEL_PROP_MAC_EXT__END = 0x1400,
 
-    SPINEL_PROP_NET__BEGIN              = 0x40,
-    SPINEL_PROP_NET_SAVED               = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
-    SPINEL_PROP_NET_IF_UP               = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
-    SPINEL_PROP_NET_STACK_UP            = SPINEL_PROP_NET__BEGIN + 2, ///< [b]
-    SPINEL_PROP_NET_ROLE                = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
-    SPINEL_PROP_NET_NETWORK_NAME        = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
-    SPINEL_PROP_NET_XPANID              = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
-    SPINEL_PROP_NET_MASTER_KEY          = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
-    SPINEL_PROP_NET_KEY_SEQUENCE_COUNTER
-                                        = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
-    SPINEL_PROP_NET_PARTITION_ID        = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
+    SPINEL_PROP_NET__BEGIN               = 0x40,
+    SPINEL_PROP_NET_SAVED                = SPINEL_PROP_NET__BEGIN + 0, ///< [b]
+    SPINEL_PROP_NET_IF_UP                = SPINEL_PROP_NET__BEGIN + 1, ///< [b]
+    SPINEL_PROP_NET_STACK_UP             = SPINEL_PROP_NET__BEGIN + 2, ///< [b]
+    SPINEL_PROP_NET_ROLE                 = SPINEL_PROP_NET__BEGIN + 3, ///< [C]
+    SPINEL_PROP_NET_NETWORK_NAME         = SPINEL_PROP_NET__BEGIN + 4, ///< [U]
+    SPINEL_PROP_NET_XPANID               = SPINEL_PROP_NET__BEGIN + 5, ///< [D]
+    SPINEL_PROP_NET_MASTER_KEY           = SPINEL_PROP_NET__BEGIN + 6, ///< [D]
+    SPINEL_PROP_NET_KEY_SEQUENCE_COUNTER = SPINEL_PROP_NET__BEGIN + 7, ///< [L]
+    SPINEL_PROP_NET_PARTITION_ID         = SPINEL_PROP_NET__BEGIN + 8, ///< [L]
 
     /// Require Join Existing
     /** Format: `b`
@@ -934,19 +913,17 @@ typedef enum
      * The behavior of this property being set to `true` when
      * `PROP_NET_STACK_UP` is already set to `true` is undefined.
      */
-    SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING
-                                        = SPINEL_PROP_NET__BEGIN + 9,
+    SPINEL_PROP_NET_REQUIRE_JOIN_EXISTING = SPINEL_PROP_NET__BEGIN + 9,
 
-    SPINEL_PROP_NET_KEY_SWITCH_GUARDTIME
-                                        = SPINEL_PROP_NET__BEGIN + 10, ///< [L]
+    SPINEL_PROP_NET_KEY_SWITCH_GUARDTIME = SPINEL_PROP_NET__BEGIN + 10, ///< [L]
 
-    SPINEL_PROP_NET_PSKC                = SPINEL_PROP_NET__BEGIN + 11, ///< [D]
+    SPINEL_PROP_NET_PSKC = SPINEL_PROP_NET__BEGIN + 11, ///< [D]
 
-    SPINEL_PROP_NET__END                = 0x50,
+    SPINEL_PROP_NET__END = 0x50,
 
-    SPINEL_PROP_THREAD__BEGIN           = 0x50,
-    SPINEL_PROP_THREAD_LEADER_ADDR      = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
-    SPINEL_PROP_THREAD_PARENT           = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
+    SPINEL_PROP_THREAD__BEGIN      = 0x50,
+    SPINEL_PROP_THREAD_LEADER_ADDR = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
+    SPINEL_PROP_THREAD_PARENT      = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
 
     /// Thread Child Table
     /** Format: [A(t(ESLLCCcCc)] - Read only
@@ -964,18 +941,14 @@ typedef enum
      *  `c`: Last RSSI (in dBm)
      *
      */
-    SPINEL_PROP_THREAD_CHILD_TABLE      = SPINEL_PROP_THREAD__BEGIN + 2,
-    SPINEL_PROP_THREAD_LEADER_RID       = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
-    SPINEL_PROP_THREAD_LEADER_WEIGHT    = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
-    SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT
-                                        = SPINEL_PROP_THREAD__BEGIN + 5, ///< [C]
-    SPINEL_PROP_THREAD_NETWORK_DATA     = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
-    SPINEL_PROP_THREAD_NETWORK_DATA_VERSION
-                                        = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
-    SPINEL_PROP_THREAD_STABLE_NETWORK_DATA
-                                        = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
-    SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION
-                                        = SPINEL_PROP_THREAD__BEGIN + 9,  ///< [S]
+    SPINEL_PROP_THREAD_CHILD_TABLE                 = SPINEL_PROP_THREAD__BEGIN + 2,
+    SPINEL_PROP_THREAD_LEADER_RID                  = SPINEL_PROP_THREAD__BEGIN + 3, ///< [C]
+    SPINEL_PROP_THREAD_LEADER_WEIGHT               = SPINEL_PROP_THREAD__BEGIN + 4, ///< [C]
+    SPINEL_PROP_THREAD_LOCAL_LEADER_WEIGHT         = SPINEL_PROP_THREAD__BEGIN + 5, ///< [C]
+    SPINEL_PROP_THREAD_NETWORK_DATA                = SPINEL_PROP_THREAD__BEGIN + 6, ///< [D]
+    SPINEL_PROP_THREAD_NETWORK_DATA_VERSION        = SPINEL_PROP_THREAD__BEGIN + 7, ///< [S]
+    SPINEL_PROP_THREAD_STABLE_NETWORK_DATA         = SPINEL_PROP_THREAD__BEGIN + 8, ///< [D]
+    SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION = SPINEL_PROP_THREAD__BEGIN + 9, ///< [S]
 
     /// On-Mesh Prefixes
     /** Format: `A(t(6CbCbS))`
@@ -993,7 +966,7 @@ typedef enum
      *       This value is not used and ignored when adding an on-mesh prefix.
      *
      */
-    SPINEL_PROP_THREAD_ON_MESH_NETS     = SPINEL_PROP_THREAD__BEGIN + 10,
+    SPINEL_PROP_THREAD_ON_MESH_NETS = SPINEL_PROP_THREAD__BEGIN + 10,
 
     /// Off-mesh routes
     /** Format: [A(t(6CbCbb))]
@@ -1016,11 +989,10 @@ typedef enum
      *       This value is not used and ignored when adding a route.
      *
      */
-    SPINEL_PROP_THREAD_OFF_MESH_ROUTES  = SPINEL_PROP_THREAD__BEGIN + 11,
+    SPINEL_PROP_THREAD_OFF_MESH_ROUTES = SPINEL_PROP_THREAD__BEGIN + 11,
 
-    SPINEL_PROP_THREAD_ASSISTING_PORTS  = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
-    SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE
-                                        = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
+    SPINEL_PROP_THREAD_ASSISTING_PORTS             = SPINEL_PROP_THREAD__BEGIN + 12, ///< array(portn) [A(S)]
+    SPINEL_PROP_THREAD_ALLOW_LOCAL_NET_DATA_CHANGE = SPINEL_PROP_THREAD__BEGIN + 13, ///< [b]
 
     /// Thread Mode
     /** Format: `C`
@@ -1030,40 +1002,37 @@ typedef enum
      *  bitfield are defined by section 4.5.2 of the Thread
      *  specification.
      */
-    SPINEL_PROP_THREAD_MODE             = SPINEL_PROP_THREAD__BEGIN + 14,
-    SPINEL_PROP_THREAD__END             = 0x60,
+    SPINEL_PROP_THREAD_MODE = SPINEL_PROP_THREAD__BEGIN + 14,
+    SPINEL_PROP_THREAD__END = 0x60,
 
-    SPINEL_PROP_THREAD_EXT__BEGIN       = 0x1500,
+    SPINEL_PROP_THREAD_EXT__BEGIN = 0x1500,
 
     /// Thread Child Timeout
     /** Format: `L`
      *
      *  Used when operating in the Child role.
      */
-    SPINEL_PROP_THREAD_CHILD_TIMEOUT    = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
+    SPINEL_PROP_THREAD_CHILD_TIMEOUT = SPINEL_PROP_THREAD_EXT__BEGIN + 0,
 
     /// Thread RLOC16
     /** Format: `S`
      */
-    SPINEL_PROP_THREAD_RLOC16           = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
+    SPINEL_PROP_THREAD_RLOC16 = SPINEL_PROP_THREAD_EXT__BEGIN + 1,
 
     /// Thread Router Upgrade Threshold
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
+    SPINEL_PROP_THREAD_ROUTER_UPGRADE_THRESHOLD = SPINEL_PROP_THREAD_EXT__BEGIN + 2,
 
     /// Thread Context Reuse Delay
     /** Format: `L`
      */
-    SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
+    SPINEL_PROP_THREAD_CONTEXT_REUSE_DELAY = SPINEL_PROP_THREAD_EXT__BEGIN + 3,
 
     /// Thread Network ID Timeout
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
+    SPINEL_PROP_THREAD_NETWORK_ID_TIMEOUT = SPINEL_PROP_THREAD_EXT__BEGIN + 4,
 
     /// List of active thread router ids
     /** Format: `A(C)`
@@ -1072,38 +1041,32 @@ typedef enum
      * routerids, but may support CMD_REMOVE_VALUE when the node is
      * a leader.
      */
-    SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
+    SPINEL_PROP_THREAD_ACTIVE_ROUTER_IDS = SPINEL_PROP_THREAD_EXT__BEGIN + 5,
 
     /// Forward IPv6 packets that use RLOC16 addresses to HOST.
     /** Format: `b`
      */
-    SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
+    SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU = SPINEL_PROP_THREAD_EXT__BEGIN + 6,
 
     /// This property indicates whether or not the `Router Role` is enabled.
     /** Format `b`
      */
-    SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
+    SPINEL_PROP_THREAD_ROUTER_ROLE_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 7,
 
     /// Thread Router Downgrade Threshold
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 8,
+    SPINEL_PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD = SPINEL_PROP_THREAD_EXT__BEGIN + 8,
 
     /// Thread Router Selection Jitter
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 9,
+    SPINEL_PROP_THREAD_ROUTER_SELECTION_JITTER = SPINEL_PROP_THREAD_EXT__BEGIN + 9,
 
     /// Thread Preferred Router Id
     /** Format: `C` - Write only
      */
-    SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
+    SPINEL_PROP_THREAD_PREFERRED_ROUTER_ID = SPINEL_PROP_THREAD_EXT__BEGIN + 10,
 
     /// Thread Neighbor Table
     /** Format: `A(t(ESLCcCbLLc))` - Read only
@@ -1122,46 +1085,42 @@ typedef enum
      *  `c`: The last RSSI (in dBm)
      *
      */
-    SPINEL_PROP_THREAD_NEIGHBOR_TABLE   = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
+    SPINEL_PROP_THREAD_NEIGHBOR_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 11,
 
     /// Thread Max Child Count
     /** Format: `C`
      */
-    SPINEL_PROP_THREAD_CHILD_COUNT_MAX  = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
+    SPINEL_PROP_THREAD_CHILD_COUNT_MAX = SPINEL_PROP_THREAD_EXT__BEGIN + 12,
 
     /// Leader network data
     /** Format: `D` - Read only
      */
-    SPINEL_PROP_THREAD_LEADER_NETWORK_DATA
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
+    SPINEL_PROP_THREAD_LEADER_NETWORK_DATA = SPINEL_PROP_THREAD_EXT__BEGIN + 13,
 
     /// Stable leader network data
     /** Format: `D` - Read only
      */
-    SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
+    SPINEL_PROP_THREAD_STABLE_LEADER_NETWORK_DATA = SPINEL_PROP_THREAD_EXT__BEGIN + 14,
 
     /// Thread joiner data
     /** Format `A(T(ULE))`
-    *  PSKd, joiner timeout, eui64 (optional)
-    */
-    SPINEL_PROP_THREAD_JOINERS          = SPINEL_PROP_THREAD_EXT__BEGIN + 15,
+     *  PSKd, joiner timeout, eui64 (optional)
+     */
+    SPINEL_PROP_THREAD_JOINERS = SPINEL_PROP_THREAD_EXT__BEGIN + 15,
 
     /// Thread commissioner enable
     /** Format `b`
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_THREAD_COMMISSIONER_ENABLED
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 16,
+    SPINEL_PROP_THREAD_COMMISSIONER_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 16,
 
     /// Thread TMF proxy enable
     /** Format `b`
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_THREAD_TMF_PROXY_ENABLED
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
+    SPINEL_PROP_THREAD_TMF_PROXY_ENABLED = SPINEL_PROP_THREAD_EXT__BEGIN + 17,
 
     /// Thread TMF proxy stream
     /** Format `dSS`
@@ -1175,16 +1134,14 @@ typedef enum
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 19,
+    SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG = SPINEL_PROP_THREAD_EXT__BEGIN + 19,
 
     /// Enable EUI64 filtering for discovery scan operation.
     /** Format `b`
      *
      * Default value is `false`
      */
-    SPINEL_PROP_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 20,
+    SPINEL_PROP_THREAD_DISCOVERY_SCAN_ENABLE_FILTERING = SPINEL_PROP_THREAD_EXT__BEGIN + 20,
 
     /// PANID used for Discovery scan operation (used for PANID filtering).
     /** Format: `S`
@@ -1192,8 +1149,7 @@ typedef enum
      * Default value is 0xffff (Broadcast PAN) to disable PANID filtering
      *
      */
-    SPINEL_PROP_THREAD_DISCOVERY_SCAN_PANID
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 21,
+    SPINEL_PROP_THREAD_DISCOVERY_SCAN_PANID = SPINEL_PROP_THREAD_EXT__BEGIN + 21,
 
     /// Thread (out of band) steering data for MLE Discovery Response.
     /** Format `E` - Write only
@@ -1207,7 +1163,7 @@ typedef enum
      *  - A specific EUI64 which is then added to current steering data/bloom filter.
      *
      */
-    SPINEL_PROP_THREAD_STEERING_DATA    = SPINEL_PROP_THREAD_EXT__BEGIN + 22,
+    SPINEL_PROP_THREAD_STEERING_DATA = SPINEL_PROP_THREAD_EXT__BEGIN + 22,
 
     /// Thread Router Table.
     /** Format: `A(t(ESCCCCCCb)` - Read only
@@ -1225,7 +1181,7 @@ typedef enum
      *  `b`: Link established with Router ID or not.
      *
      */
-    SPINEL_PROP_THREAD_ROUTER_TABLE     = SPINEL_PROP_THREAD_EXT__BEGIN + 23,
+    SPINEL_PROP_THREAD_ROUTER_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 23,
 
     /// Thread Active Operational Dataset
     /** Format: `A(t(iD))` - Read-Write
@@ -1256,7 +1212,7 @@ typedef enum
      *   SPINEL_PROP_DATASET_SECURITY_POLICY
      *
      */
-    SPINEL_PROP_THREAD_ACTIVE_DATASET   = SPINEL_PROP_THREAD_EXT__BEGIN + 24,
+    SPINEL_PROP_THREAD_ACTIVE_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 24,
 
     /// Thread Pending Operational Dataset
     /** Format: `A(t(iD))` - Read-Write
@@ -1272,7 +1228,7 @@ typedef enum
      *   SPINEL_PROP_DATASET_DELAY_TIMER
      *
      */
-    SPINEL_PROP_THREAD_PENDING_DATASET  = SPINEL_PROP_THREAD_EXT__BEGIN + 25,
+    SPINEL_PROP_THREAD_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 25,
 
     /// Thread Active Operational Dataset (MGMT send)
     /** Format: `A(t(iD))` - Write only
@@ -1289,8 +1245,7 @@ typedef enum
      *    SPINEL_PROP_DATASET_RAW_TLVS
      *
      */
-    SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 26,
+    SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 26,
 
     /// Thread Pending Operational Dataset (MGMT send)
     /** Format: `A(t(iD))` - Write only
@@ -1303,8 +1258,7 @@ typedef enum
      *    SPINEL_PROP_DATASET_RAW_TLVS
      *
      */
-    SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 27,
+    SPINEL_PROP_THREAD_MGMT_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 27,
 
     /// Operational Dataset Active Timestamp
     /** Format: `X` - No direct read or write
@@ -1317,8 +1271,7 @@ typedef enum
      *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
      *
      */
-    SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 28,
+    SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP = SPINEL_PROP_THREAD_EXT__BEGIN + 28,
 
     /// Operational Dataset Pending Timestamp
     /** Format: `X` - No direct read or write
@@ -1329,8 +1282,7 @@ typedef enum
      *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
      *
      */
-    SPINEL_PROP_DATASET_PENDING_TIMESTAMP
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 29,
+    SPINEL_PROP_DATASET_PENDING_TIMESTAMP = SPINEL_PROP_THREAD_EXT__BEGIN + 29,
 
     /// Operational Dataset Delay Timer
     /** Format: `L` - No direct read or write
@@ -1344,7 +1296,7 @@ typedef enum
      *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
      *
      */
-    SPINEL_PROP_DATASET_DELAY_TIMER     = SPINEL_PROP_THREAD_EXT__BEGIN + 30,
+    SPINEL_PROP_DATASET_DELAY_TIMER = SPINEL_PROP_THREAD_EXT__BEGIN + 30,
 
     /// Operational Dataset Security Policy
     /** Format: `SC` - No direct read or write
@@ -1374,7 +1326,7 @@ typedef enum
      *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
      *
      */
-    SPINEL_PROP_DATASET_RAW_TLVS        = SPINEL_PROP_THREAD_EXT__BEGIN + 32,
+    SPINEL_PROP_DATASET_RAW_TLVS = SPINEL_PROP_THREAD_EXT__BEGIN + 32,
 
     /// Child table addresses
     /** Format: `A(t(ESA(6)))` - Read only
@@ -1389,8 +1341,7 @@ typedef enum
      *  `A(6)`: List of IPv6 addresses registered by the child (if any)
      *
      */
-    SPINEL_PROP_THREAD_CHILD_TABLE_ADDRESSES
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 33,
+    SPINEL_PROP_THREAD_CHILD_TABLE_ADDRESSES = SPINEL_PROP_THREAD_EXT__BEGIN + 33,
 
     /// Neighbor Table Frame and Message Error Rates
     /** Format: `A(t(ESSScc))`
@@ -1414,8 +1365,7 @@ typedef enum
      *  `c`: Last RSSI (in dBm)
      *
      */
-    SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
+    SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
 
     /// EID (Endpoint Identifier) IPv6 Address Cache Table
     /** Format `A(t(6SC))`
@@ -1429,15 +1379,14 @@ typedef enum
      *  `C` : Age (order of use, 0 indicates most recently used entry)
      *
      */
-    SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE
-                                        = SPINEL_PROP_THREAD_EXT__BEGIN + 35,
+    SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 35,
 
-    SPINEL_PROP_THREAD_EXT__END         = 0x1600,
+    SPINEL_PROP_THREAD_EXT__END = 0x1600,
 
-    SPINEL_PROP_IPV6__BEGIN             = 0x60,
-    SPINEL_PROP_IPV6_LL_ADDR            = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
-    SPINEL_PROP_IPV6_ML_ADDR            = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
-    SPINEL_PROP_IPV6_ML_PREFIX          = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
+    SPINEL_PROP_IPV6__BEGIN    = 0x60,
+    SPINEL_PROP_IPV6_LL_ADDR   = SPINEL_PROP_IPV6__BEGIN + 0, ///< [6]
+    SPINEL_PROP_IPV6_ML_ADDR   = SPINEL_PROP_IPV6__BEGIN + 1, ///< [6C]
+    SPINEL_PROP_IPV6_ML_PREFIX = SPINEL_PROP_IPV6__BEGIN + 2, ///< [6C]
 
     /// IPv6 Address Table
     /** Format: `A(t(6CLLC))`
@@ -1453,9 +1402,10 @@ typedef enum
      *  `C`: Flags
      *
      */
-    SPINEL_PROP_IPV6_ADDRESS_TABLE      = SPINEL_PROP_IPV6__BEGIN + 3,
+    SPINEL_PROP_IPV6_ADDRESS_TABLE = SPINEL_PROP_IPV6__BEGIN + 3,
 
-    SPINEL_PROP_IPV6_ROUTE_TABLE        = SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
+    SPINEL_PROP_IPV6_ROUTE_TABLE =
+        SPINEL_PROP_IPV6__BEGIN + 4, ///< array(ipv6prefix,prefixlen,iface,flags) [A(t(6CCC))]
 
     /// IPv6 ICMP Ping Offload
     /** Format: `b`
@@ -1465,10 +1415,9 @@ typedef enum
      *
      * Default value is `false`.
      */
-    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD  = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD = SPINEL_PROP_IPV6__BEGIN + 5, ///< [b]
 
-    SPINEL_PROP_IPV6_MULTICAST_ADDRESS_TABLE
-                                        = SPINEL_PROP_IPV6__BEGIN + 6, ///< [A(t(6))]
+    SPINEL_PROP_IPV6_MULTICAST_ADDRESS_TABLE = SPINEL_PROP_IPV6__BEGIN + 6, ///< [A(t(6))]
 
     /// IPv6 ICMP Ping Offload
     /** Format: `C`
@@ -1481,16 +1430,15 @@ typedef enum
      *
      * Default value is `NET_IPV6_ICMP_PING_OFFLOAD_DISABLED`.
      */
-    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE
-                                        = SPINEL_PROP_IPV6__BEGIN + 7, ///< [b]
+    SPINEL_PROP_IPV6_ICMP_PING_OFFLOAD_MODE = SPINEL_PROP_IPV6__BEGIN + 7, ///< [b]
 
-    SPINEL_PROP_IPV6__END               = 0x70,
+    SPINEL_PROP_IPV6__END = 0x70,
 
-    SPINEL_PROP_STREAM__BEGIN           = 0x70,
-    SPINEL_PROP_STREAM_DEBUG            = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
-    SPINEL_PROP_STREAM_RAW              = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
-    SPINEL_PROP_STREAM_NET              = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
-    SPINEL_PROP_STREAM_NET_INSECURE     = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
+    SPINEL_PROP_STREAM__BEGIN       = 0x70,
+    SPINEL_PROP_STREAM_DEBUG        = SPINEL_PROP_STREAM__BEGIN + 0, ///< [U]
+    SPINEL_PROP_STREAM_RAW          = SPINEL_PROP_STREAM__BEGIN + 1, ///< [dD]
+    SPINEL_PROP_STREAM_NET          = SPINEL_PROP_STREAM__BEGIN + 2, ///< [dD]
+    SPINEL_PROP_STREAM_NET_INSECURE = SPINEL_PROP_STREAM__BEGIN + 3, ///< [dD]
 
     /// Log Stream
     /** Format: `UD` (stream, read only)
@@ -1514,10 +1462,10 @@ typedef enum
      *         `SPINEL_NCP_LOG_REGION_<region>).
      *
      */
-    SPINEL_PROP_STREAM_LOG              = SPINEL_PROP_STREAM__BEGIN + 4,
-    SPINEL_PROP_STREAM__END             = 0x80,
+    SPINEL_PROP_STREAM_LOG  = SPINEL_PROP_STREAM__BEGIN + 4,
+    SPINEL_PROP_STREAM__END = 0x80,
 
-    SPINEL_PROP_OPENTHREAD__BEGIN       = 0x1900,
+    SPINEL_PROP_OPENTHREAD__BEGIN = 0x1900,
 
     /// Channel Manager - Channel Change New Channel
     /** Format: `C` (read-write)
@@ -1532,8 +1480,7 @@ typedef enum
      * (previously requested) channel change.
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 0,
+    SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL = SPINEL_PROP_OPENTHREAD__BEGIN + 0,
 
     /// Channel Manager - Channel Change Delay
     /** Format 'S'
@@ -1549,7 +1496,7 @@ typedef enum
      * network.
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_DELAY   = SPINEL_PROP_OPENTHREAD__BEGIN + 1,
+    SPINEL_PROP_CHANNEL_MANAGER_DELAY = SPINEL_PROP_OPENTHREAD__BEGIN + 1,
 
     /// Channel Manager Supported Channels
     /** Format 'A(C)'
@@ -1559,8 +1506,7 @@ typedef enum
      * This property specifies the list of supported channels.
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_SUPPORTED_CHANNELS
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 2,
+    SPINEL_PROP_CHANNEL_MANAGER_SUPPORTED_CHANNELS = SPINEL_PROP_OPENTHREAD__BEGIN + 2,
 
     /// Channel Manager Favored Channels
     /** Format 'A(C)'
@@ -1570,8 +1516,7 @@ typedef enum
      * This property specifies the list of favored channels (when `ChannelManager` is asked to select channel)
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_FAVORED_CHANNELS
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 3,
+    SPINEL_PROP_CHANNEL_MANAGER_FAVORED_CHANNELS = SPINEL_PROP_OPENTHREAD__BEGIN + 3,
 
     /// Channel Manager Channel Select Trigger
     /** Format 'b'
@@ -1597,8 +1542,7 @@ typedef enum
      * Reading this property always yields `false`.
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_CHANNEL_SELECT
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 4,
+    SPINEL_PROP_CHANNEL_MANAGER_CHANNEL_SELECT = SPINEL_PROP_OPENTHREAD__BEGIN + 4,
 
     /// Channel Manager Auto Channel Selection Enabled
     /** Format 'b'
@@ -1611,8 +1555,7 @@ typedef enum
      * is specified by `SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL`.
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_ENABLED
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 5,
+    SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_ENABLED = SPINEL_PROP_OPENTHREAD__BEGIN + 5,
 
     /// Channel Manager Auto Channel Selection Interval
     /** Format 'L'
@@ -1623,8 +1566,7 @@ typedef enum
      * This property specifies the auto-channel-selection check interval (in seconds).
      *
      */
-    SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 6,
+    SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL = SPINEL_PROP_OPENTHREAD__BEGIN + 6,
 
     /// Thread network time.
     /** Format: `Xc` - Read only
@@ -1635,8 +1577,7 @@ typedef enum
      *  `c`: Time synchronization status.
      *
      */
-    SPINEL_PROP_THREAD_NETWORK_TIME
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 7,
+    SPINEL_PROP_THREAD_NETWORK_TIME = SPINEL_PROP_OPENTHREAD__BEGIN + 7,
 
     /// Thread time synchronization period
     /** Format: `S` - Read-Write
@@ -1646,8 +1587,7 @@ typedef enum
      *  `S`: Time synchronization period, in seconds.
      *
      */
-    SPINEL_PROP_TIME_SYNC_PERIOD
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 8,
+    SPINEL_PROP_TIME_SYNC_PERIOD = SPINEL_PROP_OPENTHREAD__BEGIN + 8,
 
     /// Thread Time synchronization XTAL accuracy threshold for Router
     /** Format: `S` - Read-Write
@@ -1657,11 +1597,9 @@ typedef enum
      *  `S`: The XTAL accuracy threshold for Router, in PPM.
      *
      */
-    SPINEL_PROP_TIME_SYNC_XTAL_THRESHOLD
-                                        = SPINEL_PROP_OPENTHREAD__BEGIN + 9,
+    SPINEL_PROP_TIME_SYNC_XTAL_THRESHOLD = SPINEL_PROP_OPENTHREAD__BEGIN + 9,
 
-
-    SPINEL_PROP_OPENTHREAD__END         = 0x2000,
+    SPINEL_PROP_OPENTHREAD__END = 0x2000,
 
     /// UART Bitrate
     /** Format: `L`
@@ -1685,7 +1623,7 @@ typedef enum
      *  the host, all further frames will be transmitted at the new
      *  bitrate.
      */
-    SPINEL_PROP_UART_BITRATE            = 0x100,
+    SPINEL_PROP_UART_BITRATE = 0x100,
 
     /// UART Software Flow Control
     /** Format: `b`
@@ -1698,9 +1636,9 @@ typedef enum
      *  This property is only implemented when a UART is being
      *  used for Spinel. This property is optional.
      */
-    SPINEL_PROP_UART_XON_XOFF           = 0x101,
+    SPINEL_PROP_UART_XON_XOFF = 0x101,
 
-    SPINEL_PROP_15_4_PIB__BEGIN         = 1024,
+    SPINEL_PROP_15_4_PIB__BEGIN = 1024,
     // For direct access to the 802.15.4 PID.
     // Individual registers are fetched using
     // `SPINEL_PROP_15_4_PIB__BEGIN+[PIB_IDENTIFIER]`
@@ -1709,202 +1647,198 @@ typedef enum
     // For brevity, the entire 802.15.4 PIB space is
     // not defined here, but a few choice attributes
     // are defined for illustration and convenience.
-    SPINEL_PROP_15_4_PIB_PHY_CHANNELS_SUPPORTED
-                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x01, ///< [A(L)]
-    SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE
-                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
-    SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED
-                                        = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
-    SPINEL_PROP_15_4_PIB__END           = 1280,
+    SPINEL_PROP_15_4_PIB_PHY_CHANNELS_SUPPORTED = SPINEL_PROP_15_4_PIB__BEGIN + 0x01, ///< [A(L)]
+    SPINEL_PROP_15_4_PIB_MAC_PROMISCUOUS_MODE   = SPINEL_PROP_15_4_PIB__BEGIN + 0x51, ///< [b]
+    SPINEL_PROP_15_4_PIB_MAC_SECURITY_ENABLED   = SPINEL_PROP_15_4_PIB__BEGIN + 0x5d, ///< [b]
+    SPINEL_PROP_15_4_PIB__END                   = 1280,
 
-    SPINEL_PROP_CNTR__BEGIN             = 1280,
+    SPINEL_PROP_CNTR__BEGIN = 1280,
 
     /// Counter reset behavior
     /** Format: `C`
      *  Writing a '1' to this property will reset
      *  all of the counters to zero. */
-    SPINEL_PROP_CNTR_RESET              = SPINEL_PROP_CNTR__BEGIN + 0,
+    SPINEL_PROP_CNTR_RESET = SPINEL_PROP_CNTR__BEGIN + 0,
 
     /// The total number of transmissions.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_TOTAL       = SPINEL_PROP_CNTR__BEGIN + 1,
+    SPINEL_PROP_CNTR_TX_PKT_TOTAL = SPINEL_PROP_CNTR__BEGIN + 1,
 
     /// The number of transmissions with ack request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ     = SPINEL_PROP_CNTR__BEGIN + 2,
+    SPINEL_PROP_CNTR_TX_PKT_ACK_REQ = SPINEL_PROP_CNTR__BEGIN + 2,
 
     /// The number of transmissions that were acked.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_ACKED       = SPINEL_PROP_CNTR__BEGIN + 3,
+    SPINEL_PROP_CNTR_TX_PKT_ACKED = SPINEL_PROP_CNTR__BEGIN + 3,
 
     /// The number of transmissions without ack request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ  = SPINEL_PROP_CNTR__BEGIN + 4,
+    SPINEL_PROP_CNTR_TX_PKT_NO_ACK_REQ = SPINEL_PROP_CNTR__BEGIN + 4,
 
     /// The number of transmitted data.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_DATA        = SPINEL_PROP_CNTR__BEGIN + 5,
+    SPINEL_PROP_CNTR_TX_PKT_DATA = SPINEL_PROP_CNTR__BEGIN + 5,
 
     /// The number of transmitted data poll.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL   = SPINEL_PROP_CNTR__BEGIN + 6,
+    SPINEL_PROP_CNTR_TX_PKT_DATA_POLL = SPINEL_PROP_CNTR__BEGIN + 6,
 
     /// The number of transmitted beacon.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BEACON      = SPINEL_PROP_CNTR__BEGIN + 7,
+    SPINEL_PROP_CNTR_TX_PKT_BEACON = SPINEL_PROP_CNTR__BEGIN + 7,
 
     /// The number of transmitted beacon request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ  = SPINEL_PROP_CNTR__BEGIN + 8,
+    SPINEL_PROP_CNTR_TX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 8,
 
     /// The number of transmitted other types of frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_OTHER       = SPINEL_PROP_CNTR__BEGIN + 9,
+    SPINEL_PROP_CNTR_TX_PKT_OTHER = SPINEL_PROP_CNTR__BEGIN + 9,
 
     /// The number of retransmission times.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_RETRY       = SPINEL_PROP_CNTR__BEGIN + 10,
+    SPINEL_PROP_CNTR_TX_PKT_RETRY = SPINEL_PROP_CNTR__BEGIN + 10,
 
     /// The number of CCA failure times.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_ERR_CCA         = SPINEL_PROP_CNTR__BEGIN + 11,
+    SPINEL_PROP_CNTR_TX_ERR_CCA = SPINEL_PROP_CNTR__BEGIN + 11,
 
     /// The number of unicast packets transmitted.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_UNICAST     = SPINEL_PROP_CNTR__BEGIN + 12,
+    SPINEL_PROP_CNTR_TX_PKT_UNICAST = SPINEL_PROP_CNTR__BEGIN + 12,
 
     /// The number of broadcast packets transmitted.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_PKT_BROADCAST   = SPINEL_PROP_CNTR__BEGIN + 13,
+    SPINEL_PROP_CNTR_TX_PKT_BROADCAST = SPINEL_PROP_CNTR__BEGIN + 13,
 
     /// The number of frame transmission failures due to abort error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_ERR_ABORT       = SPINEL_PROP_CNTR__BEGIN + 14,
+    SPINEL_PROP_CNTR_TX_ERR_ABORT = SPINEL_PROP_CNTR__BEGIN + 14,
 
     /// The total number of received packets.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_TOTAL       = SPINEL_PROP_CNTR__BEGIN + 100,
+    SPINEL_PROP_CNTR_RX_PKT_TOTAL = SPINEL_PROP_CNTR__BEGIN + 100,
 
     /// The number of received data.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DATA        = SPINEL_PROP_CNTR__BEGIN + 101,
+    SPINEL_PROP_CNTR_RX_PKT_DATA = SPINEL_PROP_CNTR__BEGIN + 101,
 
     /// The number of received data poll.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL   = SPINEL_PROP_CNTR__BEGIN + 102,
+    SPINEL_PROP_CNTR_RX_PKT_DATA_POLL = SPINEL_PROP_CNTR__BEGIN + 102,
 
     /// The number of received beacon.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BEACON      = SPINEL_PROP_CNTR__BEGIN + 103,
+    SPINEL_PROP_CNTR_RX_PKT_BEACON = SPINEL_PROP_CNTR__BEGIN + 103,
 
     /// The number of received beacon request.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ  = SPINEL_PROP_CNTR__BEGIN + 104,
+    SPINEL_PROP_CNTR_RX_PKT_BEACON_REQ = SPINEL_PROP_CNTR__BEGIN + 104,
 
     /// The number of received other types of frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_OTHER       = SPINEL_PROP_CNTR__BEGIN + 105,
+    SPINEL_PROP_CNTR_RX_PKT_OTHER = SPINEL_PROP_CNTR__BEGIN + 105,
 
     /// The number of received packets filtered by whitelist.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_FILT_WL     = SPINEL_PROP_CNTR__BEGIN + 106,
+    SPINEL_PROP_CNTR_RX_PKT_FILT_WL = SPINEL_PROP_CNTR__BEGIN + 106,
 
     /// The number of received packets filtered by destination check.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_FILT_DA     = SPINEL_PROP_CNTR__BEGIN + 107,
+    SPINEL_PROP_CNTR_RX_PKT_FILT_DA = SPINEL_PROP_CNTR__BEGIN + 107,
 
     /// The number of received packets that are empty.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_EMPTY       = SPINEL_PROP_CNTR__BEGIN + 108,
+    SPINEL_PROP_CNTR_RX_ERR_EMPTY = SPINEL_PROP_CNTR__BEGIN + 108,
 
     /// The number of received packets from an unknown neighbor.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR    = SPINEL_PROP_CNTR__BEGIN + 109,
+    SPINEL_PROP_CNTR_RX_ERR_UKWN_NBR = SPINEL_PROP_CNTR__BEGIN + 109,
 
     /// The number of received packets whose source address is invalid.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR  = SPINEL_PROP_CNTR__BEGIN + 110,
+    SPINEL_PROP_CNTR_RX_ERR_NVLD_SADDR = SPINEL_PROP_CNTR__BEGIN + 110,
 
     /// The number of received packets with a security error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_SECURITY    = SPINEL_PROP_CNTR__BEGIN + 111,
+    SPINEL_PROP_CNTR_RX_ERR_SECURITY = SPINEL_PROP_CNTR__BEGIN + 111,
 
     /// The number of received packets with a checksum error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS     = SPINEL_PROP_CNTR__BEGIN + 112,
+    SPINEL_PROP_CNTR_RX_ERR_BAD_FCS = SPINEL_PROP_CNTR__BEGIN + 112,
 
     /// The number of received packets with other errors.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_ERR_OTHER       = SPINEL_PROP_CNTR__BEGIN + 113,
+    SPINEL_PROP_CNTR_RX_ERR_OTHER = SPINEL_PROP_CNTR__BEGIN + 113,
 
     /// The number of received duplicated.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_DUP         = SPINEL_PROP_CNTR__BEGIN + 114,
+    SPINEL_PROP_CNTR_RX_PKT_DUP = SPINEL_PROP_CNTR__BEGIN + 114,
 
     /// The number of unicast packets received.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_UNICAST     = SPINEL_PROP_CNTR__BEGIN + 115,
+    SPINEL_PROP_CNTR_RX_PKT_UNICAST = SPINEL_PROP_CNTR__BEGIN + 115,
 
     /// The number of broadcast packets received.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_PKT_BROADCAST   = SPINEL_PROP_CNTR__BEGIN + 116,
+    SPINEL_PROP_CNTR_RX_PKT_BROADCAST = SPINEL_PROP_CNTR__BEGIN + 116,
 
     /// The total number of secure transmitted IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 200,
+    SPINEL_PROP_CNTR_TX_IP_SEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 200,
 
     /// The total number of insecure transmitted IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL  = SPINEL_PROP_CNTR__BEGIN + 201,
+    SPINEL_PROP_CNTR_TX_IP_INSEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 201,
 
     /// The number of dropped (not transmitted) IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_IP_DROPPED      = SPINEL_PROP_CNTR__BEGIN + 202,
+    SPINEL_PROP_CNTR_TX_IP_DROPPED = SPINEL_PROP_CNTR__BEGIN + 202,
 
     /// The total number of secure received IP message.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_SEC_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 203,
+    SPINEL_PROP_CNTR_RX_IP_SEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 203,
 
     /// The total number of insecure received IP message.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_INSEC_TOTAL  = SPINEL_PROP_CNTR__BEGIN + 204,
+    SPINEL_PROP_CNTR_RX_IP_INSEC_TOTAL = SPINEL_PROP_CNTR__BEGIN + 204,
 
     /// The number of dropped received IP messages.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_IP_DROPPED      = SPINEL_PROP_CNTR__BEGIN + 205,
+    SPINEL_PROP_CNTR_RX_IP_DROPPED = SPINEL_PROP_CNTR__BEGIN + 205,
 
     /// The number of transmitted spinel frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_TX_SPINEL_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 300,
+    SPINEL_PROP_CNTR_TX_SPINEL_TOTAL = SPINEL_PROP_CNTR__BEGIN + 300,
 
     /// The number of received spinel frames.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_SPINEL_TOTAL    = SPINEL_PROP_CNTR__BEGIN + 301,
+    SPINEL_PROP_CNTR_RX_SPINEL_TOTAL = SPINEL_PROP_CNTR__BEGIN + 301,
 
     /// The number of received spinel frames with error.
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_SPINEL_ERR      = SPINEL_PROP_CNTR__BEGIN + 302,
+    SPINEL_PROP_CNTR_RX_SPINEL_ERR = SPINEL_PROP_CNTR__BEGIN + 302,
 
     /// Number of out of order received spinel frames (tid increase by more than 1).
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID
-                                        = SPINEL_PROP_CNTR__BEGIN + 303,
+    SPINEL_PROP_CNTR_RX_SPINEL_OUT_OF_ORDER_TID = SPINEL_PROP_CNTR__BEGIN + 303,
 
     /// The number of successful Tx IP packets
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_IP_TX_SUCCESS      = SPINEL_PROP_CNTR__BEGIN + 304,
+    SPINEL_PROP_CNTR_IP_TX_SUCCESS = SPINEL_PROP_CNTR__BEGIN + 304,
 
     /// The number of successful Rx IP packets
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_IP_RX_SUCCESS      = SPINEL_PROP_CNTR__BEGIN + 305,
+    SPINEL_PROP_CNTR_IP_RX_SUCCESS = SPINEL_PROP_CNTR__BEGIN + 305,
 
     /// The number of failed Tx IP packets
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_IP_TX_FAILURE      = SPINEL_PROP_CNTR__BEGIN + 306,
+    SPINEL_PROP_CNTR_IP_TX_FAILURE = SPINEL_PROP_CNTR__BEGIN + 306,
 
     /// The number of failed Rx IP packets
     /** Format: `L` (Read-only) */
-    SPINEL_PROP_CNTR_IP_RX_FAILURE      = SPINEL_PROP_CNTR__BEGIN + 307,
+    SPINEL_PROP_CNTR_IP_RX_FAILURE = SPINEL_PROP_CNTR__BEGIN + 307,
 
     /// The message buffer counter info
     /** Format: `SSSSSSSSSSSSSSSS` (Read-only)
@@ -1925,7 +1859,7 @@ typedef enum
      *      `S`, (CoapMessages)           The number of messages in the CoAP send queue.
      *      `S`, (CoapBuffers)            The number of buffers in the CoAP send queue.
      */
-    SPINEL_PROP_MSG_BUFFER_COUNTERS     = SPINEL_PROP_CNTR__BEGIN + 400,
+    SPINEL_PROP_MSG_BUFFER_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 400,
 
     /// All MAC related counters.
     /** Format: t(A(L))t(A(L))  (Read-only)
@@ -1972,28 +1906,27 @@ typedef enum
      *   'L': RxErrFcs             (The number of received packets with FCS error).
      *   'L': RxErrOther           (The number of received packets with other error).
      */
-    SPINEL_PROP_CNTR_ALL_MAC_COUNTERS   =  SPINEL_PROP_CNTR__BEGIN + 401,
+    SPINEL_PROP_CNTR_ALL_MAC_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 401,
 
-    SPINEL_PROP_CNTR__END               = 2048,
+    SPINEL_PROP_CNTR__END = 2048,
 
-    SPINEL_PROP_NEST__BEGIN             = 15296,
-    SPINEL_PROP_NEST_STREAM_MFG         = SPINEL_PROP_NEST__BEGIN + 0,
+    SPINEL_PROP_NEST__BEGIN     = 15296,
+    SPINEL_PROP_NEST_STREAM_MFG = SPINEL_PROP_NEST__BEGIN + 0,
 
     /// The legacy network ULA prefix (8 bytes)
     /** Format: 'D' */
-    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX  = SPINEL_PROP_NEST__BEGIN + 1,
+    SPINEL_PROP_NEST_LEGACY_ULA_PREFIX = SPINEL_PROP_NEST__BEGIN + 1,
 
     /// The EUI64 of last node joined using legacy protocol (if none, all zero EUI64 is returned).
     /** Format: 'E' */
-    SPINEL_PROP_NEST_LEGACY_LAST_NODE_JOINED
-                                        = SPINEL_PROP_NEST__BEGIN + 2,
+    SPINEL_PROP_NEST_LEGACY_LAST_NODE_JOINED = SPINEL_PROP_NEST__BEGIN + 2,
 
-    SPINEL_PROP_NEST__END               = 15360,
+    SPINEL_PROP_NEST__END = 15360,
 
-    SPINEL_PROP_VENDOR__BEGIN           = 15360,
-    SPINEL_PROP_VENDOR__END             = 16384,
+    SPINEL_PROP_VENDOR__BEGIN = 15360,
+    SPINEL_PROP_VENDOR__END   = 16384,
 
-    SPINEL_PROP_DEBUG__BEGIN            = 16384,
+    SPINEL_PROP_DEBUG__BEGIN = 16384,
 
     /// Testing platform assert
     /** Format: 'b' (read-only)
@@ -2003,11 +1936,11 @@ typedef enum
      * boolean is returned in response.
      *
      */
-    SPINEL_PROP_DEBUG_TEST_ASSERT       = SPINEL_PROP_DEBUG__BEGIN + 0,
+    SPINEL_PROP_DEBUG_TEST_ASSERT = SPINEL_PROP_DEBUG__BEGIN + 0,
 
     /// The NCP log level.
     /** Format: `C` */
-    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL     = SPINEL_PROP_DEBUG__BEGIN + 1,
+    SPINEL_PROP_DEBUG_NCP_LOG_LEVEL = SPINEL_PROP_DEBUG__BEGIN + 1,
 
     /// Testing platform watchdog
     /** Format: Empty  (read-only)
@@ -2017,136 +1950,138 @@ typedef enum
      * This is intended for testing the watchdog functionality on the underlying platform/NCP.
      *
      */
-    SPINEL_PROP_DEBUG_TEST_WATCHDOG     = SPINEL_PROP_DEBUG__BEGIN + 2,
+    SPINEL_PROP_DEBUG_TEST_WATCHDOG = SPINEL_PROP_DEBUG__BEGIN + 2,
 
-    SPINEL_PROP_DEBUG__END              = 17408,
+    SPINEL_PROP_DEBUG__END = 17408,
 
-    SPINEL_PROP_EXPERIMENTAL__BEGIN     = 2000000,
-    SPINEL_PROP_EXPERIMENTAL__END       = 2097152,
+    SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
+    SPINEL_PROP_EXPERIMENTAL__END   = 2097152,
 } spinel_prop_key_t;
 
 // ----------------------------------------------------------------------------
 
-#define SPINEL_HEADER_FLAG              0x80
+#define SPINEL_HEADER_FLAG 0x80
 
-#define SPINEL_HEADER_TID_SHIFT         0
-#define SPINEL_HEADER_TID_MASK          (15 << SPINEL_HEADER_TID_SHIFT)
+#define SPINEL_HEADER_TID_SHIFT 0
+#define SPINEL_HEADER_TID_MASK (15 << SPINEL_HEADER_TID_SHIFT)
 
-#define SPINEL_HEADER_IID_SHIFT         4
-#define SPINEL_HEADER_IID_MASK          (3 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_SHIFT 4
+#define SPINEL_HEADER_IID_MASK (3 << SPINEL_HEADER_IID_SHIFT)
 
-#define SPINEL_HEADER_IID_0             (0 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_1             (1 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_2             (2 << SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_IID_3             (3 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_0 (0 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_1 (1 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_2 (2 << SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_IID_3 (3 << SPINEL_HEADER_IID_SHIFT)
 
-#define SPINEL_HEADER_GET_IID(x)        (((x) & SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
-#define SPINEL_HEADER_GET_TID(x)        (spinel_tid_t)(((x)&SPINEL_HEADER_TID_MASK)>>SPINEL_HEADER_TID_SHIFT)
+#define SPINEL_HEADER_GET_IID(x) (((x)&SPINEL_HEADER_IID_MASK) >> SPINEL_HEADER_IID_SHIFT)
+#define SPINEL_HEADER_GET_TID(x) (spinel_tid_t)(((x)&SPINEL_HEADER_TID_MASK) >> SPINEL_HEADER_TID_SHIFT)
 
-#define SPINEL_GET_NEXT_TID(x)          (spinel_tid_t)((x)>=0xF?1:(x)+1)
+#define SPINEL_GET_NEXT_TID(x) (spinel_tid_t)((x) >= 0xF ? 1 : (x) + 1)
 
-#define SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT                                                         \
-                                        4
+#define SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT 4
 
-#define SPINEL_BEACON_THREAD_FLAG_VERSION_MASK                                                          \
-                                        (0xf << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT)
+#define SPINEL_BEACON_THREAD_FLAG_VERSION_MASK (0xf << SPINEL_BEACON_THREAD_FLAG_VERSION_SHIFT)
 
-#define SPINEL_BEACON_THREAD_FLAG_JOINABLE                                                              \
-                                        (1 << 0)
+#define SPINEL_BEACON_THREAD_FLAG_JOINABLE (1 << 0)
 
-#define SPINEL_BEACON_THREAD_FLAG_NATIVE                                                                \
-                                       (1 << 3)
+#define SPINEL_BEACON_THREAD_FLAG_NATIVE (1 << 3)
 
 // ----------------------------------------------------------------------------
 
 enum
 {
-    SPINEL_DATATYPE_NULL_C              = 0,
-    SPINEL_DATATYPE_VOID_C              = '.',
-    SPINEL_DATATYPE_BOOL_C              = 'b',
-    SPINEL_DATATYPE_UINT8_C             = 'C',
-    SPINEL_DATATYPE_INT8_C              = 'c',
-    SPINEL_DATATYPE_UINT16_C            = 'S',
-    SPINEL_DATATYPE_INT16_C             = 's',
-    SPINEL_DATATYPE_UINT32_C            = 'L',
-    SPINEL_DATATYPE_INT32_C             = 'l',
-    SPINEL_DATATYPE_UINT64_C            = 'X',
-    SPINEL_DATATYPE_INT64_C             = 'x',
-    SPINEL_DATATYPE_UINT_PACKED_C       = 'i',
-    SPINEL_DATATYPE_IPv6ADDR_C          = '6',
-    SPINEL_DATATYPE_EUI64_C             = 'E',
-    SPINEL_DATATYPE_EUI48_C             = 'e',
-    SPINEL_DATATYPE_DATA_WLEN_C         = 'd',
-    SPINEL_DATATYPE_DATA_C              = 'D',
-    SPINEL_DATATYPE_UTF8_C              = 'U', //!< Zero-Terminated UTF8-Encoded String
-    SPINEL_DATATYPE_STRUCT_C            = 't',
-    SPINEL_DATATYPE_ARRAY_C             = 'A',
+    SPINEL_DATATYPE_NULL_C        = 0,
+    SPINEL_DATATYPE_VOID_C        = '.',
+    SPINEL_DATATYPE_BOOL_C        = 'b',
+    SPINEL_DATATYPE_UINT8_C       = 'C',
+    SPINEL_DATATYPE_INT8_C        = 'c',
+    SPINEL_DATATYPE_UINT16_C      = 'S',
+    SPINEL_DATATYPE_INT16_C       = 's',
+    SPINEL_DATATYPE_UINT32_C      = 'L',
+    SPINEL_DATATYPE_INT32_C       = 'l',
+    SPINEL_DATATYPE_UINT64_C      = 'X',
+    SPINEL_DATATYPE_INT64_C       = 'x',
+    SPINEL_DATATYPE_UINT_PACKED_C = 'i',
+    SPINEL_DATATYPE_IPv6ADDR_C    = '6',
+    SPINEL_DATATYPE_EUI64_C       = 'E',
+    SPINEL_DATATYPE_EUI48_C       = 'e',
+    SPINEL_DATATYPE_DATA_WLEN_C   = 'd',
+    SPINEL_DATATYPE_DATA_C        = 'D',
+    SPINEL_DATATYPE_UTF8_C        = 'U', //!< Zero-Terminated UTF8-Encoded String
+    SPINEL_DATATYPE_STRUCT_C      = 't',
+    SPINEL_DATATYPE_ARRAY_C       = 'A',
 };
 
 typedef char spinel_datatype_t;
 
-#define SPINEL_DATATYPE_NULL_S          ""
-#define SPINEL_DATATYPE_VOID_S          "."
-#define SPINEL_DATATYPE_BOOL_S          "b"
-#define SPINEL_DATATYPE_UINT8_S         "C"
-#define SPINEL_DATATYPE_INT8_S          "c"
-#define SPINEL_DATATYPE_UINT16_S        "S"
-#define SPINEL_DATATYPE_INT16_S         "s"
-#define SPINEL_DATATYPE_UINT32_S        "L"
-#define SPINEL_DATATYPE_INT32_S         "l"
-#define SPINEL_DATATYPE_UINT64_S        "X"
-#define SPINEL_DATATYPE_INT64_S         "x"
-#define SPINEL_DATATYPE_UINT_PACKED_S   "i"
-#define SPINEL_DATATYPE_IPv6ADDR_S      "6"
-#define SPINEL_DATATYPE_EUI64_S         "E"
-#define SPINEL_DATATYPE_EUI48_S         "e"
-#define SPINEL_DATATYPE_DATA_WLEN_S     "d"
-#define SPINEL_DATATYPE_DATA_S          "D"
-#define SPINEL_DATATYPE_UTF8_S          "U" //!< Zero-Terminated UTF8-Encoded String
+#define SPINEL_DATATYPE_NULL_S ""
+#define SPINEL_DATATYPE_VOID_S "."
+#define SPINEL_DATATYPE_BOOL_S "b"
+#define SPINEL_DATATYPE_UINT8_S "C"
+#define SPINEL_DATATYPE_INT8_S "c"
+#define SPINEL_DATATYPE_UINT16_S "S"
+#define SPINEL_DATATYPE_INT16_S "s"
+#define SPINEL_DATATYPE_UINT32_S "L"
+#define SPINEL_DATATYPE_INT32_S "l"
+#define SPINEL_DATATYPE_UINT64_S "X"
+#define SPINEL_DATATYPE_INT64_S "x"
+#define SPINEL_DATATYPE_UINT_PACKED_S "i"
+#define SPINEL_DATATYPE_IPv6ADDR_S "6"
+#define SPINEL_DATATYPE_EUI64_S "E"
+#define SPINEL_DATATYPE_EUI48_S "e"
+#define SPINEL_DATATYPE_DATA_WLEN_S "d"
+#define SPINEL_DATATYPE_DATA_S "D"
+#define SPINEL_DATATYPE_UTF8_S "U" //!< Zero-Terminated UTF8-Encoded String
 
-#define SPINEL_DATATYPE_ARRAY_S(x)      "A(" x ")"
-#define SPINEL_DATATYPE_STRUCT_S(x)     "t(" x ")"
+#define SPINEL_DATATYPE_ARRAY_S(x) "A(" x ")"
+#define SPINEL_DATATYPE_STRUCT_S(x) "t(" x ")"
 
-#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x)                                                               \
-                                        SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
+#define SPINEL_DATATYPE_ARRAY_STRUCT_S(x) SPINEL_DATATYPE_ARRAY_S(SPINEL_DATATYPE_STRUCT_WLEN_S(x))
 
-#define SPINEL_DATATYPE_COMMAND_S       SPINEL_DATATYPE_UINT8_S       /* header  */                     \
-                                        SPINEL_DATATYPE_UINT_PACKED_S /* command */
+#define SPINEL_DATATYPE_COMMAND_S                   \
+    SPINEL_DATATYPE_UINT8_S           /* header  */ \
+        SPINEL_DATATYPE_UINT_PACKED_S /* command */
 
-#define SPINEL_DATATYPE_COMMAND_PROP_S  SPINEL_DATATYPE_COMMAND_S     /* prop command  */               \
-                                        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
+#define SPINEL_DATATYPE_COMMAND_PROP_S                    \
+    SPINEL_DATATYPE_COMMAND_S         /* prop command  */ \
+        SPINEL_DATATYPE_UINT_PACKED_S /* property id */
 
-#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str)                               \
-                                        SPINEL_DATATYPE_UINT8_S /* Channel */                           \
-                                        SPINEL_DATATYPE_INT8_S  /* RSSI */                              \
-                                        SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */   \
-                                        SPINEL_DATATYPE_STRUCT_S(net_format_str) /* net-layer data */
+#define SPINEL_DATATYPE_MAC_SCAN_RESULT_S(mac_format_str, net_format_str) \
+    SPINEL_DATATYPE_UINT8_S                          /* Channel */        \
+            SPINEL_DATATYPE_INT8_S                   /* RSSI */           \
+            SPINEL_DATATYPE_STRUCT_S(mac_format_str) /* mac-layer data */ \
+        SPINEL_DATATYPE_STRUCT_S(net_format_str)     /* net-layer data */
 
-#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S                                                   \
-                                        SPINEL_DATATYPE_EUI64_S  /* laddr */                            \
-                                        SPINEL_DATATYPE_UINT16_S /* saddr */                            \
-                                        SPINEL_DATATYPE_UINT16_S /* panid */                            \
-                                        SPINEL_DATATYPE_UINT8_S  /* lqi   */
+#define SPINEL_802_15_4_DATATYPE_MAC_SCAN_RESULT_V1_S \
+    SPINEL_DATATYPE_EUI64_S              /* laddr */  \
+                SPINEL_DATATYPE_UINT16_S /* saddr */  \
+                SPINEL_DATATYPE_UINT16_S /* panid */  \
+                SPINEL_DATATYPE_UINT8_S  /* lqi   */
 
-#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                                                        \
-                                        SPINEL_DATATYPE_UINT_PACKED_S /* type */                        \
-                                        SPINEL_DATATYPE_UINT8_S /* flags */                             \
-                                        SPINEL_DATATYPE_UTF8_S /* network name */                       \
-                                        SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S               \
+    SPINEL_DATATYPE_UINT_PACKED_S           /* type */         \
+                SPINEL_DATATYPE_UINT8_S     /* flags */        \
+                SPINEL_DATATYPE_UTF8_S      /* network name */ \
+                SPINEL_DATATYPE_DATA_WLEN_S /* xpanid */
 
-#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V2_S                                                        \
-                                        SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S                        \
-                                        SPINEL_DATATYPE_DATA_WLEN_S /* steering data */
+#define SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V2_S \
+    SPINEL_NET_DATATYPE_MAC_SCAN_RESULT_V1_S     \
+    SPINEL_DATATYPE_DATA_WLEN_S /* steering data */
 
+#define SPINEL_MAX_UINT_PACKED 2097151
 
-#define SPINEL_MAX_UINT_PACKED          2097151
-
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *data_out, spinel_size_t data_len,
-                                                      const char *pack_format, ...);
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vpack(uint8_t *data_out, spinel_size_t data_len,
-                                                       const char *pack_format, va_list args);
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in, spinel_size_t data_len,
-                                                        const char *pack_format, ...);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_pack(uint8_t *     data_out,
+                                                      spinel_size_t data_len,
+                                                      const char *  pack_format,
+                                                      ...);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_out,
+                                                       spinel_size_t data_len,
+                                                       const char *  pack_format,
+                                                       va_list       args);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in,
+                                                        spinel_size_t  data_len,
+                                                        const char *   pack_format,
+                                                        ...);
 /**
  * This function parses spinel data similar to sscanf().
  *
@@ -2171,10 +2106,14 @@ SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack(const uint8_t *data_in, 
  * @sa spinel_datatype_vunpack_in_place()
  *
  */
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_in, spinel_size_t data_len,
-                                                        const char *pack_format, ...);
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_in, spinel_size_t data_len,
-                                                         const char *pack_format, va_list args);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_unpack_in_place(const uint8_t *data_in,
+                                                                 spinel_size_t  data_len,
+                                                                 const char *   pack_format,
+                                                                 ...);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_in,
+                                                         spinel_size_t  data_len,
+                                                         const char *   pack_format,
+                                                         va_list        args);
 /**
  * This function parses spinel data similar to vsscanf().
  *
@@ -2197,11 +2136,14 @@ SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack(const uint8_t *data_in,
  * @sa spinel_datatype_unpack_in_place()
  *
  */
-SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_in, spinel_size_t data_len,
-                                                         const char *pack_format, va_list args);
+SPINEL_API_EXTERN spinel_ssize_t spinel_datatype_vunpack_in_place(const uint8_t *data_in,
+                                                                  spinel_size_t  data_len,
+                                                                  const char *   pack_format,
+                                                                  va_list        args);
 
-SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_decode(const uint8_t *bytes, spinel_size_t len,
-                                                           unsigned int *value);
+SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_decode(const uint8_t *bytes,
+                                                           spinel_size_t  len,
+                                                           unsigned int * value);
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_encode(uint8_t *bytes, spinel_size_t len, unsigned int value);
 SPINEL_API_EXTERN spinel_ssize_t spinel_packed_uint_size(unsigned int value);
 


### PR DESCRIPTION
This commit updates `spinel.h` and `spinel.c` from OpenThread at
commit 92282bffa757.

----------

The changes are due to applying OpenThread code-style format ("make pretty") on `NCP` source files including spinel files.

