### PR TITLE
Revert "[misc] Use /dev/net/tun with non-root access in Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -38,6 +38,7 @@ LOCAL_C_INCLUDES                                         := \
 LOCAL_DEFAULT_VERSION := $(shell cat $(LOCAL_PATH)/.default-version)
 LOCAL_PRIVATE_SOURCE_VERSION := $(shell git -C $(LOCAL_PATH) describe --always --match "[0-9].*" 2> /dev/null)
 LOCAL_CFLAGS := \
+	-DTUNNEL_TUNTAP_DEVICE=\"/dev/tun\" \
 	-D_GNU_SOURCE \
 	-D_XOPEN_SOURCE \
 	-D_POSIX_C_SOURCE \


### PR DESCRIPTION
Some platform doesn't export /dev/net/tun

This reverts commit 5f7a39d4220ec8f48287646f61716eb71dff3a56.