### PR TITLE
Add thread coex enable/disable properity

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -452,7 +452,6 @@ SpinelNCPInstance::get_supported_property_keys()const
 	properties.insert(kWPANTUNDProperty_NCPExtendedAddress);
 	properties.insert(kWPANTUNDProperty_NCPCCAFailureRate);
 	properties.insert(kWPANTUNDProperty_NCPCapabilities);
-	properties.insert(kWPANTUNDProperty_NCPCoexMetrics);
 
 	if (mCapabilities.count(SPINEL_CAP_ROLE_SLEEPY)) {
 		properties.insert(kWPANTUNDProperty_NCPSleepyPollInterval);
@@ -567,6 +566,11 @@ SpinelNCPInstance::get_supported_property_keys()const
 	if (mCapabilities.count(SPINEL_CAP_THREAD_SERVICE)) {
 		properties.insert(kWPANTUNDProperty_ThreadServices);
 		properties.insert(kWPANTUNDProperty_ThreadLeaderServices);
+	}
+
+	if (mCapabilities.count(SPINEL_CAP_RADIO_COEX)) {
+		properties.insert(kWPANTUNDProperty_NCPCoexEnable);
+		properties.insert(kWPANTUNDProperty_NCPCoexMetrics);
 	}
 
 	{

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1964,9 +1964,6 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 	register_get_handler_spinel_simple(
 		kWPANTUNDProperty_OpenThreadLogLevel,
 		SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, SPINEL_DATATYPE_UINT8_S);
-	register_get_handler_spinel_simple(
-		kWPANTUNDProperty_NCPCoexEnable,
-		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_S);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties requiring capability check and associated with a spinel property
@@ -2252,6 +2249,10 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 		kWPANTUNDProperty_OpenThreadSLAACEnabled,
 		SPINEL_CAP_SLAAC,
 		SPINEL_PROP_SLAAC_ENABLED, SPINEL_DATATYPE_BOOL_S);
+	register_get_handler_capability_spinel_simple(
+		kWPANTUNDProperty_NCPCoexEnable,
+		SPINEL_CAP_RADIO_COEX,
+		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_S);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties associated with a spinel property using an unpacker
@@ -2262,12 +2263,6 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 	register_get_handler_spinel_unpacker(
 		kWPANTUNDProperty_NCPPreferredChannelMask,
 		SPINEL_PROP_PHY_CHAN_PREFERRED, unpack_channel_mask);
-	register_get_handler_spinel_unpacker(
-		kWPANTUNDProperty_NCPCoexMetrics,
-		SPINEL_PROP_RADIO_COEX_METRICS, boost::bind(unpack_coex_metrics, _1, _2, _3, /* as_val_map */ false));
-	register_get_handler_spinel_unpacker(
-		kWPANTUNDProperty_NCPCoexMetricsAsValMap,
-		SPINEL_PROP_RADIO_COEX_METRICS, boost::bind(unpack_coex_metrics, _1, _2, _3, /* as_val_map */ true));
 	register_get_handler_spinel_unpacker(
 		kWPANTUNDProperty_ThreadActiveDataset,
 		SPINEL_PROP_THREAD_ACTIVE_DATASET, boost::bind(unpack_dataset, _1, _2, _3, /* as_val_map */ false));
@@ -2385,6 +2380,14 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 		kWPANTUNDProperty_ThreadLeaderServicesAsValMap,
 		SPINEL_CAP_THREAD_SERVICE,
 		SPINEL_PROP_SERVER_LEADER_SERVICES, boost::bind(unpack_server_leader_services_as_any, _1, _2, _3, true));
+	register_get_handler_capability_spinel_unpacker(
+		kWPANTUNDProperty_NCPCoexMetrics,
+		SPINEL_CAP_RADIO_COEX,
+		SPINEL_PROP_RADIO_COEX_METRICS, boost::bind(unpack_coex_metrics, _1, _2, _3, false));
+	register_get_handler_capability_spinel_unpacker(
+		kWPANTUNDProperty_NCPCoexMetricsAsValMap,
+		SPINEL_CAP_RADIO_COEX,
+		SPINEL_PROP_RADIO_COEX_METRICS, boost::bind(unpack_coex_metrics, _1, _2, _3, true));
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties with a dedicated handler method
@@ -3141,9 +3144,6 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 	register_set_handler_spinel(
 		kWPANTUNDProperty_ThreadRouterDowngradeThreshold,
 		SPINEL_PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD, SPINEL_DATATYPE_UINT8_C);
-	register_set_handler_spinel(
-		kWPANTUNDProperty_NCPCoexEnable,
-		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_C);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties requiring persistence (saving in settings) and associated with a
@@ -3274,6 +3274,10 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 		kWPANTUNDProperty_OpenThreadSLAACEnabled,
 		SPINEL_CAP_SLAAC,
 		SPINEL_PROP_SLAAC_ENABLED, SPINEL_DATATYPE_BOOL_C);
