### PR TITLE
[cert] fix channel mask

### DIFF
--- a/src/util/string-utils.c
+++ b/src/util/string-utils.c
@@ -189,13 +189,13 @@ strtomask_uint32(const char* in_string)
 			}
 
 			while (channel_start <= channel_stop) {
-				mask |= (1 << channel_start);
+				mask |= (0x80000000 >> channel_start);
 				channel_start++;
 			}
 		} else {
 			// no range, just add channel to the scan mask
 
-			mask |= (1 << strtol(chan_ranges, NULL, 0));
+			mask |= (0x80000000 >> strtol(chan_ranges, NULL, 0));
 		}
 		chan_ranges = strtok(NULL, ",");
 	}


### PR DESCRIPTION
Thread 1.1 specification section 8.10.1.18.1,

> ChannelMask
> A variable-length bit mask that identifies the channels within the
> channel page (1 = selected, 0 = unselected). The channels are
> represented in most significant bit order. For example, the most
> significant bit of the left-most byte indicates channel 0. If channel 0
> and channel 10 are selected, the mask would be: 80 20 00 00. For IEEE
> 802.15.4- 2006 2.4 GHz PHY, the ChannelMask is 27 bits and Mask Length
> is 4.