### PR TITLE
Update address cache table property

### DIFF
--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -392,6 +392,15 @@
 
 // ----------------------------------------------------------------------------
 
+// Address cache table entry states from kWPANTUNDProperty_ThreadAddressCacheTable
+
+#define kWPANTUNDCacheTableEntryState_Cached                    "cached"
+#define kWPANTUNDCacheTableEntryState_Snooped                   "snooped"
+#define kWPANTUNDCacheTableEntryState_Query                     "query"
+#define kWPANTUNDCacheTableEntryState_RetryQuery                "retry-query"
+
+// ----------------------------------------------------------------------------
+
 // Values of  the property kWPANTUNDProperty_StatAutoLogState
 #define kWPANTUNDStatAutoLogState_Disabled                      "disabled"
 #define kWPANTUNDStatAutoLogState_Long                          "long"
@@ -410,6 +419,12 @@
 #define kWPANTUNDValueMapKey_AddressCacheTable_Address          "Address"
 #define kWPANTUNDValueMapKey_AddressCacheTable_RLOC16           "RLOC16"
 #define kWPANTUNDValueMapKey_AddressCacheTable_Age              "Age"
+#define kWPANTUNDValueMapKey_AddressCacheTable_State            "State"
+#define kWPANTUNDValueMapKey_AddressCacheTable_LastTrans        "LastTrans"
+#define kWPANTUNDValueMapKey_AddressCacheTable_MeshLocalEID     "MeshLocal-EID"
+#define kWPANTUNDValueMapKey_AddressCacheTable_CanEvict         "CanEvict"
+#define kWPANTUNDValueMapKey_AddressCacheTable_Timeout          "Timeout"
+#define kWPANTUNDValueMapKey_AddressCacheTable_RetryDelay       "RetryDelay"
 
 #define kWPANTUNDValueMapKey_CommrEnergyScanResult_ChannelMask  "ChannelMask"
 #define kWPANTUNDValueMapKey_CommrEnergyScanResult_Data         "Data"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -84,6 +84,22 @@
 #define ENOMEM 1
 #endif
 
+#ifndef SPINEL_PLATFORM_SHOULD_LOG_ASSERTS
+#define SPINEL_PLATFORM_SHOULD_LOG_ASSERTS 0
+#endif
+
+#ifndef SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
+#define SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR 0
+#endif
+
+#ifndef SPINEL_PLATFORM_DOESNT_IMPLEMENT_FPRINTF
+#define SPINEL_PLATFORM_DOESNT_IMPLEMENT_FPRINTF 0
+#endif
+
+#ifndef SPINEL_SELF_TEST
+#define SPINEL_SELF_TEST 0
+#endif
+
 #if defined(errno) && SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
 #error "SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR is set but errno is already defined."
 #endif
@@ -129,6 +145,22 @@ static int spinel_errno_workaround_;
 
 #ifndef require
 #define require(c, l) require_action(c, l, {})
+#endif
+
+#ifndef strnlen
+static size_t spinel_strnlen(const char *s, size_t maxlen)
+{
+    size_t ret;
+
+    for (ret = 0; (ret < maxlen) && (s[ret] != 0); ret++)
+    {
+        // Empty loop.
+    }
+
+    return ret;
+}
+#else
+#define spinel_strnlen strnlen
 #endif
 
 typedef struct
@@ -522,7 +554,7 @@ static spinel_ssize_t spinel_datatype_vunpack_(bool           in_place,
             // Add 1 for zero termination. If not zero terminated,
             // len will then be data_len+1, which we will detect
             // in the next check.
-            len = strnlen((const char *)data_in, data_len) + 1;
+            len = spinel_strnlen((const char *)data_in, data_len) + 1;
 
             // Verify that the string is zero terminated.
             require_action(len <= data_len, bail, (ret = -1, errno = EOVERFLOW));
@@ -2210,11 +2242,7 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
     case SPINEL_PROP_DEBUG_TEST_WATCHDOG:
         ret = "DEBUG_TEST_WATCHDOG";
         break;
-    
-    case SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE:
-        ret = "DEBUG_LOG_TIMESTAMP_BASE";
-        break;
-        
+
     default:
         break;
     }

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -630,6 +630,14 @@ enum
     SPINEL_MESHCOP_COMMISSIONER_STATE_ACTIVE   = 2,
 };
 
