### PR TITLE
Add wpan property "Thread:Parent" to get parent info

### DIFF
--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -130,6 +130,8 @@
 #define kWPANTUNDProperty_ThreadPendingDatasetAsValMap          "Thread:PendingDataset:AsValMap"
 #define kWPANTUNDProperty_ThreadAddressCacheTable               "Thread:AddressCacheTable"
 #define kWPANTUNDProperty_ThreadAddressCacheTableAsValMap       "Thread:AddressCacheTable:AsValMap"
+#define kWPANTUNDProperty_ThreadParent                          "Thread:Parent"
+#define kWPANTUNDProperty_ThreadParentAsValMap                  "Thread:Parent:AsValMap"
 
 #define kWPANTUNDProperty_DatasetActiveTimestamp                "Dataset:ActiveTimestamp"
 #define kWPANTUNDProperty_DatasetPendingTimestamp               "Dataset:PendingTimestamp"

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -923,7 +923,20 @@ typedef enum {
 
     SPINEL_PROP_THREAD__BEGIN      = 0x50,
     SPINEL_PROP_THREAD_LEADER_ADDR = SPINEL_PROP_THREAD__BEGIN + 0, ///< [6]
-    SPINEL_PROP_THREAD_PARENT      = SPINEL_PROP_THREAD__BEGIN + 1, ///< LADDR, SADDR [ES]
+
+    /// Thread Parent Info
+    /** Format: `ESLccCC` - Read only
+     *
+     *  `E`: Extended address
+     *  `S`: RLOC16
+     *  `L`: Age (seconds since last heard from)
+     *  `c`: Average RSS (in dBm)
+     *  `c`: Last RSSI (in dBm)
+     *  `C`: Link Quality In
+     *  `C`: Link Quality Out
+     *
+     */
+    SPINEL_PROP_THREAD_PARENT = SPINEL_PROP_THREAD__BEGIN + 1,
 
     /// Thread Child Table
     /** Format: [A(t(ESLLCCcCc)] - Read only


### PR DESCRIPTION
This commit adds new wpan properties "Thread:Parent" and
"Thread:Parent:AsValMap" to provide info about parent of device
when attached as a child (end-device).

Related PR in OpenThread: https://github.com/openthread/openthread/pull/2854