### PR TITLE
 FilterALOCAddresses option added

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -228,6 +228,7 @@ private:
 	void get_prop_NetworkIsCommissioned(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadRouterID(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadConfigFilterRLOCAddresses(CallbackWithStatusArg1 cb);
+    void get_prop_ThreadConfigFilterALOCAddresses(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerEnergyScanResult(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerPanIdConflictResult(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6MeshLocalPrefix(CallbackWithStatusArg1 cb);
@@ -297,6 +298,7 @@ private:
 	void set_prop_NetworkXPANID(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_IPv6MeshLocalPrefix(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_ThreadConfigFilterRLOCAddresses(const boost::any &value, CallbackWithStatus cb);
+    void set_prop_ThreadConfigFilterALOCAddresses(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_OpenThreadSteeringDataSetWhenJoinable(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_OpenThreadSteeringDataAddress(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_TmfProxyStream(const boost::any &value, CallbackWithStatus cb);
@@ -424,6 +426,7 @@ private:
 	uint8_t mThreadMode;
 	bool mIsCommissioned;
 	bool mFilterRLOCAddresses;
+    bool mFilterALOCAddresses;
 	bool mTickleOnHostDidWake;
 
 	std::set<unsigned int> mCapabilities;

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -228,7 +228,7 @@ private:
 	void get_prop_NetworkIsCommissioned(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadRouterID(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadConfigFilterRLOCAddresses(CallbackWithStatusArg1 cb);
-    void get_prop_ThreadConfigFilterALOCAddresses(CallbackWithStatusArg1 cb);
+	void get_prop_ThreadConfigFilterALOCAddresses(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerEnergyScanResult(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerPanIdConflictResult(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6MeshLocalPrefix(CallbackWithStatusArg1 cb);
@@ -298,7 +298,7 @@ private:
 	void set_prop_NetworkXPANID(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_IPv6MeshLocalPrefix(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_ThreadConfigFilterRLOCAddresses(const boost::any &value, CallbackWithStatus cb);
-    void set_prop_ThreadConfigFilterALOCAddresses(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_ThreadConfigFilterALOCAddresses(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_OpenThreadSteeringDataSetWhenJoinable(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_OpenThreadSteeringDataAddress(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_TmfProxyStream(const boost::any &value, CallbackWithStatus cb);
@@ -426,7 +426,7 @@ private:
 	uint8_t mThreadMode;
 	bool mIsCommissioned;
 	bool mFilterRLOCAddresses;
-    bool mFilterALOCAddresses;
+	bool mFilterALOCAddresses;
 	bool mTickleOnHostDidWake;
 
 	std::set<unsigned int> mCapabilities;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -125,6 +125,7 @@
 #define kWPANTUNDProperty_ThreadOnMeshPrefixes                  "Thread:OnMeshPrefixes"
 #define kWPANTUNDProperty_ThreadRouterRoleEnabled               "Thread:RouterRole:Enabled"
 #define kWPANTUNDProperty_ThreadConfigFilterRLOCAddresses       "Thread:Config:FilterRLOCAddresses"
+#define kWPANTUNDProperty_ThreadConfigFilterALOCAddresses       "Thread:Config:FilterALOCAddresses"
 #define kWPANTUNDProperty_ThreadRouterUpgradeThreshold          "Thread:RouterUpgradeThreshold"
 #define kWPANTUNDProperty_ThreadRouterDowngradeThreshold        "Thread:RouterDowngradeThreshold"
 #define kWPANTUNDProperty_ThreadActiveDataset                   "Thread:ActiveDataset"


### PR DESCRIPTION
If FilterRLOCAddresses option is enabled, then we can decide whether
ALOC addresses should be filtered using additional option
FilterALOCAddresses. Default value of FilterALOCAddresses is 'true',
so it's backward compatible - filtering behaviour will not change if
this option is not defined in wpantund.conf.