### PR TITLE
Relax parsing of set value on "Dataset:Active/PendingTimestamp"

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskForm.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskForm.cpp
@@ -69,7 +69,7 @@ nl::wpantund::SpinelNCPTaskForm::SpinelNCPTaskForm(
 		union {
 			uint64_t xpanid;
 			uint8_t bytes[1];
-		} x = { any_to_uint64((mOptions[kWPANTUNDProperty_NetworkXPANID])) };
+		} x = { any_to_uint64(mOptions[kWPANTUNDProperty_NetworkXPANID], /* expect_hex_str */ true) };
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 		reverse_bytes(x.bytes, sizeof(x.xpanid));
@@ -257,7 +257,7 @@ nl::wpantund::SpinelNCPTaskForm::vprocess_event(int event, va_list args)
 
 	if (mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
 		{
-			uint64_t xpanid(any_to_uint64((mOptions[kWPANTUNDProperty_NetworkXPANID])));
+			uint64_t xpanid(any_to_uint64(mOptions[kWPANTUNDProperty_NetworkXPANID], /* expect_hex_str */ true));
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			reverse_bytes(reinterpret_cast<uint8_t*>(&xpanid), sizeof(xpanid));

--- a/src/ncp-spinel/SpinelNCPTaskJoin.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskJoin.cpp
@@ -225,7 +225,7 @@ nl::wpantund::SpinelNCPTaskJoin::vprocess_event(int event, va_list args)
 
 	if (mOptions.count(kWPANTUNDProperty_NetworkXPANID)) {
 		{
-			uint64_t xpanid(any_to_uint64((mOptions[kWPANTUNDProperty_NetworkXPANID])));
+			uint64_t xpanid(any_to_uint64(mOptions[kWPANTUNDProperty_NetworkXPANID], /* expect_hex_str */ true));
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			reverse_bytes(reinterpret_cast<uint8_t*>(&xpanid), sizeof(xpanid));

--- a/src/util/any-to.cpp
+++ b/src/util/any-to.cpp
@@ -134,18 +134,19 @@ any_to_ipv6(const boost::any& value)
 }
 
 uint64_t
-any_to_uint64(const boost::any& value)
+any_to_uint64(const boost::any& value, bool expect_hex_str)
 {
 	uint64_t ret(0);
 
 	if (value.type() == typeid(std::string)) {
 		const std::string& key_string = boost::any_cast<std::string>(value);
 
-		if (key_string.size() != 16) {
+		if (expect_hex_str && key_string.size() != 16) {
 			throw std::invalid_argument("String not 16 characters long");
 		}
 
-		ret = static_cast<uint64_t>(strtoull(key_string.c_str(), NULL, 16));
+		// If `expect_hex_str` is set, we expect the string to be 16 hex chars.
+		ret = static_cast<uint64_t>(strtoull(key_string.c_str(), NULL, expect_hex_str ? 16 : 0));
 
 	} else if (value.type() == typeid(nl::Data)) {
 		const nl::Data& data = boost::any_cast<nl::Data>(value);

--- a/src/util/any-to.h
+++ b/src/util/any-to.h
@@ -31,7 +31,7 @@
 
 extern nl::Data any_to_data(const boost::any& value);
 extern int any_to_int(const boost::any& value);
-extern uint64_t any_to_uint64(const boost::any& value);
+extern uint64_t any_to_uint64(const boost::any& value, bool expect_hex_str = false);
 extern struct in6_addr any_to_ipv6(const boost::any& value);
 extern bool any_to_bool(const boost::any& value);
 extern std::string any_to_string(const boost::any& value);


### PR DESCRIPTION
This commit updates `any_to_uint64()` to allow a string representing
to be optionally treated as a number (decimal number or hex value
starting with `0x`). This change relaxes the input format when setting
`"Dataset:Active/PendingTimestamp"` properties, while keeping the parsing
of XPANID as before (expecting it to be a 16 char hex value).

-------------

Here is the new code in action:
```
wpanctl:wpan1> set Dataset:ActiveTimestamp 7
wpanctl:wpan1> get Dataset:ActiveTimestamp 
Dataset:ActiveTimestamp = 0x0000000000000007

wpanctl:wpan1> set Dataset:PendingTimestamp 0x1234567
wpanctl:wpan1> get Dataset:PendingTimestamp
Dataset:PendingTimestamp = 0x0000000001234567

# When using `-d` as data format, we expect 8 byes (hex string)
wpanctl:wpan1> set Dataset:PendingTimestamp -d 1122334455667788
Dataset:PendingTimestamp = 0x1122334455667788

# Keeping xpanid same as before (to ensure compatibility with test scripts using this format)
wpanctl:wpan1> set XPANID 10
set failed with error 15335433. NCP-Specific Errorcode
Error 15335433 (0xEA0009)

wpanctl:wpan1> set XPANID 8877665544332211
wpanctl:wpan1> get XPANID
XPANID = 0x8877665544332211

wpanctl:wpan1> form "test" -c 12 -x 0123456789abcdef
Forming WPAN "test" as node type "router", channel:12, xpanid:0x0123456789ABCDEF

```