### PR TITLE
Update wpanctl `form` and `join` implementation to use DBus v1 APIs

### DIFF
--- a/src/wpanctl/tool-cmd-form.c
+++ b/src/wpanctl/tool-cmd-form.c
@@ -25,40 +25,61 @@
 #include "wpanctl-utils.h"
 #include "tool-cmd-form.h"
 #include "assert-macros.h"
-#include "wpan-dbus-v0.h"
+#include "wpan-dbus-v1.h"
 #include "args.h"
 #include "string-utils.h"
 
 #include <arpa/inet.h>
 #include <errno.h>
 
-const char form_cmd_syntax[] = "[args] [network-name]";
+const char form_cmd_syntax[] = "[args] <network-name>";
 
 static const arg_list_item_t form_option_list[] = {
 	{'h', "help", NULL, "Print Help"},
 	{'t', "timeout", "ms", "Set timeout period"},
 	{'c', "channel", "channel", "Set the desired channel"},
+	{'m', "channel-mask", "mask", "Specify a channel mask (channel will be chosen randomly from given mask)"},
+	{'p', "panid", "panid", "Specify a specific PAN ID"},
+	{'x', "xpanid", "xpanid", "Specify a specific Extended PAN ID"},
+	{'k', "key", "key", "Specify the network key"},
+	{'i', "key-index", "index", "Specify network key index"},
 	{'T', "type", "node-type: router(r,2), end-device(end,e,3), sleepy-end-device(sleepy,sed,4), nl-lurker(lurker,l,6)",
-		"Join as a specific node type" },
-//	{'u', "ula-prefix", "ULA Prefix", "Specify a specific *LEGACY* ULA prefix"},
+		"Form as a specific node type" },
 	{'M', "mesh-local-prefix", "Mesh-Local IPv6 Prefix", "Specify a non-default mesh-local IPv6 prefix"},
 	{'L', "legacy-prefix", "Legacy IPv6 Prefix", "Specify a specific *LEGACY* IPv6 prefix"},
 	{0}
 };
 
-int tool_cmd_form(int argc, char* argv[])
+int tool_cmd_form(int argc, char *argv[])
 {
 	int ret = 0;
-	int c;
 	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
 	DBusConnection* connection = NULL;
 	DBusMessage *message = NULL;
 	DBusMessage *reply = NULL;
 	DBusError error;
-	const char* network_name = NULL;
-	const char* ula_prefix = NULL;
-	uint16_t node_type = WPAN_IFACE_ROLE_ROUTER; // Default to router for form
+	DBusMessageIter msg_iter;
+	DBusMessageIter dict_iter;
+
+	const char *network_name = NULL;
+	uint16_t channel = 0;
 	uint32_t channel_mask = 0;
+	uint16_t panid = 0;
+	uint64_t xpanid = 0;
+	uint8_t network_key[WPANCTL_NETWORK_KEY_SIZE];
+	uint32_t key_index = 0;
+	const char *node_type = kWPANTUNDNodeType_Router;
+	uint8_t mesh_local_prefix[WPANCTL_PREFIX_SIZE];
+	uint8_t legacy_prefix[WPANCTL_PREFIX_SIZE];
+	bool has_channel = false;
+	bool has_channel_mask = false;
+	bool has_panid = false;
+	bool has_xpanid = false;
+	bool has_network_key = false;
+	bool has_key_index = false;
+	bool has_node_type = false;
+	bool has_mesh_local_prefix = false;
+	bool has_legacy_prefix = false;
 
 	dbus_error_init(&error);
 
@@ -67,6 +88,11 @@ int tool_cmd_form(int argc, char* argv[])
 			{"help", no_argument, 0, 'h'},
 			{"timeout", required_argument, 0, 't'},
 			{"channel", required_argument, 0, 'c'},
+			{"channel-mask", required_argument, 0, 'm'},
+			{"panid", required_argument, 0, 'p'},
+			{"xpanid", required_argument, 0, 'x'},
+			{"key", required_argument, 0, 'k'},
+			{"key-index", required_argument, 0, 'i'},
 			{"ula-prefix", required_argument, 0, 'u'},
 			{"mesh-local-prefix", required_argument, 0, 'M'},
 			{"legacy-prefix", required_argument, 0, 'L'},
@@ -75,16 +101,17 @@ int tool_cmd_form(int argc, char* argv[])
 		};
 
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hc:t:T:u:", long_options,
-				&option_index);
+		int c;
 
