### PR TITLE
[build] add missing virtual destructors

### DIFF
--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -177,10 +177,10 @@ public:
 			RoutePreference preference = NCPControlInterface::ROUTE_MEDIUM_PREFERENCE,  bool stable = true,
 			uint16_t rloc16 = 0, CallbackWithStatus cb = NilReturn());
 
-	void service_was_added(Origin origin, uint32_t enterprise_number, const Data &service_data, 
+	void service_was_added(Origin origin, uint32_t enterprise_number, const Data &service_data,
 					bool stable, const Data &server_data, CallbackWithStatus cb = NilReturn());
 
-	void service_was_removed(Origin origin, uint32_t enterprise_number, const Data &service_data, 
+	void service_was_removed(Origin origin, uint32_t enterprise_number, const Data &service_data,
 					CallbackWithStatus cb = NilReturn());
 
 	static std::string on_mesh_prefix_flags_to_string(uint8_t flags, bool detailed = false);
@@ -207,7 +207,7 @@ protected:
 
 	virtual void remove_multicast_address_on_ncp(const struct in6_addr &addr, CallbackWithStatus cb) = 0;
 
-	virtual void add_service_on_ncp(uint32_t enterprise_number, const Data &service_data, bool stable, 
+	virtual void add_service_on_ncp(uint32_t enterprise_number, const Data &service_data, bool stable,
 					const Data &server_data, CallbackWithStatus cb) = 0;
 
 	virtual void remove_service_on_ncp(uint32_t enterprise_number, const Data &service_data, CallbackWithStatus cb) = 0;
@@ -290,7 +290,7 @@ public:
 
 	wpantund_status_t set_ncp_version_string(const std::string& version_string);
 
-	virtual void add_service(uint32_t enterprise_number, const Data &service_data, bool stable, 
+	virtual void add_service(uint32_t enterprise_number, const Data &service_data, bool stable,
 					const Data &server_data, CallbackWithStatus cb = NilReturn());
 
 	virtual void remove_service(uint32_t enterprise_number, const Data &service_data, CallbackWithStatus cb = NilReturn());
@@ -576,8 +576,9 @@ protected:
 
 	class ServiceEntryBase : public EntryBase {
 	public:
-		ServiceEntryBase(Origin origin, uint32_t enterprise_number, const Data &service_data) 
+		ServiceEntryBase(Origin origin, uint32_t enterprise_number, const Data &service_data)
 			: EntryBase(origin), mEnterpriseNumber(enterprise_number), mServiceData(service_data) {}
+		virtual ~ServiceEntryBase(void) {};
 
 		uint32_t get_enterprise_number(void) const { return mEnterpriseNumber; }
 		const Data &get_service_data(void) const { return mServiceData; }
@@ -593,8 +594,9 @@ protected:
 	class ServiceEntry : public ServiceEntryBase {
 	public:
 		ServiceEntry(Origin origin, uint32_t enterprise_number, const Data &service_data, bool stable,
-			const Data &server_data) 
+			const Data &server_data)
 			: ServiceEntryBase(origin, enterprise_number, service_data), mStable(stable), mServerData(server_data) {}
+		virtual ~ServiceEntry(void) {};
 
 		bool is_stable(void) const { return mStable; }
 		const Data &get_server_data(void) const { return mServerData; }


### PR DESCRIPTION
Missing these constructors will cause warnings which are treated as
errors.