### PR TITLE
Wait till end of NCP init when starting a new command task

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -130,7 +130,7 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskGetMsgBufferCounters.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetMsgBufferCounters.cpp
@@ -66,7 +66,7 @@ nl::wpantund::SpinelNCPTaskGetMsgBufferCounters::vprocess_event(int event, va_li
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskGetNetworkTopology.cpp
@@ -487,7 +487,7 @@ nl::wpantund::SpinelNCPTaskGetNetworkTopology::vprocess_event(int event, va_list
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskHostDidWake.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskHostDidWake.cpp
@@ -59,7 +59,7 @@ nl::wpantund::SpinelNCPTaskHostDidWake::vprocess_event(int event, va_list args)
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -75,7 +75,7 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoinerCommissioning.cpp
@@ -340,7 +340,7 @@ nl::wpantund::SpinelNCPTaskJoinerAttach::vprocess_event(int event, va_list args)
 		// Wait for device to be associated
 		EH_REQUIRE_WITHIN(
 			NCP_JOIN_TIMEOUT,
-			ncp_state_is_associated(mInstance->get_ncp_state()),
+			ncp_state_is_associated(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 			on_error
 		);
 	}

--- a/src/ncp-spinel/SpinelNCPTaskLeave.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskLeave.cpp
@@ -60,7 +60,7 @@ nl::wpantund::SpinelNCPTaskLeave::vprocess_event(int event, va_list args)
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskPeek.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskPeek.cpp
@@ -62,7 +62,7 @@ nl::wpantund::SpinelNCPTaskPeek::vprocess_event(int event, va_list args)
 	// Wait for a bit to see if the NCP will enter the right state.
 	EH_REQUIRE_WITHIN(
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
-		!ncp_state_is_initializing(mInstance->get_ncp_state()),
+		!ncp_state_is_initializing(mInstance->get_ncp_state()) && !mInstance->is_initializing_ncp(),
 		on_error
 	);
 

--- a/src/ncp-spinel/SpinelNCPTaskScan.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskScan.cpp
@@ -83,7 +83,8 @@ nl::wpantund::SpinelNCPTaskScan::vprocess_event(int event, va_list args)
 		NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
 		!ncp_state_is_initializing(mInstance->get_ncp_state())
 		&& (mInstance->get_ncp_state() != ASSOCIATING)
-		&& (mInstance->get_ncp_state() != CREDENTIALS_NEEDED),
+		&& (mInstance->get_ncp_state() != CREDENTIALS_NEEDED)
+		&& !mInstance->is_initializing_ncp(),
 		on_error
 	);
 


### PR DESCRIPTION
This commit changes the `NCPTask<Command>` protothread such that at
the start we wait for the end of any ongoing NCP initialization.
This commit adds the condition `!mInstance->is_initializing_ncp()` in
addition to checking of ncp state. Note that ncp state from
`get_ncp_state()` itself may change during initialization while
driver is syncing with NCP.