+	register_set_handler_capability_spinel_persist(
+		kWPANTUNDProperty_NCPCoexEnable,
+		SPINEL_CAP_RADIO_COEX,
+		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_C);
 
 	// Properties with a `ValueConverter`
 	register_set_handler_capability_spinel_persist(

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -1964,6 +1964,9 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 	register_get_handler_spinel_simple(
 		kWPANTUNDProperty_OpenThreadLogLevel,
 		SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, SPINEL_DATATYPE_UINT8_S);
+	register_get_handler_spinel_simple(
+		kWPANTUNDProperty_NCPCoexEnable,
+		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_S);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties requiring capability check and associated with a spinel property
@@ -3138,6 +3141,9 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 	register_set_handler_spinel(
 		kWPANTUNDProperty_ThreadRouterDowngradeThreshold,
 		SPINEL_PROP_THREAD_ROUTER_DOWNGRADE_THRESHOLD, SPINEL_DATATYPE_UINT8_C);
+	register_set_handler_spinel(
+		kWPANTUNDProperty_NCPCoexEnable,
+		SPINEL_PROP_RADIO_COEX_ENABLE, SPINEL_DATATYPE_BOOL_C);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties requiring persistence (saving in settings) and associated with a

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -240,6 +240,7 @@
 
 #define kWPANTUNDProperty_NCPCoexMetrics                        "NCP:CoexMetrics"
 #define kWPANTUNDProperty_NCPCoexMetricsAsValMap                "NCP:CoexMetrics:AsValMap"
+#define kWPANTUNDProperty_NCPCoexEnable                         "NCP:Coex:Enable"
 
 #define kWPANTUNDProperty_NCPCounterAllMac                      "NCP:Counter:AllMac"
 #define kWPANTUNDProperty_NCPCounterAllMacAsValMap              "NCP:Counter:AllMac:AsValMap"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1403,6 +1403,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "RADIO_COEX_METRICS";
         break;
 
+    case SPINEL_PROP_RADIO_COEX_ENABLE:
+        ret = "RADIO_COEX_ENABLE";
+        break;
+
     case SPINEL_PROP_MAC_SCAN_STATE:
         ret = "MAC_SCAN_STATE";
         break;

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -2572,6 +2572,10 @@ const char *spinel_capability_to_cstr(unsigned int capability)
         ret = "SLAAC";
         break;
 
+    case SPINEL_CAP_RADIO_COEX:
+        ret = "RADIO_COEX";
+        break;
+
     case SPINEL_CAP_ERROR_RATE_TRACKING:
         ret = "ERROR_RATE_TRACKING";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1664,6 +1664,13 @@ typedef enum
      */
     SPINEL_PROP_RADIO_COEX_METRICS = SPINEL_PROP_PHY_EXT__BEGIN + 12,
 
+    /// Radio Coex Enable
+    /** Format: `b`
+     *
+     * Indicates if radio coex is enabled or disabled. Set to true to enable radio coex.
+     */
+    SPINEL_PROP_RADIO_COEX_ENABLE = SPINEL_PROP_PHY_EXT__BEGIN + 13,
+
     SPINEL_PROP_PHY_EXT__END = 0x1300,
 
     SPINEL_PROP_MAC__BEGIN = 0x30,

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1054,6 +1054,7 @@ enum
     SPINEL_CAP_CHILD_SUPERVISION       = (SPINEL_CAP_OPENTHREAD__BEGIN + 8),
     SPINEL_CAP_POSIX_APP               = (SPINEL_CAP_OPENTHREAD__BEGIN + 9),
     SPINEL_CAP_SLAAC                   = (SPINEL_CAP_OPENTHREAD__BEGIN + 10),
+    SPINEL_CAP_RADIO_COEX              = (SPINEL_CAP_OPENTHREAD__BEGIN + 11),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN        = 1024,
@@ -1630,6 +1631,8 @@ typedef enum
     /// All coex metrics related counters.
     /** Format: t(LLLLLLLL)t(LLLLLLLLL)bL  (Read-only)
      *
+     * Required capability: `SPINEL_CAP_RADIO_COEX`
+     *
      * The contents include two structures and two common variables, first structure corresponds to
      * all transmit related coex counters, second structure provides the receive related counters.
      *
@@ -1666,6 +1669,8 @@ typedef enum
 
     /// Radio Coex Enable
     /** Format: `b`
+     *
+     * Required capability: `SPINEL_CAP_RADIO_COEX`
      *
      * Indicates if radio coex is enabled or disabled. Set to true to enable radio coex.
      */


### PR DESCRIPTION
This commit adds "SPINEL_PROP_RADIO_COEX_ENABLE" to the list of spinel properties and
add "kWPANTUNDProperty_NCPCoexEnable" wpan properties to enable/disable the radio coex.