### PR TITLE
Enabled latency test for NCP

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -254,6 +254,11 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_performance_test_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 private:
 	typedef DBusHandlerResult (interface_handler_cb)(
 		NCPControlInterface*,

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -92,6 +92,8 @@
 #define WPANTUND_IF_CMD_PEEK                  "Peek"
 #define WPANTUND_IF_CMD_POKE                  "Poke"
 
+#define WPANTUND_IF_CMD_PERFORMANCE_TEST      "PerformanceTest"
+
 // ============================================================================
 // NestLabs Internal API Interface
 

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -164,6 +164,16 @@ DummyNCPControlInterface::add_external_route(
 }
 
 void
+DummyNCPControlInterface::performance_test(
+	const struct in6_addr* peerAddr,
+	uint16_t length,
+	bool isSender,
+	CallbackWithStatus cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented);
+}
+
+void
 DummyNCPControlInterface::remove_external_route(
 	const struct in6_addr *prefix,
 	int prefix_len_in_bits,

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -154,6 +154,13 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
+	virtual void performance_test(
+		const struct in6_addr* peerAddr,
+		uint16_t length,
+		bool isSender,
+		CallbackWithStatus cb = NilReturn()
+	);
+
 	virtual void remove_external_route(
 		const struct in6_addr *prefix,
 		int prefix_len_in_bits,

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -214,6 +214,25 @@ bail:
 }
 
 void
+SpinelNCPControlInterface::performance_test(
+	const struct in6_addr* peerAddr,
+	uint16_t length,
+	bool isSender,
+	CallbackWithStatus cb
+) {
+	require_action(mNCPInstance->mEnabled, bail, cb(kWPANTUNDStatus_InvalidWhenDisabled));
+	mNCPInstance->performance_test(
+		peerAddr,
+		length,
+		isSender,
+		cb
+	);
+
+bail:
+	return;
+}
+
+void
 SpinelNCPControlInterface::remove_on_mesh_prefix(
 	const struct in6_addr& prefix,
 	uint8_t prefix_len,

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -147,6 +147,13 @@ public:
 		CallbackWithStatus cb
 	);
 
+	virtual void performance_test(
+		const struct in6_addr* peerAddr,
+		uint16_t length,
+		bool isSender,
+		CallbackWithStatus cb
+	);
+
 	virtual void add_external_route(
 		const struct in6_addr *prefix,
 		int prefix_len,

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -173,6 +173,8 @@ protected:
 	virtual void remove_route_on_ncp(const struct in6_addr &route, uint8_t prefix_len, RoutePreference preference,
 					bool stable, CallbackWithStatus cb);
 
+	virtual void performance_test(const struct in6_addr* peerAddr, uint16_t length, bool isSender, CallbackWithStatus cb);
+
 	static RoutePreference convert_flags_to_route_preference(uint8_t flags);
 	static uint8_t convert_route_preference_to_flags(RoutePreference priority);
 
@@ -301,6 +303,7 @@ private:
 	void set_prop_OpenThreadSteeringDataAddress(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_TmfProxyStream(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_UdpProxyStream(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_PerformanceTest(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DatasetActiveTimestamp(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DatasetPendingTimestamp(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DatasetMasterKey(const boost::any &value, CallbackWithStatus cb);

--- a/src/wpanctl/Makefile.am
+++ b/src/wpanctl/Makefile.am
@@ -106,6 +106,8 @@ wpanctl_SOURCES = \
 	tool-cmd-dataset.h \
 	tool-cmd-dataset.c \
 	tool-updateprop.h \
+	tool-cmd-performance.c \
+	tool-cmd-performance.h \
 	$(NULL)
 
 wpanctl_LDADD = \

--- a/src/wpanctl/tool-cmd-performance.c
+++ b/src/wpanctl/tool-cmd-performance.c
@@ -1,0 +1,226 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <getopt.h>
+#include "wpanctl-utils.h"
+#include "tool-cmd-performance.h"
+#include "assert-macros.h"
+#include "args.h"
+#include "assert-macros.h"
+#include "wpan-dbus-v1.h"
+#include "string-utils.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+
+const char performance_cmd_syntax[] = "[args] <dest address>";
+
+static const arg_list_item_t performance_option_list[] = {
+	{'h', "help", NULL, "Print Help"},
+	{'t', "type", NULL, "Performance test type: 1. latency test, 2. throughput test"},
+	{'s', "sender", NULL, "set the sending node, else set the receiving node"},
+	{'l', "length", NULL, "set sending UDP payload size"},
+	{0}
+};
+
+int tool_cmd_performance_test(int argc, char* argv[])
+{
+	int ret = 0;
+	int c;
+	int timeout = DEFAULT_TIMEOUT_IN_SECONDS * 1000;
+	DBusConnection* connection = NULL;
+	DBusMessage *message = NULL;
+	DBusMessage *reply = NULL;
+	DBusError error;
+	dbus_bool_t isSender = FALSE;
+	dbus_bool_t isReceiver = FALSE;
+	uint16_t type = 0;
+	uint16_t payloadSize = 0;
+	const char* peerAddr = NULL;
+	char address_string[INET6_ADDRSTRLEN];
+	uint8_t addrBytes[16];
+	uint8_t *addr = addrBytes;
+
+	dbus_error_init(&error);
+
+	while (1) {
+		static struct option long_options[] = {
+			{"help", no_argument, 0, 'h'},
+			{"type", required_argument, 0, 't'},
+			{"sender", no_argument, 0, 's'},
+			{"length", required_argument, 0, 'l'},
+			{0, 0, 0, 0}
+		};
+
+		int option_index = 0;
+		c = getopt_long(argc, argv, "ht:srl:", long_options,
+				&option_index);
+
+		if (c == -1)
+			break;
+
+		switch (c) {
+		case 'h':
+			print_arg_list_help(performance_option_list, argv[0], performance_cmd_syntax);
+			ret = ERRORCODE_HELP;
+			goto bail;
+
+		case 't':
+			type = (uint8_t)strtol(optarg, NULL, 0);
+			break;
+
+		case 's':
+			isSender = TRUE;
+			break;
+
+		case 'l':
+			payloadSize = (uint16_t) strtol(optarg, NULL, 0);
+			break;
+		}
+	}
+
+	if (optind < argc) {
+		if (!peerAddr) {
+			peerAddr = argv[optind];
+			optind++;
+		}
+	}
+
+	if (optind < argc) {
+		fprintf(stderr,
+				"%s: error: Unexpected extra argument: \"%s\"\n",
+				argv[0], argv[optind]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	if (gInterfaceName[0] == 0) {
+		fprintf(stderr,
+				"%s: error: No WPAN interface set (use the `cd` command, or the `-I` argument for `wpanctl`).\n",
+				argv[0]);
+		ret = ERRORCODE_BADARG;
+		goto bail;
+	}
+
+	connection = dbus_bus_get(DBUS_BUS_SYSTEM, &error);
+
+	require_string(connection != NULL, bail, error.message);
+
+	{
+		DBusMessageIter iter;
+		DBusMessageIter list_iter;
+		char path[DBUS_MAXIMUM_NAME_LENGTH+1];
+		char interface_dbus_name[DBUS_MAXIMUM_NAME_LENGTH+1];
+		ret = lookup_dbus_name_from_interface(interface_dbus_name, gInterfaceName);
+		if (ret != 0) {
+			goto bail;
+		}
+		snprintf(path,
+				sizeof(path),
+				"%s/%s",
+				WPANTUND_DBUS_PATH,
+				gInterfaceName);
+
+		message = dbus_message_new_method_call(
+				  interface_dbus_name,
+				  path,
+				  WPANTUND_DBUS_APIv1_INTERFACE,
+				  WPANTUND_IF_CMD_PERFORMANCE_TEST
+				  );
+
+		if(peerAddr) {
+			if(strstr(peerAddr,":")) {
+
+				// Address-style
+				int bits = inet_pton(AF_INET6, peerAddr, addrBytes);
+				if(bits<0) {
+					fprintf(stderr,
+							"Bad address \"%s\", errno=%d (%s)\n",
+							peerAddr,
+							errno,
+							strerror(errno));
+					goto bail;
+				} else if(!bits) {
+					fprintf(stderr, "Bad address \"%s\"\n", peerAddr);
+					goto bail;
+				}
+			}
+
+			inet_ntop(AF_INET6, (const void *)&addrBytes, address_string, INET6_ADDRSTRLEN);
+
+			fprintf(stderr, "Using dest address \"%s\"\n", address_string);
+
+		}
+
+		addr = addrBytes;
+
+		dbus_message_append_args(
+			message,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &addr, 16,
+			DBUS_TYPE_INT16, &payloadSize,
+			DBUS_TYPE_BOOLEAN, &isSender,
+			DBUS_TYPE_INVALID
+		);
+
+
+		reply = dbus_connection_send_with_reply_and_block(
+				connection,
+				message,
+				timeout,
+				&error
+				);
+
+		if (!reply) {
+			fprintf(stderr, "%s: error: %s\n", argv[0], error.message);
+			ret = ERRORCODE_TIMEOUT;
+			goto bail;
+		}
+
+		dbus_message_get_args(reply, &error,
+							  DBUS_TYPE_INT32, &ret,
+							  DBUS_TYPE_INVALID
+							 );
+
+		if (!ret) {
+			fprintf(stderr, "performance complete.\n");
+		} else {
+			fprintf(stderr, "%s failed with error %d. %s\n", argv[0], ret, wpantund_status_to_cstr(ret));
+			print_error_diagnosis(ret);
+		}
+	}
+
+bail:
+
+	if (connection)
+		dbus_connection_unref(connection);
+
+	if (message)
+		dbus_message_unref(message);
+
+	if (reply)
+		dbus_message_unref(reply);
+
+	dbus_error_free(&error);
+
+	return ret;
+}

--- a/src/wpanctl/tool-cmd-performance.h
+++ b/src/wpanctl/tool-cmd-performance.h
@@ -1,0 +1,27 @@
+/*
+ *
+ * Copyright (c) 2018 Nest Labs, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef WPANCTL_TOOL_CMD_PERFORMANCE_H
+#define WPANCTL_TOOL_CMD_PERFORMANCE_H
+
+#include "wpanctl-utils.h"
+
+int tool_cmd_performance_test(int argc, char* argv[]);
+
+#endif

--- a/src/wpanctl/wpanctl-cmds.h
+++ b/src/wpanctl/wpanctl-cmds.h
@@ -51,6 +51,7 @@
 #include "tool-cmd-commissioner.h"
 #include "tool-cmd-joiner.h"
 #include "tool-cmd-dataset.h"
+#include "tool-cmd-performance.h"
 
 #include "wpanctl-utils.h"
 
@@ -210,6 +211,11 @@
 		"poke", \
 		"Poke NCP memory (change content at a NCP memory address)", \
 		&tool_cmd_poke \
+	}, \
+	{ \
+		"performance", \
+		"Performance test include latency and throughput test", \
+		&tool_cmd_performance_test \
 	}, \
 	{ \
 		"dataset", \

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -189,6 +189,14 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
+
+	virtual void performance_test(
+		const struct in6_addr* peerAddr,
+		uint16_t length,
+		bool isSender,
+		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
 public:
 	// ========================================================================
 	// Thread Mesh Commissioning Protocol (MeshCoP) Member Functions

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -678,6 +678,14 @@ private:
 	bool mRequestRouteRefresh;
 
 protected:
+	// bool performance_test(
+	// 	const struct in6_addr* peerAddr,
+	// 	uint16_t length,
+	// 	bool isSender,
+	// 	CallbackWithStatus cb
+	// );
+
+protected:
 	//! This is set to the currently used MAC address (EUI64).
 	uint8_t mMACAddress[8];
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -219,6 +219,12 @@
 #define kWPANTUNDProperty_TmfProxyStream                        "TmfProxy:Stream"
 #define kWPANTUNDProperty_UdpProxyStream                        "UdpProxy:Stream"
 
+#define kWPANTUNDProperty_PerformanceTest                       "perf:test"
+#define kWPANTUNDProperty_Latency                               "latency"
+#define kWPANTUNDProperty_Hoplimit                              "hoplimit"
+
+
+
 #define kWPANTUNDProperty_CommissionerState                     "Commissioner:State"
 #define kWPANTUNDProperty_CommissionerProvisioningUrl           "Commissioner:ProvisioningUrl"
 #define kWPANTUNDProperty_CommissionerSessionId                 "Commissioner:SessionId"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -61,7 +61,7 @@
 
 // IAR's errno.h apparently doesn't define EOVERFLOW.
 #ifndef EOVERFLOW
-// There is no real good choice for what to set
+/// There is no real good choice for what to set
 // errno to in this case, so we just pick the
 // value '1' somewhat arbitrarily.
 #define EOVERFLOW 1
@@ -1842,6 +1842,18 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "RCP_VERSION";
         break;
 
+    case SPINEL_PROP_PERFORMANCE_LATENCY_TEST:
+        ret = "PERFORMANCE_LATENCY_TEST";
+        break;
+
+    case SPINEL_PROP_PERFORMANCE_LATENCY:
+        ret = "PERFORMANCE_LATENCY";
+        break;
+
+    case SPINEL_PROP_PERFORMANCE_HOPLIMIT:
+        ret = "PERFORMANCE_HOPLIMIT";
+        break;
+
     case SPINEL_PROP_UART_BITRATE:
         ret = "UART_BITRATE";
         break;
@@ -2449,6 +2461,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_POSIX_APP:
         ret = "POSIX_APP";
+        break;
+
+    case SPINEL_CAP_PERFORMANCE_TEST:
+        ret = "PERFORMANCE_TEST";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -470,6 +470,7 @@ enum
     SPINEL_CAP_TIME_SYNC               = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
     SPINEL_CAP_CHILD_SUPERVISION       = (SPINEL_CAP_OPENTHREAD__BEGIN + 8),
     SPINEL_CAP_POSIX_APP               = (SPINEL_CAP_OPENTHREAD__BEGIN + 9),
+    SPINEL_CAP_PERFORMANCE_TEST        = (SPINEL_CAP_OPENTHREAD__BEGIN + 10),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN       = 1024,
@@ -2007,6 +2008,39 @@ typedef enum {
      *
      */
     SPINEL_PROP_RCP_VERSION = SPINEL_PROP_OPENTHREAD__BEGIN + 12,
+
+    /// End-to-End Latency test
+    /** Format: `6SSb` - Write only
+     *
+     *  `6`: Peer IPv6 address
+     *  `S`: UDP payload size
+     *  `b`: Role of node, True is sending node, False is receiving node.
+     *
+     * This property sets the role of node in latency test. Launch the receiving node by setting the default value in this property,
+     * and then launch the sending node to start the test.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_LATENCY_TEST = SPINEL_PROP_OPENTHREAD__BEGIN + 14,
+
+    /// Latency test result
+    /** Format: `L` - Read only
+     *
+     *  `L`: Latnecy value, in microseconds
+     *
+     * This property sends latency value from receiving node to the Host.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_LATENCY = SPINEL_PROP_OPENTHREAD__BEGIN + 15,
+
+    /// hoplimit value
+    /** Format: `C` - Read only
+     *
+     *  `C`: hoplimit value
+     *
+     * This property sends hoplimit value from receiving node to the Host.
+     *
+     */
+    SPINEL_PROP_PERFORMANCE_HOPLIMIT = SPINEL_PROP_OPENTHREAD__BEGIN + 16,
 
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 


### PR DESCRIPTION
This feature need to enable time sync in advance on NCP.

In this commit, a command line "performance" is added into wpanctl,
user could use this command to set:
1. sending node or receiving node
2. UDP payload size
3. IPv6 destination
In addition, added two "get handlers" for latency and hoplimit, which
can be obtained from the receiving node after executing "performance"
command.

This PR is related to OT PR#3269
https://github.com/openthread/openthread/pull/3269