### PR TITLE
When logging, hide values of spinel properties related to PSK(c/d)

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -5340,6 +5340,9 @@ SpinelNCPInstance::log_spinel_frame(SpinelFrameOrigin origin, const uint8_t *fra
 				case SPINEL_PROP_NET_MASTER_KEY:
 				case SPINEL_PROP_THREAD_ACTIVE_DATASET:
 				case SPINEL_PROP_THREAD_PENDING_DATASET:
+				case SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING:
+				case SPINEL_PROP_NET_PSKC:
+				case SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS:
 					// Hide the value by skipping value dump
 					skip_value_dump = true;
 					break;


### PR DESCRIPTION
This commit adds `SPINEL_PROP_MESHCOP_JOINER_COMMISSIONING`,
`SPINEL_PROP_NET_PSKC`, and `SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS`
to the list of spinel properties for which the `log_spinel_frame()`
skips the value dump. This is to ensure PSK strings are not included
in the logs.