-		if (c == -1)
+		c = getopt_long(argc, argv, "ht:c:m:p:x:k:i:u:M:L:T:", long_options, &option_index);
+
+		if (c == -1) {
 			break;
+		}
 
 		switch (c) {
 		case 'h':
-			print_arg_list_help(form_option_list, argv[0],
-					    form_cmd_syntax);
+			print_arg_list_help(form_option_list, argv[0], form_cmd_syntax);
 			ret = ERRORCODE_HELP;
 			goto bail;
 
@@ -93,56 +120,151 @@ int tool_cmd_form(int argc, char* argv[])
 			break;
 
 		case 'c':
-			channel_mask = (1 << strtol(optarg, NULL, 0));
+			has_channel = true;
+			channel = strtol(optarg, NULL, 0);
+			break;
+
+		case 'm':
+			has_channel_mask = true;
+			channel_mask = strtomask_uint32(optarg);
+			if (channel_mask == 0) {
+				fprintf(stderr, "%s: error: Bad channel mask \"%s\"\n", argv[0], optarg);
+				ret = ERRORCODE_BADARG;
+				goto bail;
+			}
+			break;
+
+		case 'p':
+			has_panid = true;
+			panid = strtol(optarg, NULL, 0);
+			break;
+
+		case 'x':
+			has_xpanid = true;
+			xpanid = strtoull(optarg, NULL, 16);
+			break;
+
+		case 'k':
+			has_network_key = true;
+			if (parse_string_into_data(network_key, WPANCTL_NETWORK_KEY_SIZE, optarg) <= 0) {
+				fprintf(stderr, "%s: error: Bad network-key \"%s\"\n", argv[0], optarg);
+				ret = ERRORCODE_BADARG;
+				goto bail;
+			}
+			break;
+
+		case 'i':
+			has_key_index = true;
+			key_index = strtol(optarg, NULL, 0);
 			break;
 
 		case 'M':
-			fprintf(stderr,
-					"%s: error: Setting the mesh local address at the command line isn't yet implemented. Set it as a property instead.\n",
-					argv[0]);
-			ret = ERRORCODE_BADARG;
-			goto bail;
+			has_mesh_local_prefix = true;
+			ret = parse_prefix(optarg, mesh_local_prefix);
+			if (ret != ERRORCODE_OK) {
+				fprintf(stderr, "%s: error: Bad mesh-local prefix \"%s\"\n", argv[0], optarg);
+				goto bail;
+			}
 			break;
 
 		case 'L':
 		case 'u':
-			ula_prefix = optarg;
+			has_legacy_prefix = true;
+			ret = parse_prefix(optarg, legacy_prefix);
+			if (ret != ERRORCODE_OK) {
+				fprintf(stderr, "%s: error: Bad legacy prefix \"%s\"\n", argv[0], optarg);
+				goto bail;
+			}
 			break;
 
 		case 'T':
-			node_type = node_type_str2int(optarg);
+			has_node_type = true;
+			node_type = parse_node_type(optarg);
 			break;
 		}
 	}
 
 	if (optind < argc) {
-		if (!network_name) {
-			network_name = argv[optind];
-			optind++;
-		}
-	}
+		network_name = argv[optind];
+		optind++;
 
