### PR TITLE
[socket-utils] use default if baud rate is not known

### DIFF
--- a/src/util/socket-utils.c
+++ b/src/util/socket-utils.c
@@ -909,9 +909,7 @@ open_super_socket(const char* socket_name)
 				const int baud = (int)strtol(options+2,NULL,10);
 				const int baud_opt = baud_rate_to_termios_constant(baud);
 				if(baud_opt <= 0) {
-					syslog(LOG_ERR, "Unsupported baud rate %d", baud);
-					fd = -1;
-					goto bail;
+					syslog(LOG_INFO, "Unknown baud rate %d - using default", baud);
 				} else {
 					syslog(LOG_DEBUG, "Setting baud rate to %d", baud);
 				}
@@ -931,9 +929,7 @@ open_super_socket(const char* socket_name)
 
 				const int baud_opt = baud_rate_to_termios_constant(gSocketWrapperBaud);
 				if(baud_opt <= 0) {
-					syslog(LOG_ERR, "Unsupported baud rate %d", gSocketWrapperBaud);
-					fd = -1;
-					goto bail;
+					syslog(LOG_INFO, "Unknown baud rate %d - using default", gSocketWrapperBaud);
 				} else {
 					syslog(LOG_DEBUG, "Setting baud rate to %d", gSocketWrapperBaud);
 				}


### PR DESCRIPTION
This changes socket-utils to use default value if baud rate is
not known/detemined. This was changed recently in 5a664c16e (which
causes issues with oss-fuzz tests). This commit changes the
behavior back.