### PR TITLE
Relax the "discover scan" check for bringing NCP interface up

### DIFF
--- a/src/ncp-spinel/SpinelNCPTaskScan.cpp
+++ b/src/ncp-spinel/SpinelNCPTaskScan.cpp
@@ -142,7 +142,7 @@ nl::wpantund::SpinelNCPTaskScan::vprocess_event(int event, va_list args)
 		require_noerr(ret, on_error);
 
 		// For discovery scan, interface should be up
-		if (mInstance->get_ncp_state() == OFFLINE) {
+		if (!ncp_state_is_interface_up(mInstance->get_ncp_state())) {
 			mNextCommand = SpinelPackData(
 				SPINEL_FRAME_PACK_CMD_PROP_VALUE_SET(SPINEL_DATATYPE_BOOL_S),
 				SPINEL_PROP_NET_IF_UP,


### PR DESCRIPTION
This commit relaxes the NCP state check in `TaskScan` (when performing
a discover scan) to allow discover scan to be performed in any offline
state (in particular "offline:commissioned").