### PR TITLE
Allow multiple instances of same on-mesh prefix to be tracked separately

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -205,6 +205,7 @@ SpinelNCPControlInterface::add_on_mesh_prefix(
 		prefix_len,
 		SpinelNCPInstance::OnMeshPrefixEntry::encode_flag_set(flags, priority),
 		stable,
+		0,
 		cb
 	);
 
@@ -219,7 +220,7 @@ SpinelNCPControlInterface::remove_on_mesh_prefix(
 	CallbackWithStatus cb
 ) {
 	require_action(mNCPInstance->mEnabled, bail, cb(kWPANTUNDStatus_InvalidWhenDisabled));
-	mNCPInstance->on_mesh_prefix_was_removed(SpinelNCPInstance::kOriginUser, prefix, prefix_len, cb);
+	mNCPInstance->on_mesh_prefix_was_removed(SpinelNCPInstance::kOriginUser, prefix, prefix_len, 0, true, 0, cb);
 
 bail:
 	return;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -146,7 +146,8 @@ protected:
 	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
 	void handle_ncp_log_stream(const uint8_t* data_ptr, int data_len);
-	void handle_ncp_spinel_value_is_OFF_MESH_ROUTE(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
+	void handle_ncp_spinel_value_is_ON_MESH_NETS(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
+	void handle_ncp_spinel_value_is_OFF_MESH_ROUTES(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 
 	bool should_filter_address(const struct in6_addr &address, uint8_t prefix_len);
 	void filter_addresses(void);

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -471,7 +471,7 @@ NCPInstanceBase::property_get_value(
 
 	} else if (strcaseequal(key.c_str(), kWPANTUNDProperty_ThreadOnMeshPrefixes)) {
 		std::list<std::string> result;
-		std::map<struct in6_addr, OnMeshPrefixEntry>::const_iterator iter;
+		std::multimap<IPv6Prefix, OnMeshPrefixEntry>::const_iterator iter;
 		for (iter = mOnMeshPrefixes.begin(); iter != mOnMeshPrefixes.end(); iter++ ) {
 			result.push_back(iter->second.get_description(iter->first, true));
 		}


### PR DESCRIPTION
This commit change how the on-mesh prefix list is maintained by
`wpantund` to allow for instances of same prefix added by different
nodes within the Thread network (possibly with different flags) to be
tracked individually.  This commit also changes the behavior when an
IPv6 address is added with an existing prefix (e.g., prefix already
added by another node). In such case the prefix will be re-added by
the node adding the new IPv6 address.