### PR TITLE
Add support to get Thread MLE counters

### DIFF
--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -178,9 +178,6 @@
 #define kWPANTUNDProperty_OpenThreadDebugTestAssert             "OpenThread:Debug:TestAssert"
 #define kWPANTUNDProperty_OpenThreadDebugTestWatchdog           "OpenThread:Debug:TestWatchdog"
 
-#define kWPANTUNDProperty_NCPCounterAllMac                      "NCP:Counter:AllMac"
-#define kWPANTUNDProperty_NCPCounterAllMacAsValMap              "NCP:Counter:AllMac:AsValMap"
-
 #define kWPANTUNDProperty_DebugIPv6GlobalIPAddressList          "Debug:IPv6:GlobalIPAddressList"
 
 #define kWPANTUNDProperty_MACWhitelistEnabled                   "MAC:Whitelist:Enabled"
@@ -233,6 +230,11 @@
 #define kWPANTUNDCommissionerState_Active                       "active"
 
 #define kWPANTUNDProperty_ThreadJoinerState                     "Thread:Joiner:State"
+
+#define kWPANTUNDProperty_NCPCounterAllMac                      "NCP:Counter:AllMac"
+#define kWPANTUNDProperty_NCPCounterAllMacAsValMap              "NCP:Counter:AllMac:AsValMap"
+#define kWPANTUNDProperty_NCPCounterThreadMle                   "NCP:Counter:Thread:Mle"
+#define kWPANTUNDProperty_NCPCounterThreadMleAsValMap           "NCP:Counter:Thread:Mle:AsValMap"
 
 #define kWPANTUNDProperty_NCPCounter_TX_PKT_TOTAL               "NCP:Counter:TX_PKT_TOTAL"
 #define kWPANTUNDProperty_NCPCounter_TX_PKT_UNICAST             "NCP:Counter:TX_PKT_UNICAST"
@@ -439,6 +441,16 @@
 #define kWPANTUNDValueMapKey_Counter_RxErrSec                   "RxErrSec"             // Number of received packets with security error
 #define kWPANTUNDValueMapKey_Counter_RxErrFcs                   "RxErrFcs"             // Number of received packets with FCS error
 #define kWPANTUNDValueMapKey_Counter_RxErrOther                 "RxErrOther"           // Number of received packets with other error
+
+#define kWPANTUNDValueMapKey_MleCounter_DisabledRole            "DisabledRole"         // The number of times device entered DISABLED role.
+#define kWPANTUNDValueMapKey_MleCounter_DetachedRole            "DetachedRole"         // The number of times device entered DETACHED role.
+#define kWPANTUNDValueMapKey_MleCounter_ChildRole               "ChildRole"            // The number of times device entered CHILD role.
+#define kWPANTUNDValueMapKey_MleCounter_RouterRole              "RouterRole"           // The number of times device entered ROUTER role.
+#define kWPANTUNDValueMapKey_MleCounter_LeaderRole              "LeaderRole"           // The number of times device entered LEADER role.
+#define kWPANTUNDValueMapKey_MleCounter_AttachAttempts          "AttachAttempts"       // The number of attach attempts while device was detached.
+#define kWPANTUNDValueMapKey_MleCounter_PartitionIdChanges      "PartitionIdChanges"   // The number of changes to partition ID.
+#define kWPANTUNDValueMapKey_MleCounter_BetterPartitionAttaches "BetterPartAttaches"   // The number of attempts to attach to a better partition.
+#define kWPANTUNDValueMapKey_MleCounter_ParentChanges           "ParentChanges"        // The number of times device changed its parents.
 
 #define kWPANTUNDValueMapKey_TimeSync_Time                      "ThreadNetworkTime"
 #define kWPANTUNDValueMapKey_TimeSync_Status                    "TimeSyncStatus"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -2063,6 +2063,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "CNTR_ALL_MAC_COUNTERS";
         break;
 
+    case SPINEL_PROP_CNTR_MLE_COUNTERS:
+        ret = "CNTR_MLE_COUNTERS";
+        break;
+
     case SPINEL_PROP_NEST_STREAM_MFG:
         ret = "NEST_STREAM_MFG";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -3327,6 +3327,22 @@ typedef enum
      */
     SPINEL_PROP_CNTR_ALL_MAC_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 401,
 
+    /// Thread MLE counters.
+    /** Format: `SSSSSSSSS`  (Read-only)
+     *
+     *   'S': DisabledRole                  (The number of times device entered OT_DEVICE_ROLE_DISABLED role).
+     *   'S': DetachedRole                  (The number of times device entered OT_DEVICE_ROLE_DETACHED role).
+     *   'S': ChildRole                     (The number of times device entered OT_DEVICE_ROLE_CHILD role).
+     *   'S': RouterRole                    (The number of times device entered OT_DEVICE_ROLE_ROUTER role).
+     *   'S': LeaderRole                    (The number of times device entered OT_DEVICE_ROLE_LEADER role).
+     *   'S': AttachAttempts                (The number of attach attempts while device was detached).
+     *   'S': PartitionIdChanges            (The number of changes to partition ID).
+     *   'S': BetterPartitionAttachAttempts (The number of attempts to attach to a better partition).
+     *   'S': ParentChanges                 (The number of times device changed its parents).
+     *
+     */
+    SPINEL_PROP_CNTR_MLE_COUNTERS = SPINEL_PROP_CNTR__BEGIN + 402,
+
     SPINEL_PROP_CNTR__END = 0x800,
 
     SPINEL_PROP_NEST__BEGIN = 0x3BC0,


### PR DESCRIPTION
This commit adds a new wpan property "NCP:Counter:Thread:Mle" to
get the Thread MLE counters (either as human-readable string or as
a value-map dictionary).

Related PR in openthread: https://github.com/openthread/openthread/pull/3558