### PR TITLE
Move building spi-hdlc-adapter to OpenThread

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -19,16 +19,6 @@ LOCAL_PATH:= $(call my-dir)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE := spi-hdlc-adapter
-LOCAL_MODULE_TAGS := eng
-LOCAL_C_INCLUDES := $(NULL)
-LOCAL_SRC_FILES := third_party/openthread/tools/spi-hdlc-adapter/spi-hdlc-adapter.c \
-	$(NULL)
-
-include $(BUILD_EXECUTABLE)
-
-include $(CLEAR_VARS)
-
 LOCAL_MODULE:= wpantund
 LOCAL_MODULE_TAGS := eng
 


### PR DESCRIPTION
spi-hdlc-adapter is third party and is used by OpenThread itself,
building spi-hdlc-adapter in OpenThread can simplify and accelerate
fixing bugs.