### PR TITLE
Add support for Discerner for Joiner/Commissioner

### DIFF
--- a/src/ncp-dummy/DummyNCPControlInterface.cpp
+++ b/src/ncp-dummy/DummyNCPControlInterface.cpp
@@ -212,7 +212,7 @@ DummyNCPControlInterface::joiner_commissioning(
 
 void
 DummyNCPControlInterface::commissioner_add_joiner(
-	const uint8_t *eui64,
+	const JoinerInfo &joiner,
 	uint32_t timeout,
 	const char *psk,
 	CallbackWithStatus cb
@@ -222,7 +222,7 @@ DummyNCPControlInterface::commissioner_add_joiner(
 
 void
 DummyNCPControlInterface::commissioner_remove_joiner(
-	const uint8_t *eui64,
+	const JoinerInfo &joiner,
 	uint32_t timeout,
 	CallbackWithStatus cb
 ) {

--- a/src/ncp-dummy/DummyNCPControlInterface.h
+++ b/src/ncp-dummy/DummyNCPControlInterface.h
@@ -187,14 +187,14 @@ public:
 	);
 
 	virtual void commissioner_add_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		const char *psk,
 		CallbackWithStatus cb = NilReturn()
 	);
 
 	virtual void commissioner_remove_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		CallbackWithStatus cb = NilReturn()
 	);

--- a/src/ncp-spinel/SpinelNCPControlInterface.cpp
+++ b/src/ncp-spinel/SpinelNCPControlInterface.cpp
@@ -407,7 +407,7 @@ bail:
 
 void
 SpinelNCPControlInterface::commissioner_add_joiner(
-	const uint8_t *eui64,
+	const JoinerInfo &joiner,
 	uint32_t timeout,
 	const char *psk,
 	CallbackWithStatus cb
@@ -420,19 +420,9 @@ SpinelNCPControlInterface::commissioner_add_joiner(
 	} else {
 		Data command;
 
-		if (eui64 != NULL) {
-			command = SpinelPackData(
-				SPINEL_FRAME_PACK_CMD_PROP_VALUE_INSERT(
-					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_EUI64_S)
-					SPINEL_DATATYPE_UINT32_S
-					SPINEL_DATATYPE_UTF8_S
-				),
-				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
-				eui64,
-				timeout,
-				psk
-			);
-		} else {
+		switch (joiner.mType)
+		{
+		case JoinerInfo::kAny:
 			command = SpinelPackData(
 				SPINEL_FRAME_PACK_CMD_PROP_VALUE_INSERT(
 					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_NULL_S)
@@ -443,6 +433,39 @@ SpinelNCPControlInterface::commissioner_add_joiner(
 				timeout,
 				psk
 			);
+			break;
+
+		case JoinerInfo::kEui64:
+			command = SpinelPackData(
+				SPINEL_FRAME_PACK_CMD_PROP_VALUE_INSERT(
+					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_EUI64_S)
+					SPINEL_DATATYPE_UINT32_S
+					SPINEL_DATATYPE_UTF8_S
+				),
+				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
+				&joiner.mEui64,
+				timeout,
+				psk
+			);
+			break;
+
+		case JoinerInfo::kDiscerner:
+			command = SpinelPackData(
+				SPINEL_FRAME_PACK_CMD_PROP_VALUE_INSERT(
+					SPINEL_DATATYPE_STRUCT_S(
+						SPINEL_DATATYPE_UINT8_S
+						SPINEL_DATATYPE_UINT64_S
+					)
+					SPINEL_DATATYPE_UINT32_S
+					SPINEL_DATATYPE_UTF8_S
+				),
+				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
+				joiner.mDiscerner.mBitLength,
+				joiner.mDiscerner.mValue,
+				timeout,
+				psk
+			);
+			break;
 		}
 
 		mNCPInstance->start_new_task(
@@ -459,7 +482,7 @@ bail:
 
 void
 SpinelNCPControlInterface::commissioner_remove_joiner(
-	const uint8_t *eui64,
+	const JoinerInfo &joiner,
 	uint32_t timeout,
 	CallbackWithStatus cb
 ) {
@@ -470,17 +493,9 @@ SpinelNCPControlInterface::commissioner_remove_joiner(
 	} else {
 		Data command;
 
-		if (eui64 != NULL) {
-			command = SpinelPackData(
-				SPINEL_FRAME_PACK_CMD_PROP_VALUE_REMOVE(
-					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_EUI64_S)
-					SPINEL_DATATYPE_UINT32_S
-				),
-				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
-				eui64,
-				timeout
-			);
-		} else {
+		switch (joiner.mType)
+		{
+		case JoinerInfo::kAny:
 			command = SpinelPackData(
 				SPINEL_FRAME_PACK_CMD_PROP_VALUE_REMOVE(
 					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_NULL_S)
@@ -489,6 +504,35 @@ SpinelNCPControlInterface::commissioner_remove_joiner(
 				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
 				timeout
 			);
+			break;
+
+		case JoinerInfo::kEui64:
+			command = SpinelPackData(
+				SPINEL_FRAME_PACK_CMD_PROP_VALUE_REMOVE(
+					SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_EUI64_S)
+					SPINEL_DATATYPE_UINT32_S
+				),
+				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
+				&joiner.mEui64,
+				timeout
+			);
+			break;
+
+		case JoinerInfo::kDiscerner:
+			command = SpinelPackData(
+				SPINEL_FRAME_PACK_CMD_PROP_VALUE_REMOVE(
+					SPINEL_DATATYPE_STRUCT_S(
+						SPINEL_DATATYPE_UINT8_S
+						SPINEL_DATATYPE_UINT64_S
+					)
+					SPINEL_DATATYPE_UINT32_S
+				),
+				SPINEL_PROP_MESHCOP_COMMISSIONER_JOINERS,
+				joiner.mDiscerner.mBitLength,
+				joiner.mDiscerner.mValue,
+				timeout
+			);
+			break;
 		}
 
 		mNCPInstance->start_new_task(

--- a/src/ncp-spinel/SpinelNCPControlInterface.h
+++ b/src/ncp-spinel/SpinelNCPControlInterface.h
@@ -189,14 +189,14 @@ public:
 	);
 
 	virtual void commissioner_add_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		const char *psk,
 		CallbackWithStatus cb = NilReturn()
 	);
 
 	virtual void commissioner_remove_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		CallbackWithStatus cb = NilReturn()
 	);

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -236,6 +236,7 @@ private:
 	void get_prop_ThreadRouterID(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadConfigFilterRLOCAddresses(CallbackWithStatusArg1 cb);
 	void get_prop_ThreadConfigFilterALOCAddresses(CallbackWithStatusArg1 cb);
+	void get_prop_JoinerDiscernerBitLength(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerEnergyScanResult(CallbackWithStatusArg1 cb);
 	void get_prop_CommissionerPanIdConflictResult(CallbackWithStatusArg1 cb);
 	void get_prop_IPv6MeshLocalPrefix(CallbackWithStatusArg1 cb);
@@ -331,6 +332,8 @@ private:
 	void set_prop_DatasetCommand(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_DaemonTickleOnHostDidWake(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_MACFilterFixedRssi(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_JoinerDiscernerBitLength(const boost::any &value, CallbackWithStatus cb);
+	void set_prop_JoinerDiscernerValue(const boost::any &value, CallbackWithStatus cb);
 
 private:
 	void check_capability_prop_update(const boost::any &value, CallbackWithStatus cb, const std::string &prop_name,
@@ -470,6 +473,7 @@ private:
 	uint8_t mChannelManagerNewChannel;
 	int8_t mMacFilterFixedRssi;
 
+	uint8_t mJoinerDiscernerBitLength;
 	std::list<ValueMap> mCommissionerEnergyScanResult;
 	std::list<ValueMap> mCommissionerPanIdConflictResult;
 

--- a/src/wpanctl/tool-cmd-commr.c
+++ b/src/wpanctl/tool-cmd-commr.c
@@ -484,7 +484,7 @@ tool_cmd_commr(int argc, char* argv[])
 		uint8_t discerner_bit_len = 0;
 		uint32_t joiner_timeout = 0;
 
-		// joiner-remove-with-discerner <discerner value> <discerner bit length> [<timeout>=0]
+		// joiner-remove-discerner <discerner value> <discerner bit length> [<timeout>=0]
 
 		memset(&eui64, 0, sizeof(eui64));
 

--- a/src/wpanctl/tool-cmd-commr.c
+++ b/src/wpanctl/tool-cmd-commr.c
@@ -385,7 +385,7 @@ tool_cmd_commr(int argc, char* argv[])
 		uint32_t joiner_timeout;
 		const char *psk;
 
-		// joiner-add-with-discerner <discerner value> <discerner bit length> <timeout> <psk>
+		// joiner-add-discerner <discerner value> <discerner bit length> <timeout> <psk>
 
 		memset(&eui64, 0, sizeof(eui64));
 

--- a/src/wpanctl/tool-cmd-commr.c
+++ b/src/wpanctl/tool-cmd-commr.c
@@ -22,6 +22,7 @@
 #endif
 
 #include <getopt.h>
+#include <inttypes.h>
 #include "wpanctl-utils.h"
 #include "tool-cmd-commr.h"
 #include "args.h"
@@ -38,7 +39,9 @@ enum {
 	COMMR_CMD_START,
 	COMMR_CMD_STOP,
 	COMMR_CMD_JOINER_ADD,
+	COMMR_CMD_JOINER_ADD_WITH_DISCERNER,
 	COMMR_CMD_JOINER_REMOVE,
+	COMMR_CMD_JOINER_REMOVE_WITH_DISCERNER,
 	COMMR_CMD_ANNOUNCE_BEGIN,
 	COMMR_CMD_ENERGY_SCAN,
 	COMMR_CMD_PAN_ID_QUERY,
@@ -83,10 +86,22 @@ static const struct commr_command_entry_t
 		"Add joiner, use * as <eui64> for any, <timeout> in sec"
 	},
 	{
+		COMMR_CMD_JOINER_ADD_WITH_DISCERNER,
+		"joiner-add-discerner", "add-discerner",
+		4, 4, " <value> <bit-len> <timeout> <psk>",
+		"Add joiner with a given discerner value/bit-len, <timeout> in sec"
+	},
+	{
 		COMMR_CMD_JOINER_REMOVE,
 		"joiner-remove", "remove",
 		1, 2, " <eui64> [<timeout>=0]",
 		"Remove joiner, use * as <eui64> for any, <timeout> in sec"
+	},
+	{
+		COMMR_CMD_JOINER_REMOVE_WITH_DISCERNER,
+		"joiner-remove-discerner", "remove-discerner",
+		2, 3, " <value> <bit-len> [<timeout>=0]",
+		"Remove joiner with a given discerner value/bit-len, <timeout> in sec"
 	},
 	{
 		COMMR_CMD_ANNOUNCE_BEGIN,
@@ -361,6 +376,52 @@ tool_cmd_commr(int argc, char* argv[])
 		break;
 	}
 
+	case COMMR_CMD_JOINER_ADD_WITH_DISCERNER:
+	{
+		uint8_t eui64[COMMR_EUI64_SIZE];
+		uint8_t *eui64_ptr = eui64;
+		uint64_t discerner_value = 0;
+		uint8_t discerner_bit_len = 0;
+		uint32_t joiner_timeout;
+		const char *psk;
+
+		// joiner-add-with-discerner <discerner value> <discerner bit length> <timeout> <psk>
+
+		memset(&eui64, 0, sizeof(eui64));
+
+		discerner_value = (uint64_t)strtoll(argv[optind], NULL, 0);
+		discerner_bit_len = (uint8_t)strtol(argv[optind + 1], NULL, 0);
+		joiner_timeout = (uint32_t)strtol(argv[optind + 2], NULL, 0);
+		psk = argv[optind + 3];
+
+		if (check_psk_arg) {
+			ret = check_psk_format(psk);
+			if (ret != 0) {
+				fprintf(stderr, "%s %s: error: Invalid PSKd\n", argv[0], cmd_str);
+				goto bail;
+			}
+		}
+
+		ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_JOINER_ADD);
+		require_action(ret == 0, bail, print_error_diagnosis(ret));
+
+		dbus_message_append_args(
+			message,
+			DBUS_TYPE_STRING, &psk,
+			DBUS_TYPE_UINT32, &joiner_timeout,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &eui64_ptr, sizeof(eui64),
+			DBUS_TYPE_BYTE, &discerner_bit_len,
+			DBUS_TYPE_UINT64, &discerner_value,
+			DBUS_TYPE_INVALID
+		);
+
+		snprintf(outcome_str, sizeof(outcome_str),
+			"Added Joiner with Discerner %" PRIu64 ", bit-len:%d, timeout:%d, PSKd:\"%s\"",
+			discerner_value, discerner_bit_len,joiner_timeout, psk);
+
+		break;
+	}
+
 	case COMMR_CMD_JOINER_REMOVE:
 	{
 		uint8_t eui64[COMMR_EUI64_SIZE];
@@ -411,6 +472,43 @@ tool_cmd_commr(int argc, char* argv[])
 				joiner_timeout
 			);
 		}
+
+		break;
+	}
+
+	case COMMR_CMD_JOINER_REMOVE_WITH_DISCERNER:
+	{
+		uint8_t eui64[COMMR_EUI64_SIZE];
+		uint8_t *eui64_ptr = eui64;
+		uint64_t discerner_value = 0;
+		uint8_t discerner_bit_len = 0;
+		uint32_t joiner_timeout = 0;
+
+		// joiner-remove-with-discerner <discerner value> <discerner bit length> [<timeout>=0]
+
+		memset(&eui64, 0, sizeof(eui64));
+
+		discerner_value = (uint64_t)strtoll(argv[optind], NULL, 0);
+		discerner_bit_len = (uint8_t)strtol(argv[optind + 1], NULL, 0);
+
+		if (optind + 2 < argc) {
+			joiner_timeout = (uint32_t)strtol(argv[optind + 2], NULL, 0);
+		}
+
+		ret = create_new_wpan_dbus_message(&message, WPANTUND_IF_CMD_JOINER_REMOVE);
+		require_action(ret == 0, bail, print_error_diagnosis(ret));
+
+		dbus_message_append_args(
+			message,
+			DBUS_TYPE_UINT32, &joiner_timeout,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &eui64_ptr, sizeof(eui64),
+			DBUS_TYPE_BYTE, &discerner_bit_len,
+			DBUS_TYPE_UINT64, &discerner_value,
+			DBUS_TYPE_INVALID
+		);
+		snprintf(outcome_str, sizeof(outcome_str),
+			"Removed Joiner with Discerner %" PRIu64 " bit-len:%d, timeout:%d",
+			discerner_value, discerner_bit_len, joiner_timeout);
 
 		break;
 	}

--- a/src/wpanctl/tool-cmd-joiner.c
+++ b/src/wpanctl/tool-cmd-joiner.c
@@ -66,7 +66,7 @@ int tool_cmd_joiner(int argc, char* argv[])
 	const char *vendor_model = NULL;
 	const char *vendor_sw_version = NULL;
 	const char *vendor_data = NULL;
-	const char *property_joiner_state = kWPANTUNDProperty_ThreadJoinerState;
+	const char *property_joiner_state = kWPANTUNDProperty_JoinerState;
 	dbus_bool_t returnOnStart = true;
 
 	dbus_error_init(&error);

--- a/src/wpantund/NCPConstants.h
+++ b/src/wpantund/NCPConstants.h
@@ -30,6 +30,7 @@
 
 #define NCP_NETWORK_KEY_SIZE                    16
 #define NCP_XPANID_SIZE                         8
+#define NCP_EUI64_SIZE                          8
 
 #define BUSY_DEBOUNCE_TIME_IN_MS                200
 #define MAX_INSOMNIA_TIME_IN_MS                 (MSEC_PER_SEC * 60 * 3)

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -96,6 +96,25 @@ public:
 
 	typedef std::set<PrefixFlag> OnMeshPrefixFlags;
 
+	struct JoinerInfo
+	{
+		enum Type
+		{
+			kAny,
+			kEui64,
+			kDiscerner,
+		};
+
+
+		Type    mType;
+		uint8_t mEui64[NCP_EUI64_SIZE];
+		struct Discerner
+		{
+			uint64_t mValue;
+			uint8_t  mBitLength;
+		}            mDiscerner;
+	};
+
 public:
 	// ========================================================================
 	// Static Functions
@@ -224,14 +243,14 @@ public:
 	) = 0;
 
 	virtual void commissioner_add_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		const char *psk,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;
 
 	virtual void commissioner_remove_joiner(
-		const uint8_t *eui64,
+		const JoinerInfo &joiner,
 		uint32_t timeout,
 		CallbackWithStatus cb = NilReturn()
 	) = 0;

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -226,7 +226,12 @@
 #define kWPANTUNDProperty_TmfProxyStream                        "TmfProxy:Stream"
 #define kWPANTUNDProperty_UdpForwardStream                      "UdpForward:Stream"
 
+#define kWPANTUNDProperty_JoinerState                           "Joiner:State"
+#define kWPANTUNDProperty_JoinerDiscernerValue                  "Joiner:Discerner:Value"
+#define kWPANTUNDProperty_JoinerDiscernerBitLength              "Joiner:Discerner:BitLength"
+
 #define kWPANTUNDProperty_CommissionerState                     "Commissioner:State"
+#define kWPANTUNDProperty_CommissionerJoiners                   "Commissioner:Joiners"
 #define kWPANTUNDProperty_CommissionerProvisioningUrl           "Commissioner:ProvisioningUrl"
 #define kWPANTUNDProperty_CommissionerSessionId                 "Commissioner:SessionId"
 #define kWPANTUNDProperty_CommissionerEnergyScanResult          "Commissioner:EnergyScanResult"
@@ -237,8 +242,6 @@
 #define kWPANTUNDCommissionerState_Disabled                     "disabled"
 #define kWPANTUNDCommissionerState_Petition                     "petition"
 #define kWPANTUNDCommissionerState_Active                       "active"
-
-#define kWPANTUNDProperty_ThreadJoinerState                     "Thread:Joiner:State"
 
 #define kWPANTUNDProperty_NCPCoexMetrics                        "NCP:CoexMetrics"
 #define kWPANTUNDProperty_NCPCoexMetricsAsValMap                "NCP:CoexMetrics:AsValMap"
@@ -381,7 +384,7 @@
 
 // ----------------------------------------------------------------------------
 
-// Values of the property kWPANTUNDProperty_ThreadJoinerState
+// Values of the property kWPANTUNDProperty_JoinerState
 
 #define kWPANTUNDThreadJoinerState_Idle                         "idle"
 #define kWPANTUNDThreadJoinerState_Discover                     "discover"
@@ -464,6 +467,8 @@
 #define kWPANTUNDValueMapKey_Joiner_VendorModel                 "Joiner:Vendor:Model"
 #define kWPANTUNDValueMapKey_Joiner_VendorSwVersion             "Joiner:Vendor:SwVersion"
 #define kWPANTUNDValueMapKey_Joiner_VendorData                  "Joiner:Vendor:Data"
+#define kWPANTUNDValueMapKey_Joiner_DiscernerValue              "Joiner:Discerner:Value"
+#define kWPANTUNDValueMapKey_Joiner_DiscernerBitLength          "Joiner:Discerner:BitLength"
 
 #define kWPANTUNDValueMapKey_Counter_TxTotal                    "TxTotal"              // Number of transmissions
 #define kWPANTUNDValueMapKey_Counter_TxUnicast                  "TxUnicast"            // Number of unicast transmissions

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1891,6 +1891,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "MESHCOP_COMMISSIONER_SESSION_ID";
         break;
 
+    case SPINEL_PROP_MESHCOP_JOINER_DISCERNER:
+        ret = "MESHCOP_JOINER_DISCERNER";
+        break;
+
     case SPINEL_PROP_MESHCOP_COMMISSIONER_ANNOUNCE_BEGIN:
         ret = "MESHCOP_COMMISSIONER_ANNOUNCE_BEGIN";
         break;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -3112,15 +3112,22 @@ enum
     SPINEL_PROP_MESHCOP_COMMISSIONER_STATE = SPINEL_PROP_MESHCOP__BEGIN + 2,
 
     // Thread Commissioner Joiners
-    /** Format `A(t(E)UL)` - insert or remove only
+    /** Format `A(t(t(E|CX)UL))` - get, insert or remove.
      *
      * Required capability: SPINEL_CAP_THREAD_COMMISSIONER
      *
-     * Data per item is:
+     * Data per arrat entry is:
      *
-     *  `t(E)` | `t()`: Joiner EUI64. Empty struct indicates any Joiner
-     *  `L`           : Timeout (in seconds) after which the Joiner is automatically removed
-     *  `U`           : PSKd
+     *  `t()` | `t(E)` | `t(CX)` : Joiner info struct (formatting varies).
+     *
+     *   -  `t()` or empty struct indicates any joiner.
+     *   -  `t(E)` specifies the Joiner EUI-64.
+     *   -  `t(CX) specifies Joiner Discerner, `C` is Discerner length (in bits), and `X` is Discerner value.
+     *
+     * The struct is followed by:
+     *
+     *  `L` : Timeout after which to remove Joiner (when written should be in seconds, when read is in milliseconds)
+     *  `U` : PSKd
      *
      * For CMD_PROP_VALUE_REMOVE the timeout and PSKd are optional.
      *
@@ -3142,6 +3149,32 @@ enum
      *
      */
     SPINEL_PROP_MESHCOP_COMMISSIONER_SESSION_ID = SPINEL_PROP_MESHCOP__BEGIN + 5,
+
+    /// Thread Joiner Discerner
+    /** Format `CX`  - Read-write
+     *
+     * Required capability: SPINEL_CAP_THREAD_JOINER
+     *
+     * This property represent a Joiner Discerner.
+     *
+     * The Joiner Discerner is used to calculate the Joiner ID used during commissioning/joining process.
+     *
+     * By default (when a discerner is not provided or cleared), Joiner ID is derived as first 64 bits of the result
+     * of computing SHA-256 over factory-assigned IEEE EUI-64. Note that this is the main behavior expected by Thread
+     * specification.
+     *
+     * Format:
+     *
+     *   'C' : The Joiner Discerner bit length (number of bits).
+     *   `X` : The Joiner Discerner value (64-bit unsigned)  - Only present/applicable when length is non-zero.
+     *
+     * When writing to this property, the length can be set to zero to clear any previously set Joiner Discerner value.
+     *
+     * When reading this property if there is no currently set Joiner Discerner, zero is returned as the length (with
+     * no value field).
+     *
+     */
+    SPINEL_PROP_MESHCOP_JOINER_DISCERNER = SPINEL_PROP_MESHCOP__BEGIN + 6,
 
     SPINEL_PROP_MESHCOP__END = 0x90,
 


### PR DESCRIPTION
This commit adds support for Joiner Discerner in `wpantund` and `wpanctl`.  The Joiner Discerner enables new a mechanism for Thread commissioning. The traditional Thread commissioning process uses factory assigned EUI-64 of the device to derive the Joiner ID and identify/filter a joiner (through steering data bloom filter). The Joiner Discerner (which is an unsigned value along with a user-specified bit length up to 64 bits) allows users to have more control and do not rely on factory-assigned EUI-64.

For support of Discerner for Joiner operation in `wpantund` two methods are provided: Support for two new wpan properties `Joiner:Discerner:Value` and `Joiner:Discerner:BitLength` are added. To set the Joiner Discerner on device, the bit-length must be set first followed by setting the value. Setting the bit-length to zero will clear any previously set Joiner Discerner on the NCP (i.e., device would go back to default behavior using the factory-assigned EUI-64). Alternatively, the discerner value can be specified as the value-map parameters (with same keys as wpan property names) passed along through a "Joiner Start" DBus API call.

For commissioner, the NCP Control Interface related APIs and the corresponding DBus APIs are updated to allow either an EUI-64 or a Joiner Discerner (or accepting any Joiner) to be provided. `wpanctl` `commissioner` command is also updated to allow the same.

-----
Related PR in openthread: https://github.com/openthread/openthread/pull/5137