### PR TITLE
[diag] allow longer command line for diagnostic

### DIFF
--- a/src/wpanctl/tool-cmd-mfg.c
+++ b/src/wpanctl/tool-cmd-mfg.c
@@ -28,7 +28,7 @@
 #include "wpan-dbus-v1.h"
 #include "args.h"
 
-#define MFG_MAX_COMMAND_SIZE        256
+#define MFG_MAX_COMMAND_SIZE        1300
 #define MFG_TIMEOUT_IN_SECONDS      10
 
 int tool_cmd_mfg(int argc, char *argv[])


### PR DESCRIPTION
Some diagnostic is much longer than 256. `1300` can cover those commands.