### PR TITLE
Add a common method to log sent/received spinel frame info

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -328,6 +328,8 @@ SpinelNCPInstance::ncp_to_driver_pump()
 				break;
 			}
 
+			log_spinel_frame(kNCPToDriver, mInboundFrame, mInboundFrameSize);
+
 			handle_ncp_spinel_callback(command_value, mInboundFrame, mInboundFrameSize);
 		}
 	} // while (!ncp_state_is_detached_from_ncp(get_ncp_state()))
@@ -387,41 +389,7 @@ SpinelNCPInstance::driver_to_ncp_pump()
 		// Get packet or management command, and also
 		// perform any necessary filtering.
 		if (mOutboundBufferLen > 0) {
-			if (mOutboundBuffer[1] == SPINEL_CMD_PROP_VALUE_GET) {
-				spinel_prop_key_t key;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "Cii", NULL, NULL, &key);
-				syslog(LOG_INFO, "[->NCP] CMD_PROP_VALUE_GET(%s) tid:%d", spinel_prop_key_to_cstr(key), SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_PROP_VALUE_SET) {
-				spinel_prop_key_t key;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "Cii", NULL, NULL, &key);
-				syslog(LOG_INFO, "[->NCP] CMD_PROP_VALUE_SET(%s) tid:%d", spinel_prop_key_to_cstr(key), SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_PROP_VALUE_INSERT) {
-				spinel_prop_key_t key;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "Cii", NULL, NULL, &key);
-				syslog(LOG_INFO, "[->NCP] CMD_PROP_VALUE_INSERT(%s) tid:%d", spinel_prop_key_to_cstr(key), SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_PROP_VALUE_REMOVE) {
-				spinel_prop_key_t key;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "Cii", NULL, NULL, &key);
-				syslog(LOG_INFO, "[->NCP] CMD_PROP_VALUE_REMOVE(%s) tid:%d", spinel_prop_key_to_cstr(key), SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_NOOP) {
-				syslog(LOG_INFO, "[->NCP] CMD_NOOP tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_RESET) {
-				syslog(LOG_INFO, "[->NCP] CMD_RESET tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_NET_CLEAR) {
-				syslog(LOG_INFO, "[->NCP] CMD_NET_CLEAR tid:%d", SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_PEEK) {
-				uint32_t address = 0;
-				uint16_t count = 0;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "CiLS", NULL, NULL, &address, &count);
-				syslog(LOG_INFO, "[->NCP] CMD_PEEK(0x%x,%d) tid:%d", address, count, SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else if (mOutboundBuffer[1] == SPINEL_CMD_POKE) {
-				uint32_t address = 0;
-				uint16_t count = 0;
-				spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "CiLS", NULL, NULL, &address, &count);
-				syslog(LOG_INFO, "[->NCP] CMD_NET_POKE(0x%x,%d) tid:%d", address, count, SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			} else {
-				syslog(LOG_INFO, "[->NCP] Spinel command 0x%02X tid:%d", mOutboundBuffer[1], SPINEL_HEADER_GET_TID(mOutboundBuffer[0]));
-			}
+			log_spinel_frame(kDriverToNCP, mOutboundBuffer, mOutboundBufferLen);
 		} else {
 			// There is an IPv6 packet waiting on one of the tunnel interfaces.
 

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -177,6 +177,14 @@ protected:
 	static uint8_t convert_route_preference_to_flags(RoutePreference priority);
 
 private:
+	enum SpinelFrameOrigin {
+		kDriverToNCP,
+		kNCPToDriver,
+	};
+
+	void log_spinel_frame(SpinelFrameOrigin origin, const uint8_t *frame_ptr, spinel_size_t frame_len);
+
+private:
 	void update_node_type(NodeType node_type);
 	void update_link_local_address(struct in6_addr *addr);
 	void update_mesh_local_address(struct in6_addr *addr);


### PR DESCRIPTION
This commit adds `log_spinel_frame()` which implements the code to
log sent or received spinel frame info, including the spinel command
and in case of property change (e.g., `VALUE_GET`, `VALUE_SET,
`VALUE_IS`, etc.) the property key and also hex dump of the
encoded value of the property.