### PR TITLE
Do not use glibc-internal header sys/cdefs.h

### DIFF
--- a/src/ncp-spinel/spinel-extra.h
+++ b/src/ncp-spinel/spinel-extra.h
@@ -22,7 +22,9 @@
 
 #include "spinel.h"
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 // ----------------------------------------------------------------------------
 
@@ -74,6 +76,8 @@ SPINEL_API_EXTERN spinel_ssize_t spinel_cmd_prop_type_get(uint8_t* cmd_data_ptr,
 
 SPINEL_API_EXTERN spinel_ssize_t spinel_cmd_prop_type_get(uint8_t* cmd_data_ptr, spinel_size_t cmd_data_len, spinel_prop_key_t prop_key);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // SPINEL_EXTRA_HEADER_INCLUDED

--- a/src/util/config-file.h
+++ b/src/util/config-file.h
@@ -18,7 +18,9 @@
 #ifndef __WPAN_CONFIG_FILE_H__
 #define __WPAN_CONFIG_FILE_H__ 1
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern char* get_next_arg(char *buf, char **rest);
 
 typedef int (*config_param_set_func)(void* context, const char* key, const char* value);
@@ -26,6 +28,8 @@ typedef int (*config_param_set_func)(void* context, const char* key, const char*
 extern int read_config(const char* filename, config_param_set_func setter, void* context);
 
 extern int fread_config(FILE* file, config_param_set_func setter, void* context);
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // __WPAN_CONFIG_FILE_H__

--- a/src/util/netif-mgmt.h
+++ b/src/util/netif-mgmt.h
@@ -26,7 +26,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern int netif_mgmt_open();
 extern void netif_mgmt_close(int fd);
 
@@ -53,7 +55,9 @@ extern int netif_mgmt_remove_ipv6_route(int fd, const char* if_name, const uint8
 extern int netif_mgmt_join_ipv6_multicast_address(int reqfd, const char* if_name, const uint8_t addr[16]);
 extern int netif_mgmt_leave_ipv6_multicast_address(int reqfd, const char* if_name, const uint8_t addr[16]);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 
 #endif

--- a/src/util/nlpt-select.h
+++ b/src/util/nlpt-select.h
@@ -26,9 +26,10 @@
 #include <stdbool.h>
 #include <poll.h>
 #include <sys/select.h>
-#include <sys/cdefs.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 struct nlpt {
 	struct pt pt;
@@ -70,6 +71,8 @@ extern void nlpt_select_update_fd_set(
 );
 extern bool _nlpt_checkpoll(int fd, short poll_flags);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/util/sec-random.h
+++ b/src/util/sec-random.h
@@ -20,14 +20,17 @@
 #ifndef SEC_RANDOM_HEADER_INCLUDED
 #define SEC_RANDOM_HEADER_INCLUDED 1
 
-#include <sys/cdefs.h>
 #include <stdint.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 int sec_random_init(void);
 int sec_random_fill(uint8_t* buffer, int length);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // SEC_RANDOM_HEADER_INCLUDED

--- a/src/util/socket-utils.h
+++ b/src/util/socket-utils.h
@@ -38,7 +38,9 @@
 #define SOCKET_UTILS_DEFAULT_SHELL         "/bin/sh"
 #endif
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern int gSocketWrapperBaud;
 bool socket_name_is_device(const char* socket_name);
 int lookup_sockaddr_from_host_and_port( struct sockaddr_in6* outaddr, const char* host, const char* port);
@@ -61,7 +63,9 @@ int get_super_socket_type_from_path(const char* path);
 
 int fork_unixdomain_socket(int* fd_pointer);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 
 #endif

--- a/src/util/string-utils.h
+++ b/src/util/string-utils.h
@@ -28,14 +28,15 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>
-#include <sys/cdefs.h>
 
 #define strcaseequal(x, y)   (strcasecmp(x, y) == 0)
 #define strncaseequal(x, y, n)   (strncasecmp(x, y, n) == 0)
 #define strequal(x, y)   (strcmp(x, y) == 0)
 #define strnequal(x, y, n)   (strncmp(x, y, n) == 0)
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern void memcpyrev(void* dest, const void *src, size_t len);
 extern int memcmprev(const void* dest, const void *src, size_t len);
 extern void reverse_bytes(uint8_t *bytes, size_t count);
@@ -66,6 +67,8 @@ uint32_t strtomask_uint32(const char* in_string);
 
 extern bool strtobool(const char* string);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/util/time-utils.h
+++ b/src/util/time-utils.h
@@ -30,7 +30,6 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <sys/cdefs.h>
 #include <time.h>
 
 #ifndef MSEC_PER_SEC
@@ -55,7 +54,9 @@
 
 #define CMS_SINCE(x)	(time_ms() - (x))
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 typedef int32_t cms_t;
 
 extern cms_t time_ms(void);
@@ -68,6 +69,8 @@ extern void fuzz_set_cms(cms_t value);
 extern void fuzz_ff_cms(cms_t increment);
 #endif
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/util/tunnel.h
+++ b/src/util/tunnel.h
@@ -35,12 +35,16 @@
 
 #define TUNNEL_MAX_INTERFACE_NAME_LEN	60
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern int tunnel_open(const char* tun_name);
 extern int tunnel_get_name(int fd, char* name, int maxlen);
 extern int tunnel_set_hwaddr(int fd, uint8_t *addr, int addr_len);
 extern void tunnel_close(int fd);
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -19,11 +19,14 @@
 
 #ifndef INTERNAL_VERSION_H__
 
-#include <sys/cdefs.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 extern const char *internal_build_source_version;
 extern const char *internal_build_date;
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif // INTERNAL_VERSION_H__

--- a/src/wpantund/wpan-error.h
+++ b/src/wpantund/wpan-error.h
@@ -20,7 +20,9 @@
 #define wpantund_wpan_error_h
 #include <stddef.h>
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 typedef enum {
 	kWPANTUNDStatus_Ok                            = 0,
@@ -75,6 +77,8 @@ typedef enum {
 
 extern const char* wpantund_status_to_cstr(int status);
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/wpantund/wpantund.cpp
+++ b/src/wpantund/wpantund.cpp
@@ -129,9 +129,13 @@ using ::boost::shared_ptr;
 
 #ifndef SOURCE_VERSION
 #define SOURCE_VERSION		PACKAGE_VERSION
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 #include "version.c.in"
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 #endif
 
 using namespace nl;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -51,16 +51,6 @@
 #define SPINEL_API_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #endif // ifdef __GNUC__
 
-#if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-#if defined(__cplusplus)
-#define __BEGIN_DECLS extern "C" {
-#define __END_DECLS }
-#else // if defined(__cplusplus)
-#define __BEGIN_DECLS
-#define __END_DECLS
-#endif // else defined(__cplusplus)
-#endif // if !defined(__BEGIN_DECLS) || !defined(__END_DECLS)
-
 #endif // ifndef DOXYGEN_SHOULD_SKIP_THIS
 
 #ifndef SPINEL_API_EXTERN
@@ -105,7 +95,9 @@
 
 // ----------------------------------------------------------------------------
 
-__BEGIN_DECLS
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 typedef enum {
     SPINEL_STATUS_OK      = 0, ///< Operation has completed successfully.
@@ -2574,6 +2566,8 @@ SPINEL_API_EXTERN const char *spinel_capability_to_cstr(unsigned int capability)
 
 // ----------------------------------------------------------------------------
 
-__END_DECLS
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* defined(SPINEL_HEADER_INCLUDED) */


### PR DESCRIPTION
The `sys/cdefs.h` is an internal header of `glibc` and is not meant to
be used by user code.  The macros needed from it can be trivially
implemented where required, relying on this header being present
excludes `wpantund` from being used on systems where `glibc` is not the
used C library (e.g. OpenWRT, where `uclibc` or `musl` is standard).

https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E