### PR TITLE
Add thread radio coex metrics support

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1051,7 +1051,7 @@ unpack_coex_metrics(const uint8_t *data_in, spinel_size_t data_len, boost::any& 
 	int ret = kWPANTUNDStatus_Ok;
 	spinel_ssize_t len;
 	bool stopped;
-	uint32_t numGrantGlitch;
+	uint32_t num_grant_glitch;
 
 	const char *tx_coex_metrics_names[] = {
 		kWPANTUNDValueMapKey_CoexMetrics_NumTxRequest,
@@ -1083,21 +1083,21 @@ unpack_coex_metrics(const uint8_t *data_in, spinel_size_t data_len, boost::any& 
 	data_in += len;
 	data_len -= len;
 
-	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT32_S, &numGrantGlitch);
+	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT32_S, &num_grant_glitch);
 	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
 	data_in += len;
 	data_len -= len;
 
 	if (!as_val_map) {
 		char c_string[200];
-		snprintf(c_string, sizeof(c_string), "%-20s = %d", kWPANTUNDValueMapKey_CoexMetrics_Stopped, stopped);
+		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_Stopped, stopped);
 		result_as_string.push_back(std::string(c_string));
 
-		snprintf(c_string, sizeof(c_string), "%-20s = %d", kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch, numGrantGlitch);
+		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch, num_grant_glitch);
 		result_as_string.push_back(std::string(c_string));
 	} else {
 		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_Stopped] = stopped;
-		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch] = numGrantGlitch;
+		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch] = num_grant_glitch;
 	}
 
 	for (int index = 0; index < 2; index++)
