### PR TITLE
Handle timestamp log metadata received from NCP

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -232,7 +232,7 @@ SpinelNCPInstance::handle_ncp_log_stream(const uint8_t *data_in, int data_len)
 		data_in += len;
 		data_len -= len;
 
-		if(data_len >= sizeof(log_timestamp)) {
+		if (data_len >= sizeof(log_timestamp)) {
 			len = spinel_datatype_unpack(
 				data_in,
 				data_len,
@@ -2077,6 +2077,9 @@ SpinelNCPInstance::regsiter_all_get_handlers(void)
 	register_get_handler_spinel_simple(
 		kWPANTUNDProperty_OpenThreadLogLevel,
 		SPINEL_PROP_DEBUG_NCP_LOG_LEVEL, SPINEL_DATATYPE_UINT8_S);
+	register_get_handler_spinel_simple(
+		kWPANTUNDProperty_OpenThreadLogTimestampBase,
+		SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE, SPINEL_DATATYPE_UINT64_S);
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	// Properties requiring capability check and associated with a spinel property

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -215,24 +215,49 @@ SpinelNCPInstance::handle_ncp_log_stream(const uint8_t *data_in, int data_len)
 	if ((data_len > 0) && mCapabilities.count(SPINEL_CAP_OPENTHREAD_LOG_METADATA)) {
 		uint8_t log_level;
 		unsigned int log_region;
+		uint64_t log_timestamp;
 
 		len = spinel_datatype_unpack(
 			data_in,
 			data_len,
-			SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT_PACKED_S,
+			( 
+				SPINEL_DATATYPE_UINT8_S 
+				SPINEL_DATATYPE_UINT_PACKED_S
+			),
 			&log_level,
 			&log_region
 		);
-
 		require(len >= 0, bail);
 
-		snprintf(
+		data_in += len;
+		data_len -= len;
+
+		if(data_len >= sizeof(log_timestamp)) {
+			len = spinel_datatype_unpack(
+				data_in,
+				data_len,
+				SPINEL_DATATYPE_UINT64_S,
+				&log_timestamp
+			);
+			require(len >= 0, bail);
+		
+			snprintf(
+				prefix_string,
+				sizeof(prefix_string),
+				"[%013llu][%s]%s: ",
+				static_cast<unsigned long long>(log_timestamp),
+				ot_log_level_to_string(log_level),
+				ot_log_region_to_string(log_region)
+			);
+		} else {
+			snprintf(
 			prefix_string,
 			sizeof(prefix_string),
 			"[%s]%s: ",
 			ot_log_level_to_string(log_level),
 			ot_log_region_to_string(log_region)
 		);
+		}
 	}
 
 	syslog(LOG_WARNING, "NCP => %s%s\n", prefix_string, log_string);
@@ -572,6 +597,10 @@ SpinelNCPInstance::get_supported_property_keys()const
 	if (mCapabilities.count(SPINEL_CAP_RADIO_COEX)) {
 		properties.insert(kWPANTUNDProperty_NCPCoexEnable);
 		properties.insert(kWPANTUNDProperty_NCPCoexMetrics);
+	}
+
+	if (mCapabilities.count(SPINEL_CAP_OPENTHREAD_LOG_METADATA)) {
+		properties.insert(kWPANTUNDProperty_OpenThreadLogTimestampBase);
 	}
 
 	{
@@ -3298,7 +3327,11 @@ SpinelNCPInstance::regsiter_all_set_handlers(void)
 		kWPANTUNDProperty_TimeSync_XtalThreshold,
 		SPINEL_CAP_TIME_SYNC,
 		SPINEL_PROP_TIME_SYNC_XTAL_THRESHOLD, SPINEL_DATATYPE_UINT16_C);
-
+	register_set_handler_capability_spinel(
+		kWPANTUNDProperty_OpenThreadLogTimestampBase,
+		SPINEL_CAP_OPENTHREAD_LOG_METADATA,
+		SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE, SPINEL_DATATYPE_UINT64_C);
+	
 	// Properties with a `ValueConverter`
 	register_set_handler_capability_spinel(
 		kWPANTUNDProperty_CommissionerState,

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -251,12 +251,12 @@ SpinelNCPInstance::handle_ncp_log_stream(const uint8_t *data_in, int data_len)
 			);
 		} else {
 			snprintf(
-			prefix_string,
-			sizeof(prefix_string),
-			"[%s]%s: ",
-			ot_log_level_to_string(log_level),
-			ot_log_region_to_string(log_region)
-		);
+				prefix_string,
+				sizeof(prefix_string),
+				"[%s]%s: ",
+				ot_log_level_to_string(log_level),
+				ot_log_region_to_string(log_region)
+			);
 		}
 	}
 

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -174,6 +174,7 @@
 #define kWPANTUNDProperty_POSIXAppRCPVersionCached              "POSIXApp:RCPVersion:Cached"
 
 #define kWPANTUNDProperty_OpenThreadLogLevel                    "OpenThread:LogLevel"
+#define kWPANTUNDProperty_OpenThreadLogTimestampBase            "OpenThread:LogTimestampBase"
 #define kWPANTUNDProperty_OpenThreadSLAACEnabled                "OpenThread:SLAAC:Enabled"
 #define kWPANTUNDProperty_OpenThreadSteeringDataAddress         "OpenThread:SteeringData:Address"
 #define kWPANTUNDProperty_OpenThreadSteeringDataSetWhenJoinable "OpenThread:SteeringData:SetWhenJoinable"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -2202,7 +2202,11 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
     case SPINEL_PROP_DEBUG_TEST_WATCHDOG:
         ret = "DEBUG_TEST_WATCHDOG";
         break;
-
+    
+    case SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE:
+        ret = "DEBUG_LOG_TIMESTAMP_BASE";
+        break;
+        
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -3896,6 +3896,14 @@ typedef enum
      */
     SPINEL_PROP_DEBUG_TEST_WATCHDOG = SPINEL_PROP_DEBUG__BEGIN + 2,
 
+    /// The NCP timestamp base
+    /** Format: X (write-only) 
+     * 
+     * This property controls the time base value that is used for log timestamp field calulation.
+     * 
+    */
+    SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE = SPINEL_PROP_DEBUG__BEGIN + 3,
+
     SPINEL_PROP_DEBUG__END = 0x4400,
 
     SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -3899,7 +3899,7 @@ typedef enum
     /// The NCP timestamp base
     /** Format: X (write-only) 
      * 
-     * This property controls the time base value that is used for log timestamp field calulation.
+     * This property controls the time base value that is used for log timestamp field calculation.
      * 
     */
     SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE = SPINEL_PROP_DEBUG__BEGIN + 3,


### PR DESCRIPTION
* Handle timestamp field in log metadata introduced by:
https://github.com/openthread/openthread/pull/4439

* Add new property "OpenThread:LogTimestampBase" that can be used to change the NCP log base timestamp

This change does not break the compatibility: older wpantund will work with newer OpenThread and newer wpantund will work with older OpenThread.