### PR TITLE
Add support for sending MGMT_GET for Active/Pending Dataset

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1250,10 +1250,12 @@ SpinelNCPInstance::get_dataset_command_help(std::list<std::string> &list)
 	list.push_back("   - `" kWPANTUNDDatasetCommand_Erase "`: Erase the local Dataset (all fields are un-set)");
 	list.push_back("   - `" kWPANTUNDDatasetCommand_GetActive "`: Get the NCP's Active Operational Dataset and populate the local Dataset from it");
 	list.push_back("   - `" kWPANTUNDDatasetCommand_SetActive "`: Set the NCP's Active Operational Dataset from the current local Dataset");
-	list.push_back("   - `" kWPANTUNDDatasetCommand_MgmtSendActive "`: Send the current local Dataset to leader with a MGMT_SEND_ACTIVE meshcop command");
+	list.push_back("   - `" kWPANTUNDDatasetCommand_SendMgmtGetActive "`: Send MGMT_GET_ACTIVE meshcop command requesting TLVs in current local Dataset");
+	list.push_back("   - `" kWPANTUNDDatasetCommand_SendMgmtSetActive "`: Send MGMT_SET_ACTIVE meshcop command along with the current local Dataset");
 	list.push_back("   - `" kWPANTUNDDatasetCommand_GetPending "`: Get the NCP's Pending Operational Dataset and populate the local DataSet from it");
 	list.push_back("   - `" kWPANTUNDDatasetCommand_SetPending "`: Set the NCP's Pending Operational Dataset from the current local Dataset");
-	list.push_back("   - `" kWPANTUNDDatasetCommand_MgmtSendPending "`: Send the current local Dataset to leader with MGMT_SEND_PENDING meshcop command");
+	list.push_back("   - `" kWPANTUNDDatasetCommand_SendMgmtGetPending "`: Send MGMT_GET_PENDING meshcop command requesting TLVs in the current local Dataset");
+	list.push_back("   - `" kWPANTUNDDatasetCommand_SendMgmtSetPending "`: Send MGMT_SET_PENDING meshcop command along with the current local Dataset");
 }
 
 int
@@ -1295,7 +1297,23 @@ SpinelNCPInstance::perform_dataset_command(const std::string &command, CallbackW
 			.finish()
 		);
 
