### PR TITLE
Use trusty for android check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ matrix:
           compiler: gcc
         - env: BUILD_TARGET="android-build" VERBOSE=1
           os: linux
+          dist: trusty


### PR DESCRIPTION
The android build system requires an old version of make, which is not
available in the latest build environment of Travis. This PR sets the
dist to trusty for Android check.