### PR TITLE
Adding spinel event handler methods.

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -146,11 +146,14 @@ protected:
 	void handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 	void handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
 	void handle_ncp_spinel_value_removed(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len);
-	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
-	void handle_ncp_log_stream(const uint8_t* data_ptr, int data_len);
-	void handle_ncp_spinel_value_is_ON_MESH_NETS(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
-	void handle_ncp_spinel_value_is_OFF_MESH_ROUTES(const uint8_t* value_data_ptr, spinel_size_t value_data_len);
+	template <spinel_prop_key_t key> void handle_spinel_value_is(const uint8_t *value_data_ptr, spinel_size_t value_data_len);
+	template <spinel_prop_key_t key> void handle_spinel_value_inserted(const uint8_t *value_data_ptr, spinel_size_t value_data_len);
+	template <spinel_prop_key_t key> void handle_spinel_value_removed(const uint8_t *value_data_ptr, spinel_size_t value_data_len);
+
+	void handle_spinel_value_is_stream_net(bool is_secure, const uint8_t *value_data_ptr, spinel_size_t value_data_len);
+
+	void handle_ncp_state_change(NCPState new_ncp_state, NCPState old_ncp_state);
 
 	bool should_filter_address(const struct in6_addr &address, uint8_t prefix_len);
 	void filter_addresses(void);


### PR DESCRIPTION
This commit adds spinel event handler methods for `PROP_VALUE_IS`,
`PROP_VALUE_INSERTED` and `PROP_VALUE_REMOVED` evens from NCP. The
handlers are declared as template methods (using `spinel_prop_key_t`
as their template argument). The template handlers are then
specialized for spinel property key values which are needed. This
change helps simplify the code.