-	if (optind < argc) {
-		fprintf(stderr,
-			"%s: error: Unexpected extra argument: \"%s\"\n",
-			argv[0], argv[optind]);
+		if (strnlen(network_name, WPANCTL_NETWORK_NAME_MAX_LEN + 1) > WPANCTL_NETWORK_NAME_MAX_LEN) {
+			fprintf(stderr, "%s: error: Network name \"%s\" is too long (max %d chars)\n", argv[0], network_name,
+				WPANCTL_NETWORK_NAME_MAX_LEN);
+			ret = ERRORCODE_BADARG;
+			goto bail;
+		}
+
+	} else {
+		fprintf(stderr, "%s: error: Missing network name\n", argv[0]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
 
-	if (!network_name) {
-		fprintf(stderr, "%s: error: Missing network name.\n", argv[0]);
+	if (optind < argc) {
+		fprintf(stderr, "%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
 
 	if (gInterfaceName[0] == 0) {
 		fprintf(stderr,
-		        "%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
-		        argv[0]);
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n", argv[0]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
+
+	// Print the parameters
+
+	fprintf(stdout, "Forming WPAN \"%s\" as node type \"%s\"", network_name, node_type);
+
+	if (has_channel) {
+		fprintf(stdout, ", channel:%d", channel);
+	} else if (has_channel_mask) {
+		fprintf(stdout, ", channel-mask:0x%x", channel_mask);
+	}
+
+	if (has_panid) {
+		fprintf(stdout, ", panid:0x%04X", panid);
+	}
+
+	if (has_xpanid) {
+		fprintf(stdout, ", xpanid:0x%016llX", (unsigned long long)xpanid);
+	}
+
+	if (has_network_key) {
+		char key_str[WPANCTL_NETWORK_KEY_SIZE * 2 + 4];
+		encode_data_into_string(network_key, sizeof(network_key), key_str, sizeof(key_str), 0);
+		fprintf(stdout, ", key:[%s]", key_str);
+	}
+
+	if (has_key_index) {
+		fprintf(stdout, ", key-index:%d", key_index);
+	}
+
+	if (has_mesh_local_prefix) {
+		char address_string[INET6_ADDRSTRLEN] = "::";
+		uint8_t prefix_address[WPANCTL_IPv6_ADDRESS_SIZE];
+
+		memset(prefix_address, 0, sizeof(prefix_address));
+		memcpy(prefix_address, mesh_local_prefix, WPANCTL_PREFIX_SIZE);
+		inet_ntop(AF_INET6, (const void *)&prefix_address, address_string, sizeof(address_string));
+		fprintf(stdout, ", mesh-local-prefix:\"%s\"", address_string);
+	}
+
+	if (has_legacy_prefix) {
+		char address_string[INET6_ADDRSTRLEN] = "::";
+		uint8_t prefix_address[WPANCTL_IPv6_ADDRESS_SIZE];
+
+		memset(prefix_address, 0, sizeof(prefix_address));
+		memcpy(prefix_address, legacy_prefix, WPANCTL_PREFIX_SIZE);
+		inet_ntop(AF_INET6, (const void *)&prefix_address, address_string, sizeof(address_string));
+		fprintf(stdout, ", legacy-prefix:\"%s\"", address_string);
+	}
+
+	fprintf(stdout, "\n");
+
+	// Prepare DBus connection
 
 	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
 
@@ -154,122 +276,145 @@ int tool_cmd_form(int argc, char* argv[])
 
 	require_string(connection != NULL, bail, error.message);
 
-	{
-		DBusMessageIter iter;
-		DBusMessageIter list_iter;
-		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
-		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
-		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
-		if (ret != 0) {
-			goto bail;
-		}
-		snprintf(path,
-		         sizeof(path),
-		         "%s/%s",
-		         WPAN_TUNNEL_DBUS_PATH,
-		         gInterfaceName);
+	// Prepare DBus message
 
-		message = dbus_message_new_method_call(
-		    interface_dbus_name,
-		    path,
-		    WPAN_TUNNEL_DBUS_INTERFACE,
-		    WPAN_IFACE_CMD_FORM
-		    );
+	ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_FORM);
+	require_action(ret == 0, bail, print_error_diagnosis(ret));
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_STRING, &network_name,
-		    DBUS_TYPE_INT16, &node_type,
-		    DBUS_TYPE_UINT32, &channel_mask,
-		    DBUS_TYPE_INVALID
-		    );
+	dbus_message_iter_init_append(message, &msg_iter);
 
-		if(ula_prefix) {
-			uint8_t ula_bytes[16] = {};
+	// Open a container as "Array of Dictionary entries from String to Variants" (dbus type "a{sv}")
+	dbus_message_iter_open_container(
+		&msg_iter,
+		DBUS_TYPE_ARRAY,
+		DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+			DBUS_TYPE_STRING_AS_STRING
+			DBUS_TYPE_VARIANT_AS_STRING
+		DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
+		&dict_iter
+	);
 
-			// So the ULA prefix could either be
-			// specified like an IPv6 address, or
-			// specified as a bunch of hex numbers.
-			// We use the presence of a colon (':')
-			// to differentiate.
-			if(strstr(ula_prefix,":")) {
+	// Append dictionary entries
 
-				// Address-style
-				int bits = inet_pton(AF_INET6,ula_prefix,ula_bytes);
-				if(bits<0) {
-					fprintf(stderr,
-					        "Bad ULA \"%s\", errno=%d (%s)\n",
-					        ula_prefix,
-					        errno,
-					        strerror(errno));
-					goto bail;
-				} else if(!bits) {
-					fprintf(stderr, "Bad ULA \"%s\"\n", ula_prefix);
-					goto bail;
-				}
-			} else {
-				// DATA-style
-				int length = parse_string_into_data(ula_bytes,
-				                                    8,
-				                                    ula_prefix);
-				if(length<=0) {
-					fprintf(stderr, "Bad ULA \"%s\"\n", ula_prefix);
-					goto bail;
-				}
-			}
+	append_dbus_dict_entry_basic(
+		&dict_iter,
+		kWPANTUNDProperty_NetworkName,
+		DBUS_TYPE_STRING, &network_name
+	);
 
-			fprintf(stderr, "Using ULA prefix \"%s\"\n", ula_prefix);
+	if (has_node_type) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkNodeType,
+			DBUS_TYPE_STRING, &node_type
+		);
+	}
 
-			uint8_t *addr = ula_bytes;
-			dbus_message_append_args(
-			    message,
-			    DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 8,
-			    DBUS_TYPE_INVALID
-			    );
-		}
+	if (has_channel) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NCPChannel,
+			DBUS_TYPE_UINT16, &channel
+		);
+	}
 
-		fprintf(stderr,
-		        "Forming WPAN \"%s\" as node type \"%s\"\n",
-		        network_name,
-		        node_type_int2str(node_type));
+	if (has_channel_mask) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NCPChannelMask,
+			DBUS_TYPE_UINT32, &channel_mask
+		);
+	}
 
+	if (has_panid) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkPANID,
+			DBUS_TYPE_UINT16, &panid
+		);
+	}
 
-		reply = dbus_connection_send_with_reply_and_block(
-		    connection,
-		    message,
-		    timeout,
-		    &error
-		    );
+	if (has_xpanid) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkXPANID,
+			DBUS_TYPE_UINT64, &xpanid
+		);
+	}
 
-		if (!reply) {
-			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
-			ret = ERRORCODE_TIMEOUT;
-			goto bail;
-		}
+	if (has_network_key) {
+		append_dbus_dict_entry_byte_array(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkKey,
+			network_key,
+			sizeof(network_key)
+		);
+	}
 
-		dbus_message_get_args(reply, &error,
-		                      DBUS_TYPE_INT32, &ret,
-		                      DBUS_TYPE_INVALID
-		                      );
+	if (has_key_index) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkKeyIndex,
+			DBUS_TYPE_UINT32, &key_index
+		);
+	}
 