@@ -1139,7 +1139,7 @@ unpack_coex_metrics(const uint8_t *data_in, spinel_size_t data_len, boost::any& 
 
 			if (!as_val_map) {
 				char c_string[200];
-				snprintf(c_string, sizeof(c_string), "%-20s = %d", *counter_names, counter_value);
+				snprintf(c_string, sizeof(c_string), "%-20s = %u", *counter_names, counter_value);
 				result_as_string.push_back(std::string(c_string));
 			} else {
 				result_as_val_map[*counter_names] = counter_value;

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1078,28 +1078,6 @@ unpack_coex_metrics(const uint8_t *data_in, spinel_size_t data_len, boost::any& 
 		NULL
 	};
 
-	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_BOOL_S, &stopped);
-	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
-	data_in += len;
-	data_len -= len;
-
-	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT32_S, &num_grant_glitch);
-	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
-	data_in += len;
-	data_len -= len;
-
-	if (!as_val_map) {
-		char c_string[200];
-		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_Stopped, stopped);
-		result_as_string.push_back(std::string(c_string));
-
-		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch, num_grant_glitch);
-		result_as_string.push_back(std::string(c_string));
-	} else {
-		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_Stopped] = stopped;
-		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch] = num_grant_glitch;
-	}
-
 	for (int index = 0; index < 2; index++)
 	{
 		const char **counter_names;
@@ -1147,6 +1125,28 @@ unpack_coex_metrics(const uint8_t *data_in, spinel_size_t data_len, boost::any& 
 
 			counter_names++;
 		}
+	}
+
+	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_BOOL_S, &stopped);
+	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+	data_in += len;
+	data_len -= len;
+
+	len = spinel_datatype_unpack(data_in, data_len, SPINEL_DATATYPE_UINT32_S, &num_grant_glitch);
+	require_action(len > 0, bail, ret = kWPANTUNDStatus_Failure);
+	data_in += len;
+	data_len -= len;
+
+	if (!as_val_map) {
+		char c_string[200];
+		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_Stopped, stopped);
+		result_as_string.push_back(std::string(c_string));
+
+		snprintf(c_string, sizeof(c_string), "%-20s = %u", kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch, num_grant_glitch);
+		result_as_string.push_back(std::string(c_string));
+	} else {
+		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_Stopped] = stopped;
+		result_as_val_map[kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch] = num_grant_glitch;
 	}
 
 	if (as_val_map) {

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -238,6 +238,9 @@
 
 #define kWPANTUNDProperty_ThreadJoinerState                     "Thread:Joiner:State"
 
+#define kWPANTUNDProperty_NCPCoexMetrics                        "NCP:CoexMetrics"
+#define kWPANTUNDProperty_NCPCoexMetricsAsValMap                "NCP:CoexMetrics:AsValMap"
+
 #define kWPANTUNDProperty_NCPCounterAllMac                      "NCP:Counter:AllMac"
 #define kWPANTUNDProperty_NCPCounterAllMacAsValMap              "NCP:Counter:AllMac:AsValMap"
 #define kWPANTUNDProperty_NCPCounterThreadMle                   "NCP:Counter:Thread:Mle"
@@ -494,5 +497,25 @@
 #define kWPANTUNDValueMapKey_Service_Stable                     "Stable"
 #define kWPANTUNDValueMapKey_Service_ServerData                 "ServerData"
 #define kWPANTUNDValueMapKey_Service_RLOC16                     "RLOC16"
+
+#define kWPANTUNDValueMapKey_CoexMetrics_Stopped                            "Stopped"                            // Stats collection stopped due to saturation.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumGrantGlitch                     "NumGrantGlitch"                     // The number of of grant glitches.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxRequest                       "NumTxRequest"                       // The number of tx requests.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxGrantImmediate                "NumTxGrantImmediate"                // The number of tx requests while grant was active.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxGrantWait                     "NumTxGrantWait"                     // The number of tx requests while grant was inactive.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxGrantWaitActivated            "NumTxGrantWaitActivated"            // The number of tx requests while grant was inactive that were ultimately granted.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxGrantWaitTimeout              "NumTxGrantWaitTimeout"              // The number of tx requests while grant was inactive that timed out.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxGrantDeactivatedDuringRequest "NumTxGrantDeactivatedDuringRequest" // The number of tx requests that were in progress when grant was deactivated.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumTxDelayedGrant                  "NumTxDelayedGrant"                  // The number of tx requests that were not granted within 50us.
+#define kWPANTUNDValueMapKey_CoexMetrics_AvgTxRequestToGrantTime            "AvgTxRequestToGrantTime"            // The average time in usec from tx request to grant.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxRequest                       "NumRxRequest"                       // The number of rx requests.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantImmediate                "NumRxGrantImmediate"                // The number of rx requests while grant was active.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantWait                     "NumRxGrantWait"                     // The number of rx requests while grant was inactive.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantWaitActivated            "NumRxGrantWaitActivated"            // The number of rx requests while grant was inactive that were ultimately granted.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantWaitTimeout              "NumRxGrantWaitTimeout"              // The number of rx requests while grant was inactive that timed out.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantDeactivatedDuringRequest "NumRxGrantDeactivatedDuringRequest" // The number of rx requests that were in progress when grant was deactivated.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxDelayedGrant                  "NumRxDelayedGrant"                  // The number of rx requests that were not granted within 50us.
+#define kWPANTUNDValueMapKey_CoexMetrics_AvgRxRequestToGrantTime            "AvgRxRequestToGrantTime"            // The average time in usec from rx request to grant.
+#define kWPANTUNDValueMapKey_CoexMetrics_NumRxGrantNone                     "NumRxGrantNone"                     // The number of rx requests that completed without receiving grant.
 
 #endif

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1399,6 +1399,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "CHANNEL_MONITOR_CHANNEL_OCCUPANCY";
         break;
 
+    case SPINEL_PROP_RADIO_COEX_METRICS:
+        ret = "RADIO_COEX_METRICS";
+        break;
+
     case SPINEL_PROP_MAC_SCAN_STATE:
         ret = "MAC_SCAN_STATE";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1628,16 +1628,12 @@ typedef enum
     SPINEL_PROP_RADIO_CAPS = SPINEL_PROP_PHY_EXT__BEGIN + 11,
 
     /// All coex metrics related counters.
-    /** Format: bLt(LLLLLLLL)t(LLLLLLLLL)  (Read-only)
+    /** Format: t(LLLLLLLL)t(LLLLLLLLL)bL  (Read-only)
      *
-     * The contents include two variables and two structs, first one corresponds to
-     * all transmit related coex counters, second one provides the receive related counters.
-     *
-     *   'b': Stopped                            (Stats collection stopped due to saturation).
-     *   'L': NumGrantGlitch                     (The number of of grant glitches).
+     * The contents include two structures and two common variables, first structure corresponds to
+     * all transmit related coex counters, second structure provides the receive related counters.
      *
      * The transmit structure includes:
-     *
      *   'L': NumTxRequest                       (The number of tx requests).
      *   'L': NumTxGrantImmediate                (The number of tx requests while grant was active).
      *   'L': NumTxGrantWait                     (The number of tx requests while grant was inactive).
@@ -1661,6 +1657,10 @@ typedef enum
      *   'L': NumRxDelayedGrant                  (The number of rx requests that were not granted within 50us).
      *   'L': AvgRxRequestToGrantTime            (The average time in usec from rx request to grant).
      *   'L': NumRxGrantNone                     (The number of rx requests that completed without receiving grant).
+     *
+     * Two common variables:
+     *   'b': Stopped        (Stats collection stopped due to saturation).
+     *   'L': NumGrantGlitch (The number of of grant glitches).
      */
     SPINEL_PROP_RADIO_COEX_METRICS = SPINEL_PROP_PHY_EXT__BEGIN + 12,
 

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1628,7 +1628,7 @@ typedef enum
     SPINEL_PROP_RADIO_CAPS = SPINEL_PROP_PHY_EXT__BEGIN + 11,
 
     /// All coex metrics related counters.
-    /** Format: Lbt(LLLLLLLL)t(LLLLLLLLL)  (Read-only)
+    /** Format: bLt(LLLLLLLL)t(LLLLLLLLL)  (Read-only)
      *
      * The contents include two variables and two structs, first one corresponds to
      * all transmit related coex counters, second one provides the receive related counters.

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1627,6 +1627,43 @@ typedef enum
      */
     SPINEL_PROP_RADIO_CAPS = SPINEL_PROP_PHY_EXT__BEGIN + 11,
 
+    /// All coex metrics related counters.
+    /** Format: Lbt(LLLLLLLL)t(LLLLLLLLL)  (Read-only)
+     *
+     * The contents include two variables and two structs, first one corresponds to
+     * all transmit related coex counters, second one provides the receive related counters.
+     *
+     *   'b': Stopped                            (Stats collection stopped due to saturation).
+     *   'L': NumGrantGlitch                     (The number of of grant glitches).
+     *
+     * The transmit structure includes:
+     *
+     *   'L': NumTxRequest                       (The number of tx requests).
+     *   'L': NumTxGrantImmediate                (The number of tx requests while grant was active).
+     *   'L': NumTxGrantWait                     (The number of tx requests while grant was inactive).
+     *   'L': NumTxGrantWaitActivated            (The number of tx requests while grant was inactive that were
+     *                                            ultimately granted).
+     *   'L': NumTxGrantWaitTimeout              (The number of tx requests while grant was inactive that timed out).
+     *   'L': NumTxGrantDeactivatedDuringRequest (The number of tx requests that were in progress when grant was
+     *                                            deactivated).
+     *   'L': NumTxDelayedGrant                  (The number of tx requests that were not granted within 50us).
+     *   'L': AvgTxRequestToGrantTime            (The average time in usec from tx request to grant).
+     *
+     * The receive structure includes:
+     *   'L': NumRxRequest                       (The number of rx requests).
+     *   'L': NumRxGrantImmediate                (The number of rx requests while grant was active).
+     *   'L': NumRxGrantWait                     (The number of rx requests while grant was inactive).
+     *   'L': NumRxGrantWaitActivated            (The number of rx requests while grant was inactive that were
+     *                                            ultimately granted).
+     *   'L': NumRxGrantWaitTimeout              (The number of rx requests while grant was inactive that timed out).
+     *   'L': NumRxGrantDeactivatedDuringRequest (The number of rx requests that were in progress when grant was
+     *                                            deactivated).
+     *   'L': NumRxDelayedGrant                  (The number of rx requests that were not granted within 50us).
+     *   'L': AvgRxRequestToGrantTime            (The average time in usec from rx request to grant).
+     *   'L': NumRxGrantNone                     (The number of rx requests that completed without receiving grant).
+     */
+    SPINEL_PROP_RADIO_COEX_METRICS = SPINEL_PROP_PHY_EXT__BEGIN + 12,
+
     SPINEL_PROP_PHY_EXT__END = 0x1300,
 
     SPINEL_PROP_MAC__BEGIN = 0x30,


### PR DESCRIPTION
This commit adds  "SPINEL_PROP_RADIO_COEX_METRICS" to the list of spinel properties. It adds "kWPANTUNDProperty_NCPCoexMetrics" and "kWPANTUNDProperty_NCPCoexMetricsAsValMap" wpan properties to get the radio coex metrics.