### PR TITLE
Listen for MLD report to add/remove multicast groups

### DIFF
--- a/src/wpantund/NCPInstanceBase-Addresses.cpp
+++ b/src/wpantund/NCPInstanceBase-Addresses.cpp
@@ -775,7 +775,6 @@ NCPInstanceBase::multicast_address_was_joined(Origin origin, const struct in6_ad
 		if ((origin == kOriginThreadNCP) || (origin == kOriginUser)) {
 			mPrimaryInterface->join_multicast_address(&address);
 		}
-
 		if (origin == kOriginPrimaryInterface) {
 			add_multicast_address_on_ncp(address,
 				boost::bind(&NCPInstanceBase::check_ncp_entry_update_status, this, _1, "adding multicast address", cb));

--- a/src/wpantund/NCPInstanceBase.cpp
+++ b/src/wpantund/NCPInstanceBase.cpp
@@ -140,8 +140,11 @@ NCPInstanceBase::NCPInstanceBase(const Settings& settings):
 	mSerialAdapter = mRawSerialAdapter;
 
 	mPrimaryInterface = boost::shared_ptr<TunnelIPv6Interface>(new TunnelIPv6Interface(wpan_interface_name));
-	mPrimaryInterface->mAddressWasAdded.connect(boost::bind(&NCPInstanceBase::unicast_address_was_added, this, kOriginPrimaryInterface, _1, _2, UINT32_MAX, UINT32_MAX));
-	mPrimaryInterface->mAddressWasRemoved.connect(boost::bind(&NCPInstanceBase::unicast_address_was_removed, this, kOriginPrimaryInterface, _1));
+	mPrimaryInterface->mUnicastAddressWasAdded.connect(boost::bind(&NCPInstanceBase::unicast_address_was_added, this, kOriginPrimaryInterface, _1, _2, UINT32_MAX, UINT32_MAX));
+	mPrimaryInterface->mUnicastAddressWasRemoved.connect(boost::bind(&NCPInstanceBase::unicast_address_was_removed, this, kOriginPrimaryInterface, _1));
+	mPrimaryInterface->mMulticastAddressWasJoined.connect(boost::bind(&NCPInstanceBase::multicast_address_was_joined, this, kOriginPrimaryInterface, _1, NilReturn()));
+	mPrimaryInterface->mMulticastAddressWasLeft.connect(boost::bind(&NCPInstanceBase::multicast_address_was_left, this, kOriginPrimaryInterface, _1, NilReturn()));
+
 	mPrimaryInterface->mLinkStateChanged.connect(boost::bind(&NCPInstanceBase::link_state_changed, this, _1, _2));
 
 	set_ncp_power(true);


### PR DESCRIPTION
Currently using IP6_JOIN_GROUP to listen on multicast addresses won't
notify wpantund. This patch listens for a MLD report and updates the
multicast group to the NCP.

Test script:

``` python
#!/usr/bin/env python3

import socket
import struct
import sys

s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)

s.bind(('ff02::158', 30000))
s.setsockopt(socket.IPPROTO_IPV6,       socket.IPV6_MULTICAST_IF, int(sys.argv[1]))
s.setsockopt(socket.IPPROTO_IPV6,       socket.IPV6_JOIN_GROUP, 
    struct.pack('16si', socket.inet_pton(socket.AF_INET6, 'ff02::158'), int(sys.argv[1])))

while True:
  print(s.recvfrom(4096))
```

Run wpantund and run the script with the first argument as the wpan0 interface index.
You can see the multicast group added to and removed from the NCP when the script starts/exits.