+enum
+{
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED      = 0, // Entry is cached and in-use.
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_SNOOPED     = 1, // Entry is created by snoop optimization
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_QUERY       = 2, // Entry represents an ongoing query for the EID.
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_RETRY_QUERY = 3, // Entry is in retry mode (a prior query did not  a response).
+};
+
 typedef struct
 {
     uint8_t bytes[8];
@@ -2646,7 +2654,7 @@ enum
     SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
 
     /// EID (Endpoint Identifier) IPv6 Address Cache Table
-    /** Format `A(t(6SC))`
+    /** Format `A(t(6SCCt(bL6)t(bSS)))
      *
      * This property provides Thread EID address cache table.
      *
@@ -2655,6 +2663,17 @@ enum
      *  `6` : Target IPv6 address
      *  `S` : RLOC16 of target
      *  `C` : Age (order of use, 0 indicates most recently used entry)
+     *  `C` : Entry state (values are defined by enumeration `SPINEL_ADDRESS_CACHE_ENTRY_STATE_*`).
+     *
+     *  `t` : Info when state is `SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED`
+     *    `b` : Indicates whether last transaction time and ML-EID are valid.
+     *    `L` : Last transaction time
+     *    `6` : Mesh-local EID
+     *
+     *  `t` : Info when state is other than `SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED`
+     *    `b` : Indicates whether the entry can be evicted.
+     *    `S` : Timeout in seconds
+     *    `S` : Retry delay (applicable if in query-retry state).
      *
      */
     SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 35,
@@ -2991,6 +3010,7 @@ enum
      *         `SPINEL_NCP_LOG_LEVEL_<level>`)
      *    `i`: OpenThread Log region (as per definition in enumeration
      *         `SPINEL_NCP_LOG_REGION_<region>).
+     *    `X`: Log timestamp = <timestamp_base> + <current_time_ms>
      *
      */
     SPINEL_PROP_STREAM_LOG = SPINEL_PROP_STREAM__BEGIN + 4,
@@ -3933,11 +3953,11 @@ enum
     SPINEL_PROP_DEBUG_TEST_WATCHDOG = SPINEL_PROP_DEBUG__BEGIN + 2,
 
     /// The NCP timestamp base
-    /** Format: X (write-only) 
-     * 
-     * This property controls the time base value that is used for log timestamp field calculation.
-     * 
-    */
+    /** Format: X (write-only)
+     *
+     * This property controls the time base value that is used for logs timestamp field calulation.
+     *
+     */
     SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE = SPINEL_PROP_DEBUG__BEGIN + 3,
 
     SPINEL_PROP_DEBUG__END = 0x4400,


### PR DESCRIPTION
This commit updates the cache table property to include additional
info (now available from NCP) about entries in different states.

---
This PR is related to PRs https://github.com/openthread/openthread/pull/4599 and https://github.com/openthread/openthread/pull/4600. The `toranj` travis tests are expected to fail  and we'd need https://github.com/openthread/openthread/pull/4599 to be merged before this PR.

----
Example of getting cache table with all different types of addresses:
```
[
	"fd00:1234::c2:3 -> 0x9c01, Age:0, State:cached, LastTrans:0, ML-EID:fd55:4ce:557:0:262a:543:3e60:cc2d"
	"fd00:1234::c2:2 -> 0x9c01, Age:1, State:cached, LastTrans:0, ML-EID:fd55:4ce:557:0:262a:543:3e60:cc2d"
	"fd00:1234::c2:1 -> 0x9c01, Age:2, State:cached"
	"fd00:1234::c2:0 -> 0x9c01, Age:3, State:cached"
	"fd00:1234::2:3 -> 0x9c00, Age:4, State:cached"
	"fd00:1234::2:2 -> 0x9c00, Age:5, State:cached"
	"fd00:1234::2:1 -> 0x9c00, Age:6, State:cached"
	"fd00:1234::2:0 -> 0x9c00, Age:7, State:cached"
	"fd00:1234::c3:3 -> 0x5c00, Age:8, State:cached, LastTrans:15, ML-EID:fd55:4ce:557:0:9000:14e0:7671:3540"
	"fd00:1234::c3:2 -> 0x5c00, Age:9, State:cached, LastTrans:12, ML-EID:fd55:4ce:557:0:9000:14e0:7671:3540"
	"fd00:1234::c3:1 -> 0x5c00, Age:10, State:cached, LastTrans:13, ML-EID:fd55:4ce:557:0:9000:14e0:7671:3540"
	"fd00:1234::900:4 -> 0xfffe, Age:11, State:query, CanEvict:no, Timeout:3, RetryDelay:4"
	"fd00:1234::900:3 -> 0xfffe, Age:12, State:query, CanEvict:no, Timeout:3, RetryDelay:4"
	"fd00:1234::900:2 -> 0xfffe, Age:13, State:query, CanEvict:no, Timeout:3, RetryDelay:4"
	"fd00:1234::900:1 -> 0xfffe, Age:14, State:query, CanEvict:no, Timeout:3, RetryDelay:4"
	"fd00:1234::900:0 -> 0xfffe, Age:15, State:query, CanEvict:no, Timeout:3, RetryDelay:4"
]
```