### PR TITLE
Add RCP version to "wpanctl status" when available

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -492,6 +492,11 @@ DBusIPCAPI_v1::status_response_helper(
 			append_dict_entry(&dict, kWPANTUNDProperty_NCPVersion, value);
 		}
 
+		value = interface->property_get_value(kWPANTUNDProperty_POSIXAppRCPVersionCached);
+		if (!value.empty()) {
+			append_dict_entry(&dict, kWPANTUNDProperty_POSIXAppRCPVersion, value);
+		}
+
 		value = interface->property_get_value(kWPANTUNDProperty_DaemonVersion);
 		if (!value.empty()) {
 			append_dict_entry(&dict, kWPANTUNDProperty_DaemonVersion, value);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2249,6 +2249,10 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 		kWPANTUNDProperty_ThreadNeighborTableErrorRatesAsValMap,
 		SPINEL_CAP_ERROR_RATE_TRACKING,
 		boost::bind(&SpinelNCPInstance::get_prop_ThreadNeighborTableErrorRatesAsValMap, this, _1));
+	register_get_handler_capability(
+		kWPANTUNDProperty_POSIXAppRCPVersionCached,
+		SPINEL_CAP_POSIX_APP,
+		boost::bind(&SpinelNCPInstance::get_prop_POSIXAppRCPVersionCached, this, _1));
 }
 
 void
@@ -2672,6 +2676,12 @@ void
 SpinelNCPInstance::get_prop_DaemonTickleOnHostDidWake(CallbackWithStatusArg1 cb)
 {
 	cb(kWPANTUNDStatus_Ok, boost::any(mTickleOnHostDidWake));
+}
+
+void
+SpinelNCPInstance::get_prop_POSIXAppRCPVersionCached(CallbackWithStatusArg1 cb)
+{
+	cb(kWPANTUNDStatus_Ok, boost::any(mRcpVersion));
 }
 
 void
@@ -4703,6 +4713,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 		len = spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_UTF8_S, &rcp_version);
 
 		if (len > 0) {
+			mRcpVersion = std::string(rcp_version);
 			syslog(LOG_NOTICE, "[-NCP-]: RCP is running \"%s\"", rcp_version);
 		}
 	} else if (key == SPINEL_PROP_THREAD_NETWORK_TIME) {

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -266,6 +266,7 @@ private:
 	void get_prop_DatasetAllFiledsAsValMap(CallbackWithStatusArg1 cb);
 	void get_prop_DatasetCommand(CallbackWithStatusArg1 cb);
 	void get_prop_DaemonTickleOnHostDidWake(CallbackWithStatusArg1 cb);
+	void get_prop_POSIXAppRCPVersionCached(CallbackWithStatusArg1 cb);
 
 private:
 	typedef boost::function<int(const boost::any&, boost::any&)> ValueConverter;
@@ -428,6 +429,7 @@ private:
 	bool mFilterRLOCAddresses;
 	bool mFilterALOCAddresses;
 	bool mTickleOnHostDidWake;
+	std::string mRcpVersion;
 
 	std::set<unsigned int> mCapabilities;
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -169,6 +169,7 @@
 #define kWPANTUNDDatasetCommand_SendMgmtSetPending              "SendMgmtSetPending"
 
 #define kWPANTUNDProperty_POSIXAppRCPVersion                    "POSIXApp:RCPVersion"
+#define kWPANTUNDProperty_POSIXAppRCPVersionCached              "POSIXApp:RCPVersion:Cached"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"


### PR DESCRIPTION
This commit adds RCP version to output of "wpanctl status" command
when POSX_APP capability is present in the list of NCP capabilities.
To enable this, `SpinelNCPInstance` is changed to save the RCP
version. A new property "POSIXApp:RCPVersion:Cached" is added to
get the cached value. Note that to ensure `status` command is
quick (does not block) all reported properties in `status` output
are cached. The `vprocess_init()` protothread is also updated to
retrieve RCP version during initialization.