-	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_MgmtSendActive)) {
+	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_SendMgmtGetActive)) {
+		Data frame;
+		mLocalDataset.convert_to_spinel_frame(frame, /* include_values */ false);
+		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+			.set_callback(cb)
+			.add_command(
+				SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
+					SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET,
+					frame.data(),
+					frame.size()
+				)
+			)
+			.finish()
+		);
+
+	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_SendMgmtSetActive)) {
 		Data frame;
 		mLocalDataset.convert_to_spinel_frame(frame);
 		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
@@ -1303,7 +1321,7 @@ SpinelNCPInstance::perform_dataset_command(const std::string &command, CallbackW
 			.add_command(
 				SpinelPackData(
 					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
-					SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET,
+					SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET,
 					frame.data(),
 					frame.size()
 				)
@@ -1337,7 +1355,23 @@ SpinelNCPInstance::perform_dataset_command(const std::string &command, CallbackW
 			.finish()
 		);
 
-	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_MgmtSendPending)) {
+	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_SendMgmtGetPending)) {
+		Data frame;
+		mLocalDataset.convert_to_spinel_frame(frame, /* include_values */ false);
+		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
+			.set_callback(cb)
+			.add_command(
+				SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
+					SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET,
+					frame.data(),
+					frame.size()
+				)
+			)
+			.finish()
+		);
+
+	} else if (strcaseequal(command.c_str(), kWPANTUNDDatasetCommand_SendMgmtSetPending)) {
 		Data frame;
 		mLocalDataset.convert_to_spinel_frame(frame);
 		start_new_task(SpinelNCPTaskSendCommand::Factory(this)
@@ -1345,7 +1379,7 @@ SpinelNCPInstance::perform_dataset_command(const std::string &command, CallbackW
 			.add_command(
 				SpinelPackData(
 					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_DATA_S),
-					SPINEL_PROP_THREAD_MGMT_PENDING_DATASET,
+					SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET,
 					frame.data(),
 					frame.size()
 				)
@@ -2137,6 +2171,13 @@ SpinelNCPInstance::property_get_value(
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DatasetRawTlvs)) {
 		if (mLocalDataset.mRawTlvs.has_value()) {
 			cb(kWPANTUNDStatus_Ok, boost::any(mLocalDataset.mRawTlvs.get()));
+		} else {
+			cb(kWPANTUNDStatus_Ok, boost::any(Data()));
+		}
+
+	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DatasetDestIpAddress)) {
+		if (mLocalDataset.mDestIpAddress.has_value()) {
+			cb(kWPANTUNDStatus_Ok, boost::any(in6_addr_to_string(mLocalDataset.mDestIpAddress.get())));
 		} else {
 			cb(kWPANTUNDStatus_Ok, boost::any(Data()));
 		}
@@ -3125,6 +3166,10 @@ SpinelNCPInstance::property_set_value(
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DatasetRawTlvs)) {
 			mLocalDataset.mRawTlvs = any_to_data(value);
+			cb(kWPANTUNDStatus_Ok);
+
+		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DatasetDestIpAddress)) {
+			mLocalDataset.mDestIpAddress = any_to_ipv6(value);
 			cb(kWPANTUNDStatus_Ok);
 
 		} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_DatasetCommand)) {

--- a/src/ncp-spinel/SpinelNCPThreadDataset.h
+++ b/src/ncp-spinel/SpinelNCPThreadDataset.h
@@ -62,7 +62,7 @@ public:
 	void convert_to_string_list(std::list<std::string> &list);
 
 	int  set_from_spinel_frame(const uint8_t *data_in, spinel_size_t data_len);
-	void convert_to_spinel_frame(Data &frame);
+	void convert_to_spinel_frame(Data &frame, bool include_value = true);
 
 	Optional<uint64_t>         mActiveTimestamp;
 	Optional<uint64_t>         mPendingTimestamp;
@@ -77,7 +77,7 @@ public:
 	Optional<uint32_t>         mChannelMaskPage0;
 	Optional<SecurityPolicy>   mSecurityPolicy;
 	Optional<Data>             mRawTlvs;
-
+	Optional<struct in6_addr>  mDestIpAddress;
 
 private:
 	enum

--- a/src/wpanctl/tool-cmd-dataset.c
+++ b/src/wpanctl/tool-cmd-dataset.c
@@ -54,8 +54,12 @@ static dataset_command_t datsetCommandList[] =
 		"Set the NCP's Active Operational Dataset from the current local Dataset."
 	},
 	{
-		"mgmt-active", "ma", kWPANTUNDDatasetCommand_MgmtSendActive,
-		"Send the current local Dataset to leader with a MGMT_SEND_ACTIVE meshcop command."
+		"mgmt-get-active", "mga", kWPANTUNDDatasetCommand_SendMgmtGetActive,
+		"Send a MGMT_GET_ACTIVE meshcop command requesting TLVs in the current local Dataset."
+	},
+	{
+		"mgmt-set-active", "msa", kWPANTUNDDatasetCommand_SendMgmtSetActive,
+		"Send a MGMT_SET_ACTIVE meshcop command along with the current local Dataset."
 	},
 	{
 		"get-pending", "gp", kWPANTUNDDatasetCommand_GetPending,
@@ -66,8 +70,12 @@ static dataset_command_t datsetCommandList[] =
 		"Set the NCP's Pending Operational Dataset from the current local Dataset."
 	},
 	{
-		"mgmt-pending", "mp", kWPANTUNDDatasetCommand_MgmtSendPending,
-		"Send the current local Dataset to leader with a MGMT_SEND_PENDING meshcop command."
+		"mgmt-get-pending", "mgp", kWPANTUNDDatasetCommand_SendMgmtGetPending,
+		"Send a MGMT_GET_PENDING meshcop command requesting TLVs in the current local Dataset."
+	},
+	{
+		"mgmt-set-pending", "msp", kWPANTUNDDatasetCommand_SendMgmtSetPending,
+		"Send a MGMT_SET_PENDING meshcop command along with the current local Dataset to leader"
 	},
 	{
 		NULL, NULL, NULL, NULL
@@ -83,7 +91,7 @@ static void print_help(const char *command_name)
 	printf("Valid commands are:\n");
 
 	while (entry->long_name != NULL)	{
-		printf("   %-12s (or %-2s)      %s\n", entry->long_name, entry->short_name, entry->help_string);
+		printf("   %-16s (or %-3s)      %s\n", entry->long_name, entry->short_name, entry->help_string);
 		entry++;
 	}
 }

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -147,6 +147,7 @@
 #define kWPANTUNDProperty_DatasetSecPolicyKeyRotation           "Dataset:SecPolicy:KeyRotation"
 #define kWPANTUNDProperty_DatasetSecPolicyFlags                 "Dataset:SecPolicy:Flags"
 #define kWPANTUNDProperty_DatasetRawTlvs                        "Dataset:RawTlvs"