-		if (!ret) {
-			fprintf(stderr, "Successfully formed!\n");
-		} else {
-			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
-			print_error_diagnosis(ret);
-		}
+	if (has_mesh_local_prefix) {
+		append_dbus_dict_entry_byte_array(
+			&dict_iter,
+			kWPANTUNDProperty_IPv6MeshLocalPrefix,
+			mesh_local_prefix,
+			WPANCTL_PREFIX_SIZE
+		);
+	}
+
+	if (has_legacy_prefix) {
+		append_dbus_dict_entry_byte_array(
+			&dict_iter,
+			kWPANTUNDProperty_NestLabs_LegacyMeshLocalPrefix,
+			legacy_prefix,
+			WPANCTL_PREFIX_SIZE
+		);
+	}
+
+	dbus_message_iter_close_container(&msg_iter, &dict_iter);
+
+	// Send DBus message and parse the DBus reply
+
+	reply = dbus_connection_send_with_reply_and_block(connection, message, timeout, &error);
+
+	if (!reply) {
+		fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+		ret = ERRORCODE_TIMEOUT;
+		goto bail;
+	}
+
+	dbus_message_get_args(
+		reply, &error,
+		DBUS_TYPE_INT32, &ret,
+		DBUS_TYPE_INVALID
+	);
+
+	if (!ret) {
+		fprintf(stdout, "Successfully formed!\n");
+	} else {
+		fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
 	}
 
 bail:
 
-	if (connection)
+	if (connection) {
 		dbus_connection_unref(connection);
+	}
 
-	if (message)
+	if (message) {
 		dbus_message_unref(message);
+	}
 
-	if (reply)
+	if (reply) {
 		dbus_message_unref(reply);
+	}
 
 	dbus_error_free(&error);
 

--- a/src/wpanctl/tool-cmd-join.c
+++ b/src/wpanctl/tool-cmd-join.c
@@ -24,39 +24,55 @@
 #include <stdlib.h>
 #include <getopt.h>
 #include "wpanctl-utils.h"
+#include "string-utils.h"
 #include "tool-cmd-join.h"
 #include "tool-cmd-scan.h"
 #include "assert-macros.h"
 #include "args.h"
 #include "assert-macros.h"
-#include "wpan-dbus-v0.h"
+#include "wpan-dbus-v1.h"
 
 #include <errno.h>
 
-const char join_cmd_syntax[] = "[args] [network-name]";
+const char join_cmd_syntax[] = "[args] <network name> or <index of a previously scanned network>";
 
 static const arg_list_item_t join_option_list[] = {
 	{'h', "help", NULL, "Print Help"},
 	{'t', "timeout", "ms", "Set timeout period"},
 	{'T', "type", "node-type: router(r,2), end-device(end,e,3), sleepy-end-device(sleepy,sed,4), nl-lurker(lurker,l,6)",
 		"Join as a specific node type"},
-	{'p', "panid", "panid", "Specify a specific PAN ID"},
-	{'x', "xpanid", "xpanid", "Specify a specific Extended PAN ID"},
-	{'c', "channel", "channel", "Specify a specific channel"},
+	{'p', "panid", NULL, "Specify a specific PAN ID"},
+	{'x', "xpanid", NULL, "Specify a specific Extended PAN ID"},
+	{'c', "channel", NULL, "Specify a specific channel"},
+	{'k', "key", NULL, "Specify the network key"},
+	{'n', "name", NULL, "Forces the input argument to be treated as <network name> instead of scan index"
+		" (useful if network name is a number)"},
 	{0}
 };
 
 int tool_cmd_join(int argc, char* argv[])
 {
-	int ret = 0;
-	int c;
+	int ret = ERRORCODE_OK;
 	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
 	DBusConnection* connection = NULL;
 	DBusMessage *message = NULL;
 	DBusMessage *reply = NULL;
 	DBusError error;
-	uint16_t node_type = WPAN_IFACE_ROLE_END_DEVICE;
-	struct wpan_network_info_s target_network = {};
+	DBusMessageIter msg_iter;
+	DBusMessageIter dict_iter;
+
+	bool parse_arg_as_network_name = false;
+	int scanned_network_index = -1;
+	const char *network_name = NULL;
+	const char *node_type = kWPANTUNDNodeType_EndDevice;
+	uint16_t channel = 0;
+	uint16_t panid = 0;
+	uint64_t xpanid = 0;
+	uint8_t network_key[WPANCTL_NETWORK_KEY_SIZE];
+	bool has_channel = false;
+	bool has_panid = false;
+	bool has_xpanid = false;
+	bool has_network_key = false;
 
 	dbus_error_init(&error);
 
@@ -68,20 +84,23 @@ int tool_cmd_join(int argc, char* argv[])
 			{"panid", required_argument, 0, 'p'},
 			{"xpanid", required_argument, 0, 'x'},
 			{"channel", required_argument, 0, 'c'},
+			{"key", required_argument, 0, 'k'},
+			{"name", no_argument, 0, 'n'},
 			{0, 0, 0, 0}
 		};
 
 		int option_index = 0;
-		c = getopt_long(argc, argv, "hc:t:T:x:p:", long_options,
-				&option_index);
+		int c;
 
