### PR TITLE
Fix possible dereference of begin() iterator when std::vector is empty

### DIFF
--- a/src/util/Data.h
+++ b/src/util/Data.h
@@ -59,11 +59,11 @@ public:
 	}
 
 	uint8_t* data() {
-		return &*begin();
+		return empty() ? NULL : &*begin();
 	}
 
 	const uint8_t* data() const {
-		return &*begin();
+		return empty() ? NULL : &*begin();
 	}
 };
 };


### PR DESCRIPTION
---
If `std::vector` happens to be empty, we protect against  dereference of `begin()` iterator.
http://www.cplusplus.com/reference/vector/vector/begin/