### PR TITLE
NCP supporting SLAAC

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -468,6 +468,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 				{ SPINEL_PROP_NET_IF_UP, 0 },
 				{ SPINEL_PROP_NET_STACK_UP, 0 },
 				{ SPINEL_PROP_NET_ROLE, 0 },
+				{ SPINEL_PROP_SLAAC_ENABLED, SPINEL_CAP_SLAAC },
 				{ SPINEL_PROP_RCP_VERSION , SPINEL_CAP_POSIX_APP },
 			};
 

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -2002,6 +2002,10 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 		kWPANTUNDProperty_POSIXAppRCPVersion,
 		SPINEL_CAP_POSIX_APP,
 		SPINEL_PROP_RCP_VERSION, SPINEL_DATATYPE_UTF8_S);
+	register_get_handler_capability_spinel_simple(
+		kWPANTUNDProperty_OpenThreadSLAACEnabled,
+		SPINEL_CAP_SLAAC,
+		SPINEL_PROP_SLAAC_ENABLED, SPINEL_DATATYPE_BOOL_S);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties associated with a spinel property using an unpacker
@@ -2975,6 +2979,10 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 		kWPANTUNDProperty_ChannelManagerAutoSelectInterval,
 		SPINEL_CAP_CHANNEL_MANAGER,
 		SPINEL_PROP_CHANNEL_MANAGER_AUTO_SELECT_INTERVAL, SPINEL_DATATYPE_UINT32_C);
+	register_set_handler_capability_spinel_persist(
+		kWPANTUNDProperty_OpenThreadSLAACEnabled,
+		SPINEL_CAP_SLAAC,
+		SPINEL_PROP_SLAAC_ENABLED, SPINEL_DATATYPE_BOOL_C);
 
 	// Properties with a `ValueConverter`
 	register_set_handler_capability_spinel_persist(
@@ -4716,6 +4724,18 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			mRcpVersion = std::string(rcp_version);
 			syslog(LOG_NOTICE, "[-NCP-]: RCP is running \"%s\"", rcp_version);
 		}