-		if (c == -1)
+		c = getopt_long(argc, argv, "ht:T:x:p:c:k:n", long_options, &option_index);
+
+		if (c == -1) {
 			break;
+		}
 
 		switch (c) {
 		case 'h':
-			print_arg_list_help(join_option_list, argv[0],
-					    join_cmd_syntax);
+			print_arg_list_help(join_option_list, argv[0], join_cmd_syntax);
 			ret = ERRORCODE_HELP;
 			goto bail;
 
@@ -90,67 +109,148 @@ int tool_cmd_join(int argc, char* argv[])
 			break;
 
 		case 'p':
-			target_network.pan_id = strtol(optarg, NULL, 16);
-			break;
-
-		case 'c':
-			target_network.channel = strtol(optarg, NULL, 0);
+			has_panid = true;
+			panid = strtol(optarg, NULL, 0);
 			break;
 
 		case 'x':
-			target_network.xpanid = strtoull(optarg, NULL, 16);
+			has_xpanid = true;
+			xpanid = strtoull(optarg, NULL, 16);
+			break;
+
+		case 'c':
+			has_channel = true;
+			channel = strtol(optarg, NULL, 0);
+			break;
+
+		case 'k':
+			has_network_key = true;
+			if (parse_string_into_data(network_key, WPANCTL_NETWORK_KEY_SIZE, optarg) <= 0) {
+				fprintf(stderr, "%s: error: Bad network-key \"%s\"\n", argv[0], optarg);
+				ret = ERRORCODE_BADARG;
+				goto bail;
+			}
 			break;
 
 		case 'T':
-			node_type = node_type_str2int(optarg);
+			node_type = parse_node_type(optarg);
+			break;
+
+		case 'n':
+			parse_arg_as_network_name = true;
 			break;
 		}
 	}
 
 	if (optind < argc) {
-		if (!target_network.network_name[0]) {
-			int index;
-			if (1 == sscanf(argv[optind], "%d",
-					&index) && index
-			    && (index <= gScannedNetworkCount)) {
-				target_network = gScannedNetworks[index - 1];
-			} else {
-				strncpy(target_network.network_name,
-					argv[optind], 16);
-				target_network.network_name[16] = 0;
+
+		// Instead of network-name the index of a previously scanned network can be provided.
+
+		if (!parse_arg_as_network_name && sscanf(argv[optind], "%d", &scanned_network_index) == 1) {
+
+			if (gScannedNetworkCount == 0) {
+				fprintf(stderr,
+					"%s: error: Index %d but no previous/saved scanned networks\n"
+					"\nuse `-n` to force the argument to be parsed as <network-name>"
+					"\ninstead of <index of a previously scanned network>\n\n",
+					argv[0], scanned_network_index);
+				ret = ERRORCODE_BADARG;
+				goto bail;
 			}
-			optind++;
-		}
-	}
 
-	if (optind < argc) {
-		if (!target_network.xpanid) {
-			target_network.xpanid = strtoull(argv[optind], NULL, 16);
-			optind++;
-		}
-	}
+			if ((scanned_network_index == 0) || (scanned_network_index > gScannedNetworkCount)) {
+				fprintf(stderr, "%s: error: Invalid index %d. %d saved scan networks\n"
+					"\nuse `-n` to force the argument to be parsed as <network-name>"
+					"\ninstead of <index of a previously scanned network>\n\n",
+					argv[0], scanned_network_index, gScannedNetworkCount);
+				ret - ERRORCODE_BADARG;
+				goto bail;
+			}
 
-	if (optind < argc) {
-		fprintf(stderr,
-			"%s: error: Unexpected extra argument: \"%s\"\n",
-			argv[0], argv[optind]);
+			if (has_panid) {
+				fprintf(stderr, "%s: warning: Specified PANID will be overwritten by scanned network info.\n", argv[0]);
+			}
+
+			if (has_xpanid) {
+				fprintf(stderr, "%s: warning: Specified XPANID will be overwritten by scanned network info.\n",
+					argv[0]);
+			}
+
+			if (has_channel) {
+				fprintf(stderr, "%s: warning: Specified channel will be overwritten by scanned network info.\n",
+					argv[0]);
+			}
+
+			has_panid = true;
+			panid = gScannedNetworks[scanned_network_index - 1].pan_id;
+
+			has_xpanid = true;
+			xpanid = gScannedNetworks[scanned_network_index - 1].xpanid;
+
+			has_channel = true;
+			channel = gScannedNetworks[scanned_network_index - 1].channel;
+
+			network_name = gScannedNetworks[scanned_network_index -1].network_name;
+
+		} else {
+			network_name = argv[optind];
+		}
+
+		if (strnlen(network_name, WPANCTL_NETWORK_NAME_MAX_LEN + 1) > WPANCTL_NETWORK_NAME_MAX_LEN) {
+			fprintf(stderr, "%s: error: Network name \"%s\" is too long (max %d chars)\n", argv[0], network_name,
+				WPANCTL_NETWORK_NAME_MAX_LEN);
+			ret = ERRORCODE_BADARG;
+			goto bail;
+		}
+
+		optind++;
+
+	} else {
+		fprintf(stderr, "%s: error: Missing network name\n", argv[0]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
 
-	if (!target_network.network_name[0]) {
-		fprintf(stderr, "%s: error: Missing network name.\n", argv[0]);
+	if (optind < argc) {
+		fprintf(stderr, "%s: error: Unexpected extra argument: \"%s\"\n", argv[0], argv[optind]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
 
 	if (gInterfaceName[0] == 0) {
 		fprintf(stderr,
-		        "%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
-		        argv[0]);
+			"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n", argv[0]);
 		ret = ERRORCODE_BADARG;
 		goto bail;
 	}
+
+	fprintf(stderr, "Joining WPAN \"%s\" as node type \"%s\"", network_name, node_type);
+
+	if (has_channel) {
+		fprintf(stdout, ", channel:%d", channel);
+	}
+
+	if (has_panid) {
+		fprintf(stdout, ", panid:0x%04X", panid);
+	}
+
+	if (has_xpanid) {
+		fprintf(stdout, ", xpanid:0x%016llX", (unsigned long long)xpanid);
+	}
+
+	if (has_network_key) {
+		char key_str[WPANCTL_NETWORK_KEY_SIZE * 2 + 4];
+		encode_data_into_string(network_key, sizeof(network_key), key_str, sizeof(key_str), 0);
+		fprintf(stdout, ", key:[%s]", key_str);
+	}
+
+	if (scanned_network_index != -1) {
+		fprintf(stdout, " [scanned network index %d]", scanned_network_index);
+	}
+
+	fprintf(stdout, "\n");
+
+	// Prepare DBus connection
 
 	connection = dbus_bus_get(DBUS_BUS_STARTER, &error);
 
@@ -162,106 +262,116 @@ int tool_cmd_join(int argc, char* argv[])
 
 	require_string(connection != NULL, bail, error.message);
 
-	{
-		DBusMessageIter iter;
-		DBusMessageIter list_iter;
-		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
-		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
-		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
-		if (ret != 0) {
-			goto bail;
-		}
-		snprintf(path,
-		         sizeof(path),
-		         "%s/%s",
-		         WPAN_TUNNEL_DBUS_PATH,
-		         gInterfaceName);
-		char* network_name = target_network.network_name;
+	// Prepare DBus message
 
-		message = dbus_message_new_method_call(
-		    interface_dbus_name,
-		    path,
-		    WPAN_TUNNEL_DBUS_INTERFACE,
-		    WPAN_IFACE_CMD_JOIN
-		    );
+	ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_JOIN);
+	require_action(ret == 0, bail, print_error_diagnosis(ret));
 
-		fprintf(stderr,
-		        "Joining \"%s\" %016llX as node type \"%s\"\n",
-		        target_network.network_name,
-		        (unsigned long long)target_network.xpanid,
-		        node_type_int2str(node_type));
+	dbus_message_iter_init_append(message, &msg_iter);
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_STRING, &network_name,
-		    DBUS_TYPE_INVALID
-		    );
+	// Open a container as "Array of Dictionary entries from String to Variants" (dbus type "a{sv}")
+	dbus_message_iter_open_container(
+		&msg_iter,
+		DBUS_TYPE_ARRAY,
+		DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+			DBUS_TYPE_STRING_AS_STRING
+			DBUS_TYPE_VARIANT_AS_STRING
+		DBUS_DICT_ENTRY_END_CHAR_AS_STRING,
+		&dict_iter
+	);
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_INT16, &node_type,
-		    DBUS_TYPE_INVALID
-		    );
+	// Append dictionary entries
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_UINT64, &target_network.xpanid,
-		    DBUS_TYPE_INVALID
-		    );
+	append_dbus_dict_entry_basic(
+		&dict_iter,
+		kWPANTUNDProperty_NetworkName,
+		DBUS_TYPE_STRING, &network_name
+	);
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_UINT16, &target_network.pan_id,
-		    DBUS_TYPE_INVALID
-		    );
+	append_dbus_dict_entry_basic(
+		&dict_iter,
+		kWPANTUNDProperty_NetworkNodeType,
+		DBUS_TYPE_STRING, &node_type
+	);
 
-		dbus_message_append_args(
-		    message,
-		    DBUS_TYPE_BYTE, &target_network.channel,
-		    DBUS_TYPE_INVALID
-		    );
+	if (has_channel) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NCPChannel,
+			DBUS_TYPE_UINT16, &channel
+		);
+	}
 
