### PR TITLE
Feature to auto add on-mesh prefixes as interface route

### DIFF
--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -81,6 +81,7 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mSetSLAACForAutoAddedPrefix = false;
 	mAutoAddOffMeshRoutesOnInterface = true;
 	mFilterSelfAutoAddedOffMeshRoutes = true;
+	mAutoAddOnMeshPrefixesAsInterfaceRoutes = true;
 	mTerminateOnFault = false;
 	mWasBusy = false;
 	mNCPIsMisbehaving = false;
@@ -389,6 +390,7 @@ NCPInstanceBase::regsiter_all_get_handlers(void)
 	REGISTER_GET_HANDLER(IPv6SetSLAACForAutoAddedPrefix);
 	REGISTER_GET_HANDLER(DaemonOffMeshRouteAutoAddOnInterface);
 	REGISTER_GET_HANDLER(DaemonOffMeshRouteFilterSelfAutoAdded);
+	REGISTER_GET_HANDLER(DaemonOnMeshPrefixAutoAddAsIfaceRoute);
 	REGISTER_GET_HANDLER(IPv6MeshLocalPrefix);
 	REGISTER_GET_HANDLER(IPv6MeshLocalAddress);
 	REGISTER_GET_HANDLER(IPv6LinkLocalAddress);
@@ -606,6 +608,12 @@ void
 NCPInstanceBase::get_prop_DaemonOffMeshRouteFilterSelfAutoAdded(CallbackWithStatusArg1 cb)
 {
 	cb(kWPANTUNDStatus_Ok, boost::any(mFilterSelfAutoAddedOffMeshRoutes));
+}
+
+void
+NCPInstanceBase::get_prop_DaemonOnMeshPrefixAutoAddAsIfaceRoute(CallbackWithStatusArg1 cb)
+{
+	cb(kWPANTUNDStatus_Ok, boost::any(mAutoAddOnMeshPrefixesAsInterfaceRoutes));
 }
 
 void
@@ -841,6 +849,7 @@ NCPInstanceBase::regsiter_all_set_handlers(void)
 	REGISTER_SET_HANDLER(IPv6SetSLAACForAutoAddedPrefix);
 	REGISTER_SET_HANDLER(DaemonOffMeshRouteAutoAddOnInterface);
 	REGISTER_SET_HANDLER(DaemonOffMeshRouteFilterSelfAutoAdded);
+	REGISTER_SET_HANDLER(DaemonOnMeshPrefixAutoAddAsIfaceRoute);
 	REGISTER_SET_HANDLER(IPv6MeshLocalPrefix);
 	REGISTER_SET_HANDLER(IPv6MeshLocalAddress);
 	REGISTER_SET_HANDLER(DaemonAutoDeepSleep);
@@ -1006,6 +1015,13 @@ void
 NCPInstanceBase::set_prop_DaemonOffMeshRouteFilterSelfAutoAdded(const boost::any &value, CallbackWithStatus cb)
 {
 	mFilterSelfAutoAddedOffMeshRoutes = any_to_bool(value);
+	cb(kWPANTUNDStatus_Ok);
+}
+
+void
+NCPInstanceBase::set_prop_DaemonOnMeshPrefixAutoAddAsIfaceRoute(const boost::any &value, CallbackWithStatus cb)
+{
+	mAutoAddOnMeshPrefixesAsInterfaceRoutes = any_to_bool(value);
 	cb(kWPANTUNDStatus_Ok);
 }
 

--- a/src/wpantund/NCPInstanceBase.h
+++ b/src/wpantund/NCPInstanceBase.h
@@ -348,6 +348,7 @@ private:
 	void get_prop_IPv6SetSLAACForAutoAddedPrefix(CallbackWithStatusArg1 cb);
 	void get_prop_DaemonOffMeshRouteAutoAddOnInterface(CallbackWithStatusArg1 cb);
 	void get_prop_DaemonOffMeshRouteFilterSelfAutoAdded(CallbackWithStatusArg1 cb);
+	void get_prop_DaemonOnMeshPrefixAutoAddAsIfaceRoute(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6MeshLocalPrefix(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6MeshLocalAddress(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6LinkLocalAddress(CallbackWithStatusArg1 cb);
@@ -379,6 +380,7 @@ private:
 	void set_prop_IPv6SetSLAACForAutoAddedPrefix(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DaemonOffMeshRouteAutoAddOnInterface(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DaemonOffMeshRouteFilterSelfAutoAdded(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_DaemonOnMeshPrefixAutoAddAsIfaceRoute(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_IPv6MeshLocalPrefix(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_IPv6MeshLocalAddress(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DaemonAutoDeepSleep(const boost::any &value, CallbackWithStatus cb);
@@ -734,6 +736,18 @@ protected:
 	// By default this is enabled (`true`).
 	//
 	bool mFilterSelfAutoAddedOffMeshRoutes;
+
+	// This boolean flag indicates whether wpantund should add routes corresponding
+	// to on-mesh prefixes on the host interface.
+	//
+	// When enabled, wpantund would add a route on host primary interface for any
+	// prefix from thread network (with on-mesh flag set). This in turn ensures that
+	// traffic destined to an IPv6 address matching the prefix would be correctly
+	// forwarded to the wpan interface.
+	//
+	// By default this is enabled (`true`).
+	//
+	bool mAutoAddOnMeshPrefixesAsInterfaceRoutes;
 
 private:
 	NCPState mNCPState;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -55,6 +55,7 @@
 #define kWPANTUNDProperty_DaemonSetDefRouteForAutoAddedPrefix   "Daemon:SetDefaultRouteForAutoAddedPrefix"
 #define kWPANTUNDProperty_DaemonOffMeshRouteAutoAddOnInterface  "Daemon:OffMeshRoute:AutoAddOnInterface"
 #define kWPANTUNDProperty_DaemonOffMeshRouteFilterSelfAutoAdded "Daemon:OffMeshRoute:FilterSelfAutoAdded"
+#define kWPANTUNDProperty_DaemonOnMeshPrefixAutoAddAsIfaceRoute "Daemon:OnMeshPrefix:AutoAddAsInterfaceRoute"
 
 #define kWPANTUNDProperty_NCPVersion                            "NCP:Version"
 #define kWPANTUNDProperty_NCPState                              "NCP:State"


### PR DESCRIPTION
This commit adds a new feature in `wpantund` to auto add a route on
the host primary interface corresponding to on-mesh prefixes from
Thread network.

This feature can be enabled through a newly added wpan property with
name "Daemon:OnMeshPrefix:AutoAddAsIntterfaceRoute" which is enabled
by default.

When enabled, wpantund would add a route on host primary interface for
any prefix from thread network (with on-mesh flag set). This in turn
ensures that traffic destined to an IPv6 address matching the prefix
would be correctly forwarded to the `wpan` interface on host.

----
This feature is now independent of `mAutoAddOffMeshRoutesOnInterface` (each feature can be separately enabled or disabled).

https://github.com/openthread/openthread/pull/4221 adds a test-case to cover the behavior of this feature.