+
+	} else if (key == SPINEL_PROP_SLAAC_ENABLED) {
+		bool enabled;
+		spinel_ssize_t len;
+
+		len = spinel_datatype_unpack(value_data_ptr, value_data_len, SPINEL_DATATYPE_BOOL_S, &enabled);
+
+		if (len > 0) {
+			syslog(LOG_NOTICE, "[-NCP-]: SLAAC %sabled", enabled ? "en" : "dis");
+			mNCPHandlesSLAAC = enabled;
+		}
+
 	} else if (key == SPINEL_PROP_THREAD_NETWORK_TIME) {
 		ValueMap result;
 		std::string result_as_string;

--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -873,8 +873,8 @@ NCPInstanceBase::on_mesh_prefix_was_added(Origin origin, const struct in6_addr &
 		cb(kWPANTUNDStatus_Ok);
 	}
 
-	if (mAutoAddSLAACAddress && entry.is_on_mesh() && entry.is_slaac() && prefix.get_length() == kSLAACPrefixLength
-		&& !has_address_with_prefix(prefix)
+	if (mAutoAddSLAACAddress && !mNCPHandlesSLAAC && entry.is_on_mesh() && entry.is_slaac()
+		&& prefix.get_length() == kSLAACPrefixLength && !has_address_with_prefix(prefix)
 	) {
 		struct in6_addr address = make_slaac_addr_from_eui64(prefix.get_prefix().s6_addr, mMACAddress);
 		syslog(LOG_NOTICE, "Pushing a new SLAAC address %s/%d to NCP", in6_addr_to_string(address).c_str(), prefix_len);

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -76,6 +76,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mAutoUpdateInterfaceIPv6AddrsOnNCP = true;
 	mFilterUserAddedLinkLocalIPv6Address = true;
 	mAutoAddSLAACAddress = true;
+	mNCPHandlesSLAAC = false;
 	mSetDefaultRouteForAutoAddedPrefix = false;
 	mSetSLAACForAutoAddedPrefix = false;
 	mAutoAddOffMeshRoutesOnInterface = true;

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -644,6 +644,12 @@ protected:
 	// using the wpantund property "Daemon:IPv6:AutoAddSLAACAddress".
 	bool mAutoAddSLAACAddress;
 
+	// This boolean flag indicates whether NCP itself supports SLAAC.
+	// If NCP does support SLAAC, then `wpantund` lets NCP handle it
+	// (independent of state of `mAutoAddSLAACAddress` flag). By default this
+	// flag is set to `false`. It should be controlled by sub-classes.
+	bool mNCPHandlesSLAAC;
+
 	// When an unicast address is added on interface, the related on-mesh prefix
 	// is updated on NCP if `mDefaultRouteForAutoAddedPrefix` is true the prefix
 	// is added with flag "DefaultRoute" set.
@@ -738,7 +744,7 @@ private:
 	NetworkRetain mNetworkRetain;
 
 	StatCollector mStatCollector;  // Statistic collector
-	
+
 }; // class NCPInstance
 
 }; // namespace wpantund

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -172,6 +172,7 @@
 #define kWPANTUNDProperty_POSIXAppRCPVersionCached              "POSIXApp:RCPVersion:Cached"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
+#define kWPANTUNDProperty_OpenThreadSLAACEnabled                "OpenThread:SLAAC:Enabled"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"
 #define kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable "OpenThread:SteeringData:SetWhenJoinable"
 #define kWPANTUNDProperty_OpenThreadMsgBufferCounters           "OpenThread:MsgBufferCounters"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1851,6 +1851,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "PARENT_RESPONSE_INFO";
         break;
 
+    case SPINEL_PROP_SLAAC_ENABLED:
+        ret = "SLAAC_ENABLED";
+        break;
+
     case SPINEL_PROP_UART_BITRATE:
         ret = "UART_BITRATE";
         break;
@@ -2478,6 +2482,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
 
     case SPINEL_CAP_POSIX_APP:
         ret = "POSIX_APP";
+        break;
+
+    case SPINEL_CAP_SLAAC:
+        ret = "SLAAC";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -33,6 +33,17 @@
 #ifndef SPINEL_HEADER_INCLUDED
 #define SPINEL_HEADER_INCLUDED 1
 
+/*
+ * Spinel definition guideline:
+ *
+ * New NCP firmware should work with an older host driver, i.e., NCP implementation should remain backward compatible.
+ *
+ *  - Existing fields in the format of an already implemented spinel property or command cannot change.
+ *  - New fields may be appended at the end of the format (or the end of a struct) as long as the NCP implementation
+ *    treats the new fields as optional (i.e., a driver not aware of and therefore not using the new fields should
+ *    continue to function as before).
+ */
+
 #ifdef SPINEL_PLATFORM_HEADER
 #include SPINEL_PLATFORM_HEADER
 #else // ifdef SPINEL_PLATFORM_HEADER
@@ -767,6 +778,7 @@ enum
     SPINEL_CAP_TIME_SYNC               = (SPINEL_CAP_OPENTHREAD__BEGIN + 7),
     SPINEL_CAP_CHILD_SUPERVISION       = (SPINEL_CAP_OPENTHREAD__BEGIN + 8),
     SPINEL_CAP_POSIX_APP               = (SPINEL_CAP_OPENTHREAD__BEGIN + 9),
+    SPINEL_CAP_SLAAC                   = (SPINEL_CAP_OPENTHREAD__BEGIN + 10),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN        = 1024,
@@ -3013,6 +3025,17 @@ typedef enum
      *
      */
     SPINEL_PROP_PARENT_RESPONSE_INFO = SPINEL_PROP_OPENTHREAD__BEGIN + 13,
+
+    /// SLAAC enabled
+    /** Format `b` - Read-Write
+     *  Required capability: `SPINEL_CAP_SLAAC`
+     *
+     * This property allows the host to enable/disable SLAAC module on NCP at run-time. When SLAAC module is enabled,
+     * SLAAC addresses (based on on-mesh prefixes in Network Data) are added to the interface. When SLAAC module is
+     * disabled any previously added SLAAC address is removed.
+     *
+     */
+    SPINEL_PROP_SLAAC_ENABLED = SPINEL_PROP_OPENTHREAD__BEGIN + 14,
 
     SPINEL_PROP_OPENTHREAD__END = 0x2000,
 


### PR DESCRIPTION
This commit adds new wpan properties to control SLAAC behavior on
NCP (if supported). It adds "OpenThread:SLAAC:Enabled" wpan property
to check status of SLAAC on NCP/OpenThread. The new code also
ensures to disable SLAAC address addition by `wpantund` if NCP
already supports SLAAC.