-		reply = dbus_connection_send_with_reply_and_block(
-		    connection,
-		    message,
-		    timeout,
-		    &error
-		    );
+	if (has_panid) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkPANID,
+			DBUS_TYPE_UINT16, &panid
+		);
+	}
 
-		if (!reply) {
-			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
-			ret = ERRORCODE_TIMEOUT;
-			goto bail;
-		}
+	if (has_xpanid) {
+		append_dbus_dict_entry_basic(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkXPANID,
+			DBUS_TYPE_UINT64, &xpanid
+		);
+	}
 
-		dbus_message_get_args(reply, &error,
-		                      DBUS_TYPE_INT32, &ret,
-		                      DBUS_TYPE_INVALID
-		                      );
+	if (has_network_key) {
+		append_dbus_dict_entry_byte_array(
+			&dict_iter,
+			kWPANTUNDProperty_NetworkKey,
+			network_key,
+			sizeof(network_key)
+		);
+	}
 
-		if (!ret) {
-			fprintf(stderr, "Successfully Joined!\n");
-		} else if ((ret == -EINPROGRESS) || (ret == kWPANTUNDStatus_InProgress)) {
-			fprintf(stderr,
-			        "Partial (insecure) join. Credentials needed. Update key to continue.\n");
-			ret = 0;
-		} else {
-			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+	dbus_message_iter_close_container(&msg_iter, &dict_iter);
 
-			print_error_diagnosis(ret);
-		}
+	// Send DBus message and parse the DBus reply
+
+	reply = dbus_connection_send_with_reply_and_block(
+		connection,
+		message,
+		timeout,
+		&error
+	);
+
+	if (!reply) {
+		fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+		ret = ERRORCODE_TIMEOUT;
+		goto bail;
+	}
+
+	dbus_message_get_args(
+		reply, &error,
+		DBUS_TYPE_INT32, &ret,
+		DBUS_TYPE_INVALID
+	);
+
+	if (!ret) {
+		fprintf(stdout, "Successfully Joined!\n");
+	} else if ((ret == -EINPROGRESS) || (ret == kWPANTUNDStatus_InProgress)) {
+		fprintf(stdout, "Partial (insecure) join. Credentials needed. Update key to continue.\n");
+		ret = ERRORCODE_OK;
+	} else {
+		fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+		print_error_diagnosis(ret);
 	}
 
 bail:
