### PR TITLE
Re-initialize NCP on driver start after a stop

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -70,8 +70,6 @@ SpinelNCPInstance::vprocess_disabled(int event, va_list args)
 
 		reset_tasks(kWPANTUNDStatus_Canceled);
 
-		mPrimaryInterface->set_up(false);
-
 		if ((get_ncp_state() != DEEP_SLEEP) && (get_ncp_state() != FAULT)) {
 			start_new_task(boost::shared_ptr<SpinelNCPTask>(new SpinelNCPTaskDeepSleep(this, NilReturn())));
 
@@ -593,8 +591,12 @@ SpinelNCPInstance::vprocess_event(int event, va_list args)
 			EH_RESTART();
 
 		} else if (!mEnabled) {
-			syslog(LOG_NOTICE, "Interface Disabled.");
+			syslog(LOG_NOTICE, "Driver disabled.");
 			EH_SPAWN(&mSubPT, vprocess_disabled(event, args));
+			if (mEnabled) {
+				syslog(LOG_NOTICE, "Driver enabled - reinitializing NCP.");
+				EH_RESTART();
+			}
 
 		} else if (ncp_state_is_joining_or_joined(get_ncp_state())) {
 			EH_SPAWN(&mSubPT, vprocess_associated(event, args));

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -1292,6 +1292,11 @@ NCPInstanceBase::handle_ncp_state_change(NCPState new_ncp_state, NCPState old_nc
 	} else if (ncp_state_is_interface_up(old_ncp_state)
 				&& (new_ncp_state == COMMISSIONED)
 				&& mAutoResume
+				// The `mEnabled` check covers the case where driver is disabled
+				// causing a transition to COMMISSIONED state. In that case
+				// we want to fall to "InterfaceUp -> InterfaceDown (General Case)"
+				// to take the interface down.
+				&& mEnabled
 	) {
 		// We don't bother going further if autoresume is on.
 		return;


### PR DESCRIPTION
This commit contains the following changes:

1) It adds new code to restart the main proptothread from
   `SpinelNCPInstance::vprocess_event()` when driver is enabled again
   after a driver disable. This ensures internal state stays in sync
   with NCP and that the network is resumed if `mAutoResume` feature
   is enabled.

2) The code changes how the interface is taken offline when driver
   is disabled.
   It updates `NCPInstanceBase::handle_ncp_state_change()` to ensure
   when driver is disabled causing a transition to `COMMISSIONED`
   state even if `mAutoResume` is enabled, the network interface(s)
   are taken down.
   It also removes the call from `vprocess_disabled()` protothread
   to bring down the interface.