### PR TITLE
Update Joiner support (enable blocking mode and return joiner error)

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
+++ b/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
@@ -42,6 +42,8 @@ public:
 	virtual void finish(int status, const boost::any& value = boost::any());
 
 private:
+	int convert_joiner_status_to_wpan_error(int last_status);
+
 	bool      mAction;
 	ValueMap  mOptions;
 	NCPState  mLastState;

--- a/src/wpantund/NCPConstants.h
+++ b/src/wpantund/NCPConstants.h
@@ -26,6 +26,7 @@
 #define NCP_DEEP_SLEEP_TICKLE_TIMEOUT           (60*70) // Seventy minutes
 #define NCP_FORM_TIMEOUT                        60 // seconds
 #define NCP_JOIN_TIMEOUT                        60 // seconds
+#define NCP_JOINER_TIMEOUT                      60 // seconds
 
 #define NCP_NETWORK_KEY_SIZE                    16
 

--- a/src/wpantund/wpan-error.c
+++ b/src/wpantund/wpan-error.c
@@ -68,6 +68,10 @@ const char* wpantund_status_to_cstr(int status)
 	case kWPANTUNDStatus_NCP_InvalidRange: return "NCPInvalidRange";
 	case kWPANTUNDStatus_NCP_Reset: return "NCPReset";
 	case kWPANTUNDStatus_MissingXPANID: return "MissingXPANID";
+	case kWPANTUNDStatus_JoinerFailed_Security: return "JoinerFailed_Security";
+	case kWPANTUNDStatus_JoinerFailed_NoPeers: return "JoinerFailed_NoPeers";
+	case kWPANTUNDStatus_JoinerFailed_ResponseTimeout: return "JoinerFailed_ResponseTimeout";
+	case kWPANTUNDStatus_JoinerFailed_Unknown: return "JoinerFailed_Unknown";
 	default: break;
 	}
 	return "";

--- a/src/wpantund/wpan-error.h
+++ b/src/wpantund/wpan-error.h
@@ -65,6 +65,11 @@ typedef enum {
 
 	kWPANTUNDStatus_InterfaceNotFound             = 28,
 
+	kWPANTUNDStatus_JoinerFailed_Security         = 29,
+	kWPANTUNDStatus_JoinerFailed_NoPeers          = 30,
+	kWPANTUNDStatus_JoinerFailed_ResponseTimeout  = 31,
+	kWPANTUNDStatus_JoinerFailed_Unknown          = 32,
+
 	kWPANTUNDStatus_NCPError_First                = 0xEA0000,
 	kWPANTUNDStatus_NCPError_Last                 = 0xEAFFFF,
 } wpantund_status_t;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -433,6 +433,7 @@
 #define kWPANTUNDValueMapKey_Scan_EnableFiltering               "Scan:EnableFiltering"
 #define kWPANTUNDValueMapKey_Scan_PANIDFilter                   "Scan:PANID"
 
+#define kWPANTUNDValueMapKey_Joiner_ReturnImmediatelyOnStart    "Joiner:ReturnImmediatelyOnStart"
 #define kWPANTUNDValueMapKey_Joiner_ProvisioningUrl             "Joiner:ProvisioningUrl"
 #define kWPANTUNDValueMapKey_Joiner_PSKd                        "Joiner:PSKd"
 #define kWPANTUNDValueMapKey_Joiner_VendorName                  "Joiner:Vendor:Name"


### PR DESCRIPTION
This commit updates the Joiner Commissioning implementation to  add
support for blocking mode where upon Joiner start wpantund would wait
till end of operation and returns a wpan error indicating the reason
for failure including no peers, security (incorrect PSKd), response
timeout, etc. This feature is added by introducing a new value-map key
"Joiner:ReturnImmediatelyOnStart" to joiner API options which
indicates if on start of operation, we should return immediately or
wait for final status.

wpanctl `joiner` command is also updated to allow the blocking join
model using `--join` or `-j` command.