### PR TITLE
Add new property to get list of NCP capabilities

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -442,6 +442,7 @@ SpinelNCPInstance::get_supported_property_keys()const
 	properties.insert(kWPANTUNDProperty_NCPRSSI);
 	properties.insert(kWPANTUNDProperty_NCPExtendedAddress);
 	properties.insert(kWPANTUNDProperty_NCPCCAFailureRate);
+	properties.insert(kWPANTUNDProperty_NCPCapabilities);
 
 	if (mCapabilities.count(SPINEL_CAP_ROLE_SLEEPY)) {
 		properties.insert(kWPANTUNDProperty_NCPSleepyPollInterval);
@@ -1989,6 +1990,9 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 		kWPANTUNDProperty_ConfigNCPDriverName,
 		boost::bind(&SpinelNCPInstance::get_prop_ConfigNCPDriverName, this, _1));
 	register_get_handler(
+		kWPANTUNDProperty_NCPCapabilities,
+		boost::bind(&SpinelNCPInstance::get_prop_NCPCapabilities, this, _1));
+	register_get_handler(
 		kWPANTUNDProperty_NetworkIsCommissioned,
 		boost::bind(&SpinelNCPInstance::get_prop_NetworkIsCommissioned, this, _1));
 	register_get_handler(
@@ -2124,6 +2128,21 @@ void
 SpinelNCPInstance::get_prop_ConfigNCPDriverName(CallbackWithStatusArg1 cb)
 {
 	cb(kWPANTUNDStatus_Ok, boost::any(std::string("spinel")));
+}
+
+void
+SpinelNCPInstance::get_prop_NCPCapabilities(CallbackWithStatusArg1 cb)
+{
+	std::list<std::string> capability_list;
+	std::set<unsigned int>::iterator iter;
+
+	for (iter = mCapabilities.begin(); iter != mCapabilities.end(); iter++)	{
+		char str[200];
+		snprintf(str, sizeof(str), "%s (%d)", spinel_capability_to_cstr(*iter), *iter);
+		capability_list.push_back(std::string(str));
+	}
+
+	cb(kWPANTUNDStatus_Ok, boost::any(capability_list));
 }
 
 void

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -224,6 +224,7 @@ private:
 	void regsiter_all_get_handlers(void);
 
 	void get_prop_ConfigNCPDriverName(CallbackWithStatusArg1 cb);
+	void get_prop_NCPCapabilities(CallbackWithStatusArg1 cb);
 	void get_prop_NetworkIsCommissioned(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadRouterID(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadConfigFilterRLOCAddresses(CallbackWithStatusArg1 cb);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -69,6 +69,7 @@
 #define kWPANTUNDProperty_NCPRSSI                               "NCP:RSSI"
 #define kWPANTUNDProperty_NCPCCAFailureRate                     "NCP:CCAFailureRate"
 #define kWPANTUNDProperty_NCPMCUPowerState                      "NCP:MCUPowerState"
+#define kWPANTUNDProperty_NCPCapabilities                       "NCP:Capabilities"
 
 #define kWPANTUNDProperty_InterfaceUp                           "Interface:Up"
 


### PR DESCRIPTION
This commit adds a new property "NCP:Capabilities" to get a human-
readable list of capabilities provided by the NCP.

-------------------
Here is how the output looks like:
```
wpanctl:wpan1> get NCP:Capabilities
NCP:Capabilities = [
	"COUNTERS (5)"
	"JAM_DETECT (6)"
	"UNSOL_UPDATE_FILTER (12)"
	"MCU_POWER_STATE (13)"
	"802_15_4_2450MHZ_OQPSK (24)"
	"ROLE_ROUTER (48)"
	"ROLE_SLEEPY (49)"
	"NET_THREAD_1_0 (52)"
	"MAC_WHITELIST (512)"
	"OOB_STEERING_DATA (514)"
	"CHANNEL_MONITOR (515)"
	"ERROR_RATE_TRACKING (516)"
	"CHANNEL_MANAGER (517)"
	"OPENTHREAD_LOG_METADATA (518)"
	"CHILD_SUPERVISION (520)"
	"THREAD_COMMISSIONER (1024)"
	"NEST_LEGACY_INTERFACE (15296)"
]
```