### PR TITLE
Make "reset" wait till end of NCP init

### DIFF
--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -129,6 +129,11 @@ SpinelNCPControlInterface::attach(CallbackWithStatus cb)
 	);
 }
 
+static bool check_ncp_finished_initalization(SpinelNCPInstance *instance)
+{
+	return !ncp_state_is_initializing(instance->get_ncp_state()) && !instance->is_initializing_ncp();
+}
+
 void
 SpinelNCPControlInterface::reset(CallbackWithStatus cb)
 {
@@ -139,6 +144,7 @@ SpinelNCPControlInterface::reset(CallbackWithStatus cb)
 	mNCPInstance->start_new_task(SpinelNCPTaskSendCommand::Factory(mNCPInstance)
 		.set_callback(CallbackWithStatus(boost::bind(cb,kWPANTUNDStatus_Ok)))
 		.add_command(SpinelPackData(SPINEL_FRAME_PACK_CMD_RESET))
+		.set_final_check(boost::bind(check_ncp_finished_initalization, mNCPInstance))
 		.finish()
 	);
 }

--- a/src/ncp-spinel/SpinelNCPTaskSendCommand.h
+++ b/src/ncp-spinel/SpinelNCPTaskSendCommand.h
@@ -34,6 +34,7 @@ class SpinelNCPTaskSendCommand : public SpinelNCPTask
 {
 public:
 	typedef boost::function<int (const uint8_t*, spinel_size_t, boost::any&)> ReplyUnpacker;
+	typedef boost::function<bool ()> CheckHandler;
 
 	class Factory {
 	public:
@@ -59,6 +60,13 @@ public:
 
 		Factory& set_lock_property(int lock_property);
 
+		/* The caller can optionally set a final check handler.
+		 * If provided, the task will wait for the given amount
+		 * of timeout for the check handler call returning `true`.
+		 *
+		 */
+		Factory& set_final_check(const CheckHandler &handler, int timeout = NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT);
+
 		boost::shared_ptr<SpinelNCPTask> finish(void);
 
 	private:
@@ -68,6 +76,8 @@ public:
 		int mTimeout;
 		ReplyUnpacker mReplyUnpacker;
 		int mLockProperty;
+		CheckHandler mCheckHandler;
+		int mCheckTimeout;
 	};
 
 	SpinelNCPTaskSendCommand(const Factory& factory);
@@ -80,6 +90,8 @@ private:
 	std::list<Data>::const_iterator mCommandIter;
 	int mLockProperty;
 	ReplyUnpacker mReplyUnpacker;
+	CheckHandler mCheckHandler;
+	int mCheckTimeout;
 	int mRetVal;
 	boost::any mReturnValue;
 };


### PR DESCRIPTION
This commit convert the `SpinelNCPControlInterface::reset()` API to
wait till end of NCP re-initilaization (instead of returning after
issuing the `RESET` command to NCP). This is realized by adding a
feature in `TaskSendCommand` to allow an optional "final check
handler" to be added to the command. If provided after the commands
are sent to NCP, the task will invoke the provided handler and waits
until the handler returns `true` (within the given timeout interval).