+#define kWPANTUNDProperty_DatasetDestIpAddress                  "Dataset:DestIpAddress"
 
 #define kWPANTUNDProperty_DatasetAllFileds                      "Dataset:AllFields"
 #define kWPANTUNDProperty_DatasetAllFileds_AltString            "Dataset"
@@ -156,10 +157,12 @@
 #define kWPANTUNDDatasetCommand_Erase                           "Erase"
 #define kWPANTUNDDatasetCommand_GetActive                       "GetActive"
 #define kWPANTUNDDatasetCommand_SetActive                       "SetActive"
-#define kWPANTUNDDatasetCommand_MgmtSendActive                  "MgmtSendActive"
+#define kWPANTUNDDatasetCommand_SendMgmtGetActive               "SendMgmtGetActive"
+#define kWPANTUNDDatasetCommand_SendMgmtSetActive               "SendMgmtSetActive"
 #define kWPANTUNDDatasetCommand_GetPending                      "GetPending"
 #define kWPANTUNDDatasetCommand_SetPending                      "SetPending"
-#define kWPANTUNDDatasetCommand_MgmtSendPending                 "MgmtSendPending"
+#define kWPANTUNDDatasetCommand_SendMgmtGetPending              "SendMgmtGetPending"
+#define kWPANTUNDDatasetCommand_SendMgmtSetPending              "SendMgmtSetPending"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1525,12 +1525,12 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PROP_THREAD_PENDING_DATASET";
         break;
 
-    case SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET:
-        ret = "PROP_THREAD_MGMT_ACTIVE_DATASET";
+    case SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET:
+        ret = "PROP_THREAD_MGMT_SET_ACTIVE_DATASET";
         break;
 
-    case SPINEL_PROP_THREAD_MGMT_PENDING_DATASET:
-        ret = "PROP_THREAD_MGMT_PENDING_DATASET";
+    case SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET:
+        ret = "PROP_THREAD_MGMT_SET_PENDING_DATASET";
         break;
 
     case SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP:
@@ -1563,6 +1563,18 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 
     case SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE:
         ret = "PROP_THREAD_ADDRESS_CACHE_TABLE";
