### PR TITLE
Updating Joiner support - vendor parameters

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -102,6 +102,8 @@ DBusIPCAPI_v1::init_callback_tables()
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_PCAP_TERMINATE, interface_pcap_terminate_handler);
 
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_JOINER_ATTACH, interface_joiner_attach_handler);
+	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_JOINER_START, interface_joiner_start_handler);
+	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_JOINER_STOP, interface_joiner_stop_handler);
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_JOINER_COMMISSIONING, interface_joiner_commissioning_handler);
 
 	INTERFACE_CALLBACK_CONNECT(WPANTUND_IF_CMD_JOINER_ADD, interface_joiner_add_handler);
@@ -1520,10 +1522,55 @@ DBusIPCAPI_v1::interface_joiner_attach_handler(
 }
 
 DBusHandlerResult
+DBusIPCAPI_v1::interface_joiner_start_handler(
+   NCPControlInterface* interface,
+   DBusMessage *        message
+) {
+	ValueMap options;
+	DBusMessageIter iter;
+
+	dbus_message_iter_init(message, &iter);
+
+	options = value_map_from_dbus_iter(&iter);
+
+	dbus_message_ref(message);
+
+	interface->joiner_commissioning(
+		true, // start
+		options,
+		boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper, this, _1, message)
+	);
+
+	return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult
+DBusIPCAPI_v1::interface_joiner_stop_handler(
+   NCPControlInterface* interface,
+   DBusMessage *        message
+) {
+	ValueMap options;
+
+	dbus_message_ref(message);
+
+	interface->joiner_commissioning(
+		false, // stop
+		options,
+		boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper, this, _1, message)
+	);
+
+	return DBUS_HANDLER_RESULT_HANDLED;
+}
+
+DBusHandlerResult
 DBusIPCAPI_v1::interface_joiner_commissioning_handler(
    NCPControlInterface* interface,
    DBusMessage *        message
 ) {
+	// The "JoinerCommissioning" DBus command is being deprecated.
+	// Please use the "JoinerStart" and "JoinerStop" DBus commands
+	// instead
+
 	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 	dbus_bool_t action = FALSE;
 	const char* psk = NULL;
@@ -1531,6 +1578,7 @@ DBusIPCAPI_v1::interface_joiner_commissioning_handler(
 	int psk_len = 0;
 	int provisioning_url_len = 0;
 	bool did_succeed = false;
+	ValueMap options;
 
 	did_succeed = dbus_message_get_args(
 		message, NULL,
@@ -1545,11 +1593,18 @@ DBusIPCAPI_v1::interface_joiner_commissioning_handler(
 	// psk must be specified if joiner starts commissioning
 	require(action == FALSE || psk != NULL, bail);
 
+	if (psk) {
+		options[kWPANTUNDValueMapKey_Joiner_PSKd] = std::string(psk);
+	}
+
+	if (provisioning_url) {
+		options[kWPANTUNDValueMapKey_Joiner_ProvisioningUrl] = std::string(provisioning_url);
+	}
+
 	dbus_message_ref(message);
 	interface->joiner_commissioning(
 		action,
-		psk,
-		provisioning_url,
+		options,
 		boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper, this, _1, message)
 	);
 

--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -221,6 +221,16 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_joiner_start_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
+	DBusHandlerResult interface_joiner_stop_handler(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 	DBusHandlerResult interface_joiner_commissioning_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -81,7 +81,9 @@
 #define WPANTUND_IF_SIGNAL_PROP_CHANGED       "PropChanged"
 
 #define WPANTUND_IF_CMD_JOINER_ATTACH         "JoinerAttach"
-#define WPANTUND_IF_CMD_JOINER_COMMISSIONING  "JoinerCommissioning"
+#define WPANTUND_IF_CMD_JOINER_COMMISSIONING  "JoinerCommissioning" // Deprecated, please use JOINER_START and STOP
+#define WPANTUND_IF_CMD_JOINER_START          "JoinerStart"
+#define WPANTUND_IF_CMD_JOINER_STOP           "JoinerStop"
 
 #define WPANTUND_IF_CMD_JOINER_ADD            "JoinerAdd"
 #define WPANTUND_IF_CMD_JOINER_REMOVE         "JoinerRemove"

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -183,8 +183,7 @@ DummyNCPControlInterface::joiner_attach(
 void
 DummyNCPControlInterface::joiner_commissioning(
 	bool action,
-	const char *psk,
-	const char *provisioning_url,
+	const ValueMap &options,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -167,8 +167,7 @@ public:
 
 	virtual void joiner_commissioning(
 		bool action,
-		const char *psk,
-		const char *provisioning_url,
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -298,19 +298,16 @@ SpinelNCPControlInterface::joiner_attach(CallbackWithStatus cb)
 void
 SpinelNCPControlInterface::joiner_commissioning(
 		bool action,
-		const char *psk,
-		const char *provisioning_url,
+		const ValueMap &options,
 		CallbackWithStatus cb
 ) {
 	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
 		new SpinelNCPTaskJoinerCommissioning(
 				mNCPInstance,
-				boost::bind(cb,_1),
+				boost::bind(cb, _1),
 				action,
-				psk,
-				provisioning_url
-				)
-			));
+				options
+	)));
 }
 
 /*

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -169,8 +169,7 @@ public:
 
 	virtual void joiner_commissioning(
 		bool action,
-		const char *psk,
-		const char *provisioning_url,
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
+++ b/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
@@ -36,17 +36,15 @@ public:
 		SpinelNCPInstance* instance,
 		CallbackWithStatusArg1 cb,
 		bool action,
-		const char *psk,
-		const char *provisioning_url
+		const ValueMap &options
 	);
 	virtual int vprocess_event(int event, va_list args);
 	virtual void finish(int status, const boost::any& value = boost::any());
 
 private:
-	bool 		mAction;
-	std::string	mPsk;
-	std::string	mProvisioningUrl;
-	NCPState	mLastState;
+	bool      mAction;
+	ValueMap  mOptions;
+	NCPState  mLastState;
 };
 
 }; // namespace wpantund

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -199,8 +199,7 @@ public:
 
 	virtual void joiner_commissioning(
 		bool action,
-		const char *psk,
-		const char *provisioning_url,
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -412,6 +412,13 @@
 #define kWPANTUNDValueMapKey_Scan_EnableFiltering               "Scan:EnableFiltering"
 #define kWPANTUNDValueMapKey_Scan_PANIDFilter                   "Scan:PANID"
 
+#define kWPANTUNDValueMapKey_Joiner_ProvisioningUrl             "Joiner:ProvisioningUrl"
+#define kWPANTUNDValueMapKey_Joiner_PSKd                        "Joiner:PSKd"
+#define kWPANTUNDValueMapKey_Joiner_VendorName                  "Joiner:Vendor:Name"
+#define kWPANTUNDValueMapKey_Joiner_VendorModel                 "Joiner:Vendor:Model"
+#define kWPANTUNDValueMapKey_Joiner_VendorSwVersion             "Joiner:Vendor:SwVersion"
+#define kWPANTUNDValueMapKey_Joiner_VendorData                  "Joiner:Vendor:Data"
+
 #define kWPANTUNDValueMapKey_Counter_TxTotal                    "TxTotal"              // Number of transmissions
 #define kWPANTUNDValueMapKey_Counter_TxUnicast                  "TxUnicast"            // Number of unicast transmissions
 #define kWPANTUNDValueMapKey_Counter_TxBroadcast                "TxBroadcast"          // Number of broadcast transmissions

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -2638,7 +2638,7 @@ typedef enum
     SPINEL_PROP_MESHCOP_JOINER_STATE = SPINEL_PROP_MESHCOP__BEGIN + 0, ///<[C]
 
     /// Thread Joiner Commissioning command and the parameters
-    /** Format `bUU` - Write Only
+    /** Format `b` or `bU(UUUUU)` (fields in parenthesis are optional) - Write Only
      *
      * This property starts or stops Joiner's commissioning process
      *
@@ -2649,7 +2649,7 @@ typedef enum
      * the Joiner commissioning process.
      *
      * After a successful start operation, the join process outcome is reported through an
-     * asynchronous `VALUE_IS(LAST_STATUS)`  update with one of the following error status values:
+     * asynchronous `VALUE_IS(LAST_STATUS)` update with one of the following error status values:
      *
      *     - SPINEL_STATUS_JOIN_SUCCESS     the join process succeeded.
      *     - SPINEL_STATUS_JOIN_SECURITY    the join process failed due to security credentials.
@@ -2657,11 +2657,21 @@ typedef enum
      *     - SPINEL_STATUS_JOIN_RSP_TIMEOUT if a response timed out.
      *     - SPINEL_STATUS_JOIN_FAILURE     join failure.
      *
-     * Data per item is:
+     * Frame format:
      *
-     *  `b` : Start or stop commissioning process
-     *  `U` : Joiner's PSKd if start commissioning, empty string if stop commissioning
-     *  `U` : Provisioning url if start commissioning, empty string if stop commissioning
+     *  `b` : Start or stop commissioning process (true to start).
+     *
+     * Only if the start commissioning.
+     *
+     *  `U` : Joiner's PSKd.
+     *
+     * The next fields are all optional. If not provided, OpenThread default values would be used.
+     *
+     *  `U` : Provisioning URL (use empty string if not required).
+     *  `U` : Vendor Name. If not specified or empty string, use OpenThread default (PACKAGE_NAME).
+     *  `U` : Vendor Model. If not specified or empty string, use OpenThread default (OPENTHREAD_CONFIG_PLATFORM_INFO).
+     *  `U` : Vendor Sw Version. If not specified or empty string, use OpenThread default (PACKAGE_VERSION).
+     *  `U` : Vendor Data String. Will not be appended if not specified.
      *
      */
     SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING = SPINEL_PROP_MESHCOP__BEGIN + 1,


### PR DESCRIPTION
This commit updates the Joiner related implementation in `wpantund`,
mainly adding support for user to specify the vendor related parameters
(name, model, SW version, and data) when joiner commissioning starts.

The following changes are included in this commit:

- The `NCPControlInterface` API `joiner_commissioning()` is changed to
  get all parameters as a `ValueMap` dictionary `options` (aligns it to
  to follow the same pattern used by other APIs like `form()` and
  `join()`). Along with this a group of value-map keys are defined for
  all parameters (PSK, provisioning URL, vendor info) in
  `wpan-properties.h`.

- The `SpinelNCPTaskJoinerCommissioning` implementation is changed to
  use a `ValueMap` dictionary as its input and intercat with NCP using
  the new specification of  `SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING`
  spinel property. Any unspecified parameter in the dictionary is
  replaced with an empty string (which is turn converted to an OpenThread
  defined default on NCP). The logging is changed to hide the PSKc (only
  the last two characters are printed).

- Two new DBus APIs "JoinerStart" and "JoinerStop" are added which
  expect a DBus dictionary as their argument. These APIs allow user to
  start Joiner operation with a subset of parameters. The existing DBus
  API "JoinerCommissioning" is also updated to use new Control Interface
  API but its parameters are kept as before (to ensure backward
  compatibility). It is marked as being deprecated so that new code
  adopts the new more flexible APIs.

- `wpanctl` command `joiner` is updated to use the new DBus APIs and
  allow vendor info to be (optionally) specified from `joiner --start`.