-
-	if (connection)
+	if (connection) {
 		dbus_connection_unref(connection);
+	}
 
-	if (message)
+	if (message) {
 		dbus_message_unref(message);
+	}
 
-	if (reply)
+	if (reply) {
 		dbus_message_unref(reply);
+	}
 
 	dbus_error_free(&error);
 

--- a/src/wpanctl/wpanctl-utils.c
+++ b/src/wpanctl/wpanctl-utils.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
+#include <arpa/inet.h>
 
 #ifdef __APPLE__
 char gInterfaceName[32] = "utun2";
@@ -322,6 +323,83 @@ bail:
 }
 
 int
+parse_prefix(const char *prefix_str, uint8_t *prefix)
+{
+	int ret = ERRORCODE_OK;
+
+	// The prefix could either be specified like an IPv6 address, or
+	// specified as a bunch of hex numbers. Presence of a colon (':')
+	// is used to differentiate.
+
+	if (strstr(prefix_str,":")) {
+		uint8_t address[INET6_ADDRSTRLEN];
+
+		int bits = inet_pton(AF_INET6, prefix_str, address);
+
+		if (bits < 0) {
+			ret = ERRORCODE_BADARG;
+			goto bail;
+		}
+
+		memcpy(prefix, address, WPANCTL_PREFIX_SIZE);
+
+	} else {
+
+		if (parse_string_into_data(prefix, WPANCTL_PREFIX_SIZE, prefix_str) <= 0) {
+			ret = ERRORCODE_BADARG;
+		}
+	}
+
+bail:
+	return ret;
+}
+
+const char *
+parse_node_type(const char *type_str)
+{
+	const char *node_type = kWPANTUNDNodeType_Unknown;
+
+	if (!strcasecmp(type_str, "router")
+		|| !strcasecmp(type_str, "r")
+		|| !strcasecmp(type_str, "2")
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_Router)
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_Leader)
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_Commissioner)
+	) {
+		node_type = kWPANTUNDNodeType_Router;
+
+	} else if (!strcasecmp(type_str, "end-device")
+		|| !strcasecmp(type_str, "enddevice")
+		|| !strcasecmp(type_str, "end")
+		|| !strcasecmp(type_str, "ed")
+		|| !strcasecmp(type_str, "e")
+		|| !strcasecmp(type_str, "3")
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_EndDevice)
+	) {
+		node_type = kWPANTUNDNodeType_EndDevice;
+
+	} else if (!strcasecmp(type_str, "sleepy-end-device")
+		|| !strcasecmp(type_str, "sleepy")
+		|| !strcasecmp(type_str, "sed")
+		|| !strcasecmp(type_str, "s")
+		|| !strcasecmp(type_str, "4")
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_SleepyEndDevice)
+	) {
+		node_type = kWPANTUNDNodeType_SleepyEndDevice;
+
+	} else if (!strcasecmp(type_str, "lurker")
+		|| !strcasecmp(type_str, "nl-lurker")
+		|| !strcasecmp(type_str, "l")
+		|| !strcasecmp(type_str, "6")
+		|| !strcasecmp(type_str, kWPANTUNDNodeType_NestLurker)
+	) {
+		node_type = kWPANTUNDNodeType_NestLurker;
+	}
+
+	return node_type;
+}
+
+int
 lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name)
 {
 	int ret = kWPANTUNDStatus_InterfaceNotFound;
@@ -574,29 +652,8 @@ node_type_int2str(uint16_t node_type)
 	return "unknown";
 }
 
-int create_new_wpan_dbus_message(DBusMessage **message, const char *dbus_command)
-{
-	int ret = 0;
-	char path[DBUS_MAXIMUM_NAME_LENGTH + 1];
-	char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH + 1];
-
-	assert(*message == NULL);
-
-	ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
-	require_quiet(ret == 0, bail);
-
-	snprintf(path, sizeof(path), "%s/%s", WPANTUND_DBUS_PATH, gInterfaceName);
-	*message = dbus_message_new_method_call(interface_dbus_name, path, WPANTUND_DBUS_APIv1_INTERFACE, dbus_command);
-
-	if (*message == NULL) {
-		ret = ERRORCODE_ALLOC;
-	}
-
-bail:
-	return ret;
-}
-
-const char *joiner_state_int2str(uint8_t state)
+const char *
+joiner_state_int2str(uint8_t state)
 {
     const char *ret = "idle";
 
@@ -631,4 +688,77 @@ const char *joiner_state_int2str(uint8_t state)
     }
 
     return ret;