+        break;
+
+    case SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET:
+        ret = "PROP_THREAD_MGMT_GET_ACTIVE_DATASET";
+        break;
+
+    case SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET:
+        ret = "PROP_THREAD_MGMT_GET_PENDING_DATASET";
+        break;
+
+    case SPINEL_PROP_DATASET_DEST_ADDRESS:
+        ret = "PROP_DATASET_DEST_ADDRESS";
         break;
 
     case SPINEL_PROP_IPV6_LL_ADDR:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1244,7 +1244,7 @@ typedef enum {
      */
     SPINEL_PROP_THREAD_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 25,
 
-    /// Thread Active Operational Dataset (MGMT send)
+    /// Send MGMT_SET Thread Active Operational Dataset
     /** Format: `A(t(iD))` - Write only
      *
      * The formatting of this property follows the same rules as in SPINEL_PROP_THREAD_ACTIVE_DATASET.
@@ -1259,9 +1259,9 @@ typedef enum {
      *    SPINEL_PROP_DATASET_RAW_TLVS
      *
      */
-    SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 26,
+    SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 26,
 
-    /// Thread Pending Operational Dataset (MGMT send)
+    /// Send MGMT_SET Thread Pending Operational Dataset
     /** Format: `A(t(iD))` - Write only
      *
      * This property is similar to SPINEL_PROP_THREAD_PENDING_DATASET and follows the same format and rules.
@@ -1272,7 +1272,7 @@ typedef enum {
      *    SPINEL_PROP_DATASET_RAW_TLVS
      *
      */
-    SPINEL_PROP_THREAD_MGMT_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 27,
+    SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 27,
 
     /// Operational Dataset Active Timestamp
     /** Format: `X` - No direct read or write
@@ -1281,8 +1281,10 @@ typedef enum {
      *
      *   SPINEL_PROP_THREAD_ACTIVE_DATASET
      *   SPINEL_PROP_THREAD_PENDING_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
      *
      */
     SPINEL_PROP_DATASET_ACTIVE_TIMESTAMP = SPINEL_PROP_THREAD_EXT__BEGIN + 28,
@@ -1293,7 +1295,8 @@ typedef enum {
      * It can only be included in one of the Pending Dataset properties:
      *
      *   SPINEL_PROP_THREAD_PENDING_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
      *
      */
     SPINEL_PROP_DATASET_PENDING_TIMESTAMP = SPINEL_PROP_THREAD_EXT__BEGIN + 29,
@@ -1307,7 +1310,8 @@ typedef enum {
      * It can only be included in one of the Pending Dataset properties:
      *
      *   SPINEL_PROP_THREAD_PENDING_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
      *
      */
     SPINEL_PROP_DATASET_DELAY_TIMER = SPINEL_PROP_THREAD_EXT__BEGIN + 30,
@@ -1319,8 +1323,10 @@ typedef enum {
      *
      *   SPINEL_PROP_THREAD_ACTIVE_DATASET
      *   SPINEL_PROP_THREAD_PENDING_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
      *
      * Content is
      *   `S` : Key Rotation Time (in units of hour)
@@ -1336,8 +1342,10 @@ typedef enum {
      *
      * It can only be included in one of the following Dataset properties:
      *
-     *   SPINEL_PROP_THREAD_MGMT_ACTIVE_DATASET
-     *   SPINEL_PROP_THREAD_MGMT_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_SET_PENDING_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
      *
      */
     SPINEL_PROP_DATASET_RAW_TLVS = SPINEL_PROP_THREAD_EXT__BEGIN + 32,
@@ -1407,6 +1415,52 @@ typedef enum {
      *
      */
     SPINEL_PROP_THREAD_UDP_PROXY_STREAM = SPINEL_PROP_THREAD_EXT__BEGIN + 36,
+
+    /// Send MGMT_GET Thread Active Operational Dataset
+    /** Format: `A(t(iD))` - Write only
+     *
+     * The formatting of this property follows the same rules as in SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET. This
+     * property further allows the sender to not include a value associated with properties in formating of `t(iD)`,
+     * i.e., it should accept either a `t(iD)` or a `t(i)` encoding (in both cases indicating that the associated
+     * Dataset property should be requested as part of MGMT_GET command).
+     *
+     * This is write-only property. When written, it triggers a MGMT_ACTIVE_GET meshcop command to be sent to leader
+     * requesting the Dataset related properties from the format. The spinel frame response should be a `LAST_STATUS`
+     * with the status of the transmission of MGMT_ACTIVE_GET command.
+     *
+     * In addition to supported properties in SPINEL_PROP_THREAD_MGMT_SET_ACTIVE_DATASET, the following property can be
+     * optionally included in the Dataset:
+     *
+     *    SPINEL_PROP_DATASET_DEST_ADDRESS
+     *
+     */
+    SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 37,
+
+    /// Send MGMT_GET Thread Pending Operational Dataset
+    /** Format: `A(t(iD))` - Write only
+     *
+     * The formatting of this property follows the same rules as in SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET.
+     *
+     * This is write-only property. When written, it triggers a MGMT_PENDING_GET meshcop command to be sent to leader
+     * with the given Dataset. The spinel frame response should be a `LAST_STATUS` with the status of the transmission
+     * of MGMT_PENDING_GET command.
+     *
+     */
+    SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET = SPINEL_PROP_THREAD_EXT__BEGIN + 38,
+
+    /// Operational Dataset (MGMT_GET) Destination IPv6 Address
+    /** Format: `6` - No direct read or write
+     *
+     * This property specifies the IPv6 destination when sending MGMT_GET command for either Active or Pending Dataset
+     * if not provided, Leader ALOC address is used as default.
+     *
+     * It can only be included in one of the MGMT_GET Dataset properties:
+     *
+     *   SPINEL_PROP_THREAD_MGMT_GET_ACTIVE_DATASET
+     *   SPINEL_PROP_THREAD_MGMT_GET_PENDING_DATASET
+     *
+     */
+    SPINEL_PROP_DATASET_DEST_ADDRESS = SPINEL_PROP_THREAD_EXT__BEGIN + 39,
 
     SPINEL_PROP_THREAD_EXT__END = 0x1600,
 


### PR DESCRIPTION
This commit adds support to send `MGMT_GET` meshcop command for
Active/Pending Operational Dataset. wpanctl `dataset` is also
updated to add new commands.

This commit also adds a new wpan property "Dataset:DestIpAddress"
to help specify the destitaion IPv6 address for sending MGM_GET
command.