### PR TITLE
Update "Joiner Attach" to allow blocking behavior

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -1585,16 +1585,21 @@ DBusIPCAPI_v1::interface_joiner_attach_handler(
 	NCPControlInterface* interface,
 	DBusMessage *        message
 ) {
-	DBusHandlerResult ret = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+	ValueMap options;
+	DBusMessageIter iter;
+
+	dbus_message_iter_init(message, &iter);
+
+	options = value_map_from_dbus_iter(&iter);
 
 	dbus_message_ref(message);
 
-	interface->joiner_attach(boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper,
-								  this, _1, message));
+	interface->joiner_attach(
+		options,
+		boost::bind(&DBusIPCAPI_v1::CallbackWithStatus_Helper, this, _1, message)
+	);
 
-	ret = DBUS_HANDLER_RESULT_HANDLED;
-
-	return ret;
+	return DBUS_HANDLER_RESULT_HANDLED;
 }
 
 DBusHandlerResult

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -195,6 +195,7 @@ DummyNCPControlInterface::remove_service(
 
 void
 DummyNCPControlInterface::joiner_attach(
+	const ValueMap &options,
 	CallbackWithStatus cb
 ) {
 	cb(kWPANTUNDStatus_FeatureNotImplemented);

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -176,6 +176,7 @@ public:
 	);
 
 	virtual void joiner_attach(
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -322,17 +322,16 @@ bail:
 }
 
 void
-SpinelNCPControlInterface::joiner_attach(CallbackWithStatus cb)
-{
-	mNCPInstance->start_new_task(SpinelNCPTaskSendCommand::Factory(mNCPInstance)
-			.set_callback(cb)
-			.add_command(SpinelPackData(
-					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
-					SPINEL_PROP_NET_STACK_UP,
-					true
-					))
-			.finish()
-			);
+SpinelNCPControlInterface::joiner_attach(
+	const ValueMap &options,
+	CallbackWithStatus cb
+) {
+	mNCPInstance->start_new_task(boost::shared_ptr<SpinelNCPTask>(
+		new SpinelNCPTaskJoinerAttach(
+				mNCPInstance,
+				boost::bind(cb, _1),
+				options
+	)));
 }
 
 void

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -178,6 +178,7 @@ public:
 	);
 
 	virtual void joiner_attach(
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	);
 

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -106,6 +106,7 @@ class SpinelNCPInstance : public NCPInstanceBase {
 	friend class SpinelNCPTaskGetNetworkTopology;
 	friend class SpinelNCPTaskGetMsgBufferCounters;
 	friend class SpinelNCPTaskJoinerCommissioning;
+	friend class SpinelNCPTaskJoinerAttach;
 	friend class SpinelNCPVendorCustom;
 
 public:

--- a/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
+++ b/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.h
@@ -49,6 +49,20 @@ private:
 	NCPState  mLastState;
 };
 
+class SpinelNCPTaskJoinerAttach : public SpinelNCPTask
+{
+public:
+	SpinelNCPTaskJoinerAttach(
+		SpinelNCPInstance* instance,
+		CallbackWithStatusArg1 cb,
+		const ValueMap &options
+	);
+	virtual int vprocess_event(int event, va_list args);
+
+private:
+	ValueMap  mOptions;
+};
+
 }; // namespace wpantund
 }; // namespace nl
 

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -208,6 +208,7 @@ public:
 	// Thread Mesh Commissioning Protocol (MeshCoP) Member Functions
 
 	virtual void joiner_attach(
+		const ValueMap &options,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 


### PR DESCRIPTION
This commit updates the `joiner_attach()` method to allow it to be
either blocking (wait till device attaches and state changes to
"associated") or non-blocking (which is the existing behavior). A new
sub-command `--attach-blocking` is added to wpanctl `joiner` command
for this new function.