### PR TITLE
[util] include missing strlcpy header

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -119,6 +119,7 @@ LOCAL_SRC_FILES := \
 	src/util/ValueMap.cpp \
 	src/util/Timer.cpp \
 	src/util/sec-random.c \
+	src/missing/strlcpy/strlcpy.c \
 	$(NCP_SPINEL_SRC_FILES:$(LOCAL_PATH)/%=%) \
 	third_party/openthread/src/ncp/spinel.c \
 	$(NULL)

--- a/src/util/netif-mgmt.c
+++ b/src/util/netif-mgmt.c
@@ -69,6 +69,8 @@
 #define IFEF_NOAUTOIPV6LL   0x2000  /* Interface IPv6 LinkLocal address not provided by kernel */
 #endif
 
+#include "missing/strlcpy/strlcpy.h"
+
 #ifndef SIOCSIFLLADDR
 #define SIOCSIFLLADDR SIOCSIFHWADDR
 #endif


### PR DESCRIPTION
Always use the missing strlcpy header in case strlcpy is not provided
in the system library. This header will define strlcpy as a macro which
points to __missing_strlcpy.