### PR TITLE
Remove using DBUS_BUS_STARTER

### DIFF
--- a/src/ipc-dbus/DBUSIPCServer.cpp
+++ b/src/ipc-dbus/DBUSIPCServer.cpp
@@ -65,13 +65,7 @@ get_dbus_connection()
 	if (connection == NULL) {
 		syslog(LOG_DEBUG, "Getting DBus connection");
 
-		connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-		if (!connection) {
-			dbus_error_free(&error);
-			dbus_error_init(&error);
-			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-		}
+		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 		require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-add-prefix.c
+++ b/src/wpanctl/tool-cmd-add-prefix.c
@@ -195,13 +195,7 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_action_string(connection != NULL, bail, ret = ERRORCODE_ALLOC, error.message);
 

--- a/src/wpanctl/tool-cmd-add-route.c
+++ b/src/wpanctl/tool-cmd-add-route.c
@@ -129,13 +129,7 @@ int tool_cmd_add_route(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-begin-low-power.c
+++ b/src/wpanctl/tool-cmd-begin-low-power.c
@@ -91,13 +91,7 @@ int tool_cmd_begin_low_power(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-begin-net-wake.c
+++ b/src/wpanctl/tool-cmd-begin-net-wake.c
@@ -98,13 +98,7 @@ int tool_cmd_begin_net_wake(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-commissioner.c
+++ b/src/wpanctl/tool-cmd-commissioner.c
@@ -112,13 +112,8 @@ int tool_cmd_commissioner(int argc, char* argv[])
 				ret = ERRORCODE_BADARG;
 				goto bail;
 			}
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
 			require_string(connection != NULL, bail, error.message);
 
 			if (ret != 0) {
@@ -203,13 +198,8 @@ int tool_cmd_commissioner(int argc, char* argv[])
 				ret = ERRORCODE_BADARG;
 				goto bail;
 			}
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
 			require_string(connection != NULL, bail, error.message);
 
 			if (ret != 0) {
@@ -345,13 +335,7 @@ int tool_cmd_commissioner(int argc, char* argv[])
 				ret = ERRORCODE_BADARG;
 				goto bail;
 			}
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 			require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-commr.c
+++ b/src/wpanctl/tool-cmd-commr.c
@@ -245,13 +245,7 @@ tool_cmd_commr(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-config-gateway.c
+++ b/src/wpanctl/tool-cmd-config-gateway.c
@@ -142,13 +142,7 @@ int tool_cmd_config_gateway(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-dataset.c
+++ b/src/wpanctl/tool-cmd-dataset.c
@@ -130,13 +130,7 @@ int tool_cmd_dataset(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-form.c
+++ b/src/wpanctl/tool-cmd-form.c
@@ -266,13 +266,7 @@ int tool_cmd_form(int argc, char *argv[])
 
 	// Prepare DBus connection
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-getprop.c
+++ b/src/wpanctl/tool-cmd-getprop.c
@@ -130,13 +130,7 @@ int tool_cmd_getprop(int argc, char *argv[])
 	}
 
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-host-did-wake.c
+++ b/src/wpanctl/tool-cmd-host-did-wake.c
@@ -91,13 +91,7 @@ int tool_cmd_host_did_wake(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-join.c
+++ b/src/wpanctl/tool-cmd-join.c
@@ -252,13 +252,7 @@ int tool_cmd_join(int argc, char* argv[])
 
 	// Prepare DBus connection
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-joiner.c
+++ b/src/wpanctl/tool-cmd-joiner.c
@@ -112,13 +112,7 @@ int tool_cmd_joiner(int argc, char* argv[])
 				goto bail;
 			}
 
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 			ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_PROP_GET);
 			require_action(ret == 0, bail, print_error_diagnosis(ret));
@@ -174,13 +168,7 @@ int tool_cmd_joiner(int argc, char* argv[])
 
 		case 'a':
 			// joiner attaches to commissioned thread network
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 			ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_JOINER_ATTACH);
 			require_action(ret == 0, bail, print_error_diagnosis(ret));
@@ -259,13 +247,8 @@ int tool_cmd_joiner(int argc, char* argv[])
 				goto bail;
 			}
 
-			connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
+			connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
-			if (!connection) {
-				dbus_error_free(&error);
-				dbus_error_init(&error);
-				connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-			}
 			require_string(connection != NULL, bail, error.message);
 
 			ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_JOINER_COMMISSIONING);

--- a/src/wpanctl/tool-cmd-leave.c
+++ b/src/wpanctl/tool-cmd-leave.c
@@ -90,13 +90,7 @@ int tool_cmd_leave(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-list.c
+++ b/src/wpanctl/tool-cmd-list.c
@@ -82,13 +82,7 @@ int tool_cmd_list(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-mfg.c
+++ b/src/wpanctl/tool-cmd-mfg.c
@@ -75,13 +75,7 @@ int tool_cmd_mfg(int argc, char *argv[])
 		}
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(error.name == NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-pcap.c
+++ b/src/wpanctl/tool-cmd-pcap.c
@@ -55,15 +55,7 @@ do_pcap_to_fd(int fd, int timeout, DBusError *error)
 	char path[DBUS_MAXIMUM_NAME_LENGTH+1];
 	char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, error);
-
-	if (connection == NULL) {
-		if (error != NULL) {
-			dbus_error_free(error);
-			dbus_error_init(error);
-		}
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, error);
 
 	require(connection != NULL, bail);
 

--- a/src/wpanctl/tool-cmd-peek.c
+++ b/src/wpanctl/tool-cmd-peek.c
@@ -163,13 +163,7 @@ int tool_cmd_peek(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-permit-join.c
+++ b/src/wpanctl/tool-cmd-permit-join.c
@@ -131,13 +131,7 @@ int tool_cmd_permit_join(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-poke.c
+++ b/src/wpanctl/tool-cmd-poke.c
@@ -142,13 +142,7 @@ int tool_cmd_poke(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-poll.c
+++ b/src/wpanctl/tool-cmd-poll.c
@@ -91,13 +91,7 @@ int tool_cmd_poll(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-remove-prefix.c
+++ b/src/wpanctl/tool-cmd-remove-prefix.c
@@ -147,13 +147,7 @@ int tool_cmd_remove_prefix(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_action_string(connection != NULL, bail, ret = ERRORCODE_ALLOC, error.message);
 

--- a/src/wpanctl/tool-cmd-remove-route.c
+++ b/src/wpanctl/tool-cmd-remove-route.c
@@ -115,13 +115,7 @@ int tool_cmd_remove_route(int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-reset.c
+++ b/src/wpanctl/tool-cmd-reset.c
@@ -90,13 +90,7 @@ int tool_cmd_reset(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-resume.c
+++ b/src/wpanctl/tool-cmd-resume.c
@@ -90,13 +90,7 @@ int tool_cmd_resume(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-scan.c
+++ b/src/wpanctl/tool-cmd-scan.c
@@ -274,13 +274,7 @@ int tool_cmd_scan(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-cmd-status.c
+++ b/src/wpanctl/tool-cmd-status.c
@@ -90,13 +90,7 @@ int tool_cmd_status(int argc, char *argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/tool-updateprop.c
+++ b/src/wpanctl/tool-updateprop.c
@@ -145,13 +145,7 @@ int tool_updateprop(const char *dbus_method_name, int argc, char* argv[])
 		goto bail;
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/wpanctl-utils.c
+++ b/src/wpanctl/wpanctl-utils.c
@@ -413,13 +413,7 @@ lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name)
 
 	memset(dbus_bus_name, 0, DBUS_MAXIMUM_NAME_LENGTH+1);
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 

--- a/src/wpanctl/wpanctl.c
+++ b/src/wpanctl/wpanctl.c
@@ -526,19 +526,10 @@ int main(int argc, char * argv[])
 	setenv("WPANCTL_DBUS_NAME", WPAN_TUNNEL_DBUS_NAME, 0);
 
 	if (gDebugMode >= 1) {
-		fprintf(stderr, "DEBUG: Getting DBusConnection via dbus_bus_get(DBUS_BUS_STARTER). . .\n");
+		fprintf(stderr, "DEBUG: trying dbus_bus_get(DBUS_BUS_SYSTEM). . .\n");
 	}
 
-	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
-
-	if (!connection) {
-		if (gDebugMode >= 1) {
-			fprintf(stderr, "DEBUG: dbus_bus_get(DBUS_BUS_STARTER) didn't work, trying dbus_bus_get(DBUS_BUS_SYSTEM). . .\n");
-		}
-		dbus_error_free(&error);
-		dbus_error_init(&error);
-		connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
-	}
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
 
 	require_string(connection != NULL, bail, error.message);
 


### PR DESCRIPTION
Actually I'm not sure if this is the right cure, but we do encountered issues on raspberry PI desktop environment that either wpanctl or web gui cannot find the right dbus service of wpantund. Using the system dbus, it works as expected.