+}
+
+int
+create_new_wpan_dbus_message(DBusMessage **message, const char *dbus_command)
+{
+	int ret = 0;
+	char path[DBUS_MAXIMUM_NAME_LENGTH + 1];
+	char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH + 1];
+
+	assert(*message == NULL);
+
+	ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+	require_quiet(ret == 0, bail);
+
+	snprintf(path, sizeof(path), "%s/%s", WPANTUND_DBUS_PATH, gInterfaceName);
+	*message = dbus_message_new_method_call(interface_dbus_name, path, WPANTUND_DBUS_APIv1_INTERFACE, dbus_command);
+
+	if (*message == NULL) {
+		ret = ERRORCODE_ALLOC;
+	}
+
+bail:
+	return ret;
+}
+
+void
+append_dbus_dict_entry_basic(DBusMessageIter *dict_iter, const char *key, char dbus_basic_type, void *value)
+{
+	DBusMessageIter entry_iter;
+	DBusMessageIter value_iter;
+	char dbus_signature[2] = { dbus_basic_type, '\0' };
+
+	dbus_message_iter_open_container(dict_iter, DBUS_TYPE_DICT_ENTRY, NULL, &entry_iter);
+
+	// Append dictionary key as String
+	dbus_message_iter_append_basic(&entry_iter, DBUS_TYPE_STRING, &key);
+
+	// Append dictionary value as Variant with the given basic type
+	dbus_message_iter_open_container(&entry_iter, DBUS_TYPE_VARIANT, dbus_signature, &value_iter);
+	dbus_message_iter_append_basic(&value_iter, dbus_basic_type, value);
+	dbus_message_iter_close_container(&entry_iter, &value_iter);
+
+	dbus_message_iter_close_container(dict_iter, &entry_iter);
+}
+
+void
+append_dbus_dict_entry_byte_array(DBusMessageIter *dict_iter, const char *key, const uint8_t *data, int data_len)
+{
+	DBusMessageIter entry_iter;
+	DBusMessageIter value_iter;
+	DBusMessageIter array_iter;
+
+	dbus_message_iter_open_container(dict_iter, DBUS_TYPE_DICT_ENTRY, NULL, &entry_iter);
+
+	// Append dictionary key as String
+	dbus_message_iter_append_basic(&entry_iter, DBUS_TYPE_STRING, &key);
+
+	// Append dictionary value as Variant with type Array of Bytes
+	dbus_message_iter_open_container(
+		&entry_iter,
+		DBUS_TYPE_VARIANT,
+		DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING,
+		&value_iter
+	);
+
+	// Append byte array
+	dbus_message_iter_open_container(&value_iter, DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE_AS_STRING, &array_iter);
+	dbus_message_iter_append_fixed_array(&array_iter, DBUS_TYPE_BYTE, &data, data_len);
+	dbus_message_iter_close_container(&value_iter, &array_iter);
+
+	dbus_message_iter_close_container(&entry_iter, &value_iter);
+
+	dbus_message_iter_close_container(dict_iter, &entry_iter);
 }

--- a/src/wpanctl/wpanctl-utils.h
+++ b/src/wpanctl/wpanctl-utils.h
@@ -49,6 +49,12 @@
 
 #define DEFAULT_TIMEOUT_IN_SECONDS     60
 
+#define WPANCTL_PREFIX_SIZE            8
+#define WPANCTL_XPANID_SIZE            8
+#define WPANCTL_NETWORK_KEY_SIZE       16
+#define WPANCTL_IPv6_ADDRESS_SIZE      16
+#define WPANCTL_NETWORK_NAME_MAX_LEN   16  // Max number of chars
+
 struct command_info_s {
 	const char* name;
 	const char* desc;
@@ -80,12 +86,24 @@ enum joiner_state{
 void print_error_diagnosis(int error);
 int parse_network_info_from_iter(struct wpan_network_info_s *network_info, DBusMessageIter *iter);
 int parse_energy_scan_result_from_iter(int16_t *channel, int8_t *maxRssi, DBusMessageIter *iter);
+
+// Parses a given (ULA, mesh-local) prefix string `prefix_str` and output the result in `prefix` array (expected 8 bytes)
+// Returns ERRORCODE_OK on success or otherwise the error code.
+int parse_prefix(const char *prefix_str, uint8_t *prefix);
+
+// Parses a node type argument (e.g., for `form` or `join` command) and converts it to `kWPANTUNDNodeType_<type>`
+// string.
+const char *parse_node_type(const char *type_arg);
+
 int lookup_dbus_name_from_interface(char* dbus_bus_name, const char* interface_name);
 void dump_info_from_iter(FILE* file, DBusMessageIter *iter, int indent, bool bare, bool indentFirstLine);
 uint16_t node_type_str2int(const char *node_type);
 const char *node_type_int2str(uint16_t node_type);
 const char *joiner_state_int2str(uint8_t state);
+
 int create_new_wpan_dbus_message(DBusMessage **message, const char *dbus_command);
+void append_dbus_dict_entry_basic(DBusMessageIter *dict_iter, const char *key, char dbus_basic_type, void *value);
+void append_dbus_dict_entry_byte_array(DBusMessageIter *dict_iter, const char *key, const uint8_t *data, int data_len);
 
 extern char gInterfaceName[32];
 extern int gRet;


### PR DESCRIPTION
This commit enhances the implementation of `form` and `join` wpanctl
commands to use wpantund DBus v1 APIs (instead of v0). New (v1) APIs
are more flexible and allow a dictionary of property key (as string),
property value (as DBus variant type) to be provided as input. Both
`form` and `join` wpanctl commands are updated to allow more
(optional) parameters to be specified: `form` allows panid, xpaind,
network key, key index, mesh-local-prefix channel mask to be
optionally provided as part of the `form` command in addition to
network name and/or channel. `join` allows network key to be specified
as part of `join` command itself.