### PR TITLE
Fix parsing of energy scan response spinel frame

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -5527,7 +5527,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const
 		spinel_ssize_t len;
 		uint32_t channel_mask;
 		const uint8_t *energy_data = NULL;
-		uint16_t energy_data_len = 0;
+		unsigned int energy_data_len = 0;
 		ValueMap entry;
 
 		len = spinel_datatype_unpack(


### PR DESCRIPTION
This commit fixes the parsing of energy scan response spinel frame by
ensuring to use `unsigned int` as the type of length variable when
unpacking as an spinel data type of  `DATATYPE_DATA_WLEN`.