### PR TITLE
Add support for generating PSKc from pass-phrase, net-name, and XPANId

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.h
+++ b/src/ipc-dbus/DBusIPCAPI_v1.h
@@ -266,6 +266,11 @@ private:
 		DBusMessage *        message
 	);
 
+	DBusHandlerResult interface_generate_pskc(
+		NCPControlInterface* interface,
+		DBusMessage *        message
+	);
+
 	DBusHandlerResult interface_peek_handler(
 		NCPControlInterface* interface,
 		DBusMessage *        message

--- a/src/ipc-dbus/wpan-dbus-v1.h
+++ b/src/ipc-dbus/wpan-dbus-v1.h
@@ -92,6 +92,7 @@
 #define WPANTUND_IF_CMD_ANNOUNCE_BEGIN        "AnnounceBegin"
 #define WPANTUND_IF_CMD_ENERGY_SCAN_QUERY     "EnergyScanQuery"
 #define WPANTUND_IF_CMD_PAN_ID_QUERY          "PanIdQuery"
+#define WPANTUND_IF_CMD_GENERATE_PSKC         "GeneratePSKc"
 
 #define WPANTUND_IF_CMD_PEEK                  "Peek"
 #define WPANTUND_IF_CMD_POKE                  "Poke"

--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -263,6 +263,16 @@ DummyNCPControlInterface::commissioner_send_pan_id_query(
 }
 
 void
+DummyNCPControlInterface::commissioner_generate_pskc(
+	const char *pass_phrase,
+	const char *network_name,
+	const XPANId &xpanid,
+	CallbackWithStatusArg1 cb
+) {
+	cb(kWPANTUNDStatus_FeatureNotImplemented, std::string("generating PSKc is not supported"));
+}
+
+void
 DummyNCPControlInterface::permit_join(
 	int seconds,
 	uint8_t traffic_type,

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -223,6 +223,13 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
+	virtual void commissioner_generate_pskc(
+		const char *pass_phrase,
+		const char *network_name,
+		const XPANId &xpanid,
+		CallbackWithStatusArg1 cb = NilReturn()
+	);
+
 	virtual void data_poll(
 		CallbackWithStatus cb = NilReturn()
 	);

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -621,6 +621,36 @@ bail:
 }
 
 void
+SpinelNCPControlInterface::commissioner_generate_pskc(
+	const char *pass_phrase,
+	const char *network_name,
+	const XPANId &xpanid,
+	CallbackWithStatusArg1 cb
+) {
+	if (!mNCPInstance->mCapabilities.count(SPINEL_CAP_THREAD_COMMISSIONER)) {
+		cb(kWPANTUNDStatus_FeatureNotSupported, "Commissioner feature is not enabled on NCP");
+	} else {
+		mNCPInstance->start_new_task(
+			SpinelNCPTaskSendCommand::Factory(mNCPInstance)
+				.set_callback(cb)
+				.add_command(SpinelPackData(
+					SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(
+						SPINEL_DATATYPE_UTF8_S
+						SPINEL_DATATYPE_UTF8_S
+						SPINEL_DATATYPE_DATA_WLEN_S
+					),
+					SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC,
+					pass_phrase,
+					network_name,
+					xpanid.m8, sizeof(xpanid)
+				))
+				.set_reply_format(SPINEL_DATATYPE_DATA_S)
+				.finish()
+		);
+	}
+}
+
+void
 SpinelNCPControlInterface::handle_permit_join_timeout(Timer *timer, int seconds)
 {
 	syslog(LOG_NOTICE, "PermitJoin: Timeout interval of %d seconds expired", seconds);

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -225,6 +225,13 @@ public:
 		CallbackWithStatus cb = NilReturn()
 	);
 
+	virtual void commissioner_generate_pskc(
+		const char *pass_phrase,
+		const char *network_name,
+		const XPANId &xpanid,
+		CallbackWithStatusArg1 cb = NilReturn()
+	);
+
 	virtual void data_poll(
 		CallbackWithStatus cb = NilReturn()
 	);

--- a/src/wpanctl/commissioner-utils.h
+++ b/src/wpanctl/commissioner-utils.h
@@ -27,6 +27,7 @@
 
 #define COMMR_EUI64_SIZE                    8
 #define COMMR_IPv6_ADDRESS_SIZE             16
+#define COMMR_XPANID_SIZE                   8
 #define COMMR_TLVS_MAX_LEN                  255
 #define COMMR_PSK_MIN_LENGTH                6
 #define COMMR_PSK_MAX_LENGTH                32

--- a/src/wpantund/NCPConstants.h
+++ b/src/wpantund/NCPConstants.h
@@ -29,6 +29,7 @@
 #define NCP_JOINER_TIMEOUT                      60 // seconds
 
 #define NCP_NETWORK_KEY_SIZE                    16
+#define NCP_XPANID_SIZE                         8
 
 #define BUSY_DEBOUNCE_TIME_IN_MS                200
 #define MAX_INSOMNIA_TIME_IN_MS                 (MSEC_PER_SEC * 60 * 3)

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -66,6 +66,11 @@ class NCPInstance;
 class NCPControlInterface {
 public:
 
+	struct XPANId
+	{
+		uint8_t m8[NCP_XPANID_SIZE];
+	};
+
 	typedef uint32_t ChannelMask;
 
 	enum ExternalRoutePriority {
@@ -253,6 +258,13 @@ public:
 		uint32_t channel_mask,
 		const struct in6_addr& dest,
 		CallbackWithStatus cb = NilReturn()
+	) = 0;
+
+	virtual void commissioner_generate_pskc(
+		const char *pass_phrase,
+		const char *network_name,
+		const XPANId &xpanid,
+		CallbackWithStatusArg1 cb = NilReturn()
 	) = 0;
 
 public:

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -737,6 +737,11 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_out,
     // Buffer length sanity check
     require_action(data_len_max <= SPINEL_MAX_PACK_LENGTH, bail, (ret = -1, errno = EINVAL));
 
+    if (data_out == NULL)
+    {
+        data_len_max = 0;
+    }
+
     for (; *pack_format != 0; pack_format = spinel_next_packed_datatype(pack_format))
     {
         if (*pack_format == ')')
@@ -998,7 +1003,10 @@ static spinel_ssize_t spinel_datatype_vpack_(uint8_t *     data_out,
                 data_out += size_len;
                 data_len_max -= (spinel_size_t)size_len;
 
-                memcpy(data_out, arg, data_size_arg);
+                if (data_out && arg)
+                {
+                    memcpy(data_out, arg, data_size_arg);
+                }
 
                 data_out += data_size_arg;
                 data_len_max -= data_size_arg;
@@ -1106,7 +1114,7 @@ spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_out,
 // ----------------------------------------------------------------------------
 // MARK: -
 
-// **** LCOV_EXCL_START ****
+// LCOV_EXCL_START
 
 const char *spinel_command_to_cstr(unsigned int command)
 {
@@ -1491,6 +1499,14 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "MAC_CCA_FAILURE_RATE";
         break;
 
+    case SPINEL_PROP_MAC_MAX_RETRY_NUMBER_DIRECT:
+        ret = "MAC_MAX_RETRY_NUMBER_DIRECT";
+        break;
+
+    case SPINEL_PROP_MAC_MAX_RETRY_NUMBER_INDIRECT:
+        ret = "MAC_MAX_RETRY_NUMBER_INDIRECT";
+        break;
+
     case SPINEL_PROP_NET_SAVED:
         ret = "NET_SAVED";
         break;
@@ -1865,6 +1881,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
 
     case SPINEL_PROP_MESHCOP_COMMISSIONER_MGMT_SET:
         ret = "MESHCOP_COMMISSIONER_MGMT_SET";
+        break;
+
+    case SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC:
+        ret = "MESHCOP_COMMISSIONER_GENERATE_PSKC";
         break;
 
     case SPINEL_PROP_CHANNEL_MANAGER_NEW_CHANNEL:
@@ -2623,7 +2643,7 @@ const char *spinel_capability_to_cstr(unsigned int capability)
     return ret;
 }
 
-// **** LCOV_EXCL_STOP ****
+// LCOV_EXCL_STOP
 
 /* -------------------------------------------------------------------------- */
 

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1631,7 +1631,7 @@ typedef enum
     /// All coex metrics related counters.
     /** Format: t(LLLLLLLL)t(LLLLLLLLL)bL  (Read-only)
      *
-     * Required capability: `SPINEL_CAP_RADIO_COEX`
+     * Required capability: SPINEL_CAP_RADIO_COEX
      *
      * The contents include two structures and two common variables, first structure corresponds to
      * all transmit related coex counters, second structure provides the receive related counters.
@@ -1670,7 +1670,7 @@ typedef enum
     /// Radio Coex Enable
     /** Format: `b`
      *
-     * Required capability: `SPINEL_CAP_RADIO_COEX`
+     * Required capability: SPINEL_CAP_RADIO_COEX
      *
      * Indicates if radio coex is enabled or disabled. Set to true to enable radio coex.
      */
@@ -1926,6 +1926,23 @@ typedef enum
      *
      */
     SPINEL_PROP_MAC_CCA_FAILURE_RATE = SPINEL_PROP_MAC_EXT__BEGIN + 9,
+
+    /// MAC Max direct retry number
+    /** Format: `C`
+     *
+     * The maximum (user-specified) number of direct frame transmission retries.
+     *
+     */
+    SPINEL_PROP_MAC_MAX_RETRY_NUMBER_DIRECT = SPINEL_PROP_MAC_EXT__BEGIN + 10,
+
+    /// MAC Max indirect retry number
+    /** Format: `C`
+     * Required capability: `SPINEL_CAP_CONFIG_FTD`
+     *
+     * The maximum (user-specified) number of indirect frame transmission retries.
+     *
+     */
+    SPINEL_PROP_MAC_MAX_RETRY_NUMBER_INDIRECT = SPINEL_PROP_MAC_EXT__BEGIN + 11,
 
     SPINEL_PROP_MAC_EXT__END = 0x1400,
 
@@ -3190,6 +3207,29 @@ typedef enum
      *
      */
     SPINEL_PROP_MESHCOP_COMMISSIONER_MGMT_SET = SPINEL_PROP_MESHCOP_EXT__BEGIN + 6,
+
+    // Thread Commissioner Generate PSKc
+    /** Format: `UUd` - Write only
+     *
+     * Required capability: SPINEL_CAP_THREAD_COMMISSIONER
+     *
+     * Writing to this property allows user to generate PSKc from a given commissioning pass-phrase, network name,
+     * extended PAN Id.
+     *
+     * Written value format is:
+     *
+     *   `U` : The commissioning pass-phrase.
+     *   `U` : Network Name.
+     *   `d` : Extended PAN ID.
+     *
+     * The response on success would be a `VALUE_IS` command with the PSKc with format below:
+     *
+     *   `D` : The PSKc
+     *
+     * On a failure a `LAST_STATUS` is emitted with the error status.
+     *
+     */
+    SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC = SPINEL_PROP_MESHCOP_EXT__BEGIN + 7,
 
     SPINEL_PROP_MESHCOP_EXT__END = 0x1900,
 


### PR DESCRIPTION
This commit adds support in wpantund and wpanctl to generate PSKc
from a given commissioning pass-phrase, network name and XPANID.
The spinel property `SPINEL_PROP_MESHCOP_COMMISSIONER_GENERATE_PSKC`
is used for this purpose. A new DBUS API (v1) is added to expose
this functionality to other processes. wpanctl `commissioner`
command is updated to provide `gen-pskc`.

----

Related PR in OpenThread: https://github.com/openthread/openthread/pull/4294