### PR TITLE
[spinel] update domain prefix spinel property

### DIFF
--- a/src/ipc-dbus/DBusIPCAPI_v1.cpp
+++ b/src/ipc-dbus/DBusIPCAPI_v1.cpp
@@ -1241,6 +1241,8 @@ DBusIPCAPI_v1::interface_config_gateway_handler(
 	dbus_bool_t dhcp = FALSE;
 	dbus_bool_t configure = FALSE;
 	dbus_bool_t stable = TRUE;
+	dbus_bool_t nd_dns = FALSE;
+	dbus_bool_t domain_prefix = FALSE;
 	uint32_t preferred_lifetime = 0;
 	uint32_t valid_lifetime = 0;
 	uint8_t *prefix(NULL);
@@ -1267,8 +1269,29 @@ DBusIPCAPI_v1::interface_config_gateway_handler(
 		DBUS_TYPE_BOOLEAN, &configure,
 		DBUS_TYPE_BOOLEAN, &stable,
 		DBUS_TYPE_UINT16, &prefix_len_in_bits,
+		DBUS_TYPE_BOOLEAN, &nd_dns,
+		DBUS_TYPE_BOOLEAN, &domain_prefix,
 		DBUS_TYPE_INVALID
 	);
+
+	if (!did_succeed) {
+		did_succeed = dbus_message_get_args(
+			message, NULL,
+			DBUS_TYPE_BOOLEAN, &default_route,
+			DBUS_TYPE_ARRAY, DBUS_TYPE_BYTE, &prefix, &prefix_len_in_bytes,
+			DBUS_TYPE_UINT32, &preferred_lifetime,
+			DBUS_TYPE_UINT32, &valid_lifetime,
+			DBUS_TYPE_BOOLEAN, &preferred,
+			DBUS_TYPE_BOOLEAN, &slaac,
+			DBUS_TYPE_BOOLEAN, &on_mesh,
+			DBUS_TYPE_INT16, &priority_raw,
+			DBUS_TYPE_BOOLEAN, &dhcp,
+			DBUS_TYPE_BOOLEAN, &configure,
+			DBUS_TYPE_BOOLEAN, &stable,
+			DBUS_TYPE_UINT16, &prefix_len_in_bits,
+			DBUS_TYPE_INVALID
+		);
+	}
 
 	if (!did_succeed) {
 		did_succeed = dbus_message_get_args(
@@ -1346,6 +1369,14 @@ DBusIPCAPI_v1::interface_config_gateway_handler(
 
 	if (configure) {
 		flags.insert(NCPControlInterface::PREFIX_FLAG_CONFIGURE);
+	}
+
+	if (nd_dns) {
+		flags.insert(NCPControlInterface::PREFIX_FLAG_ND_DNS);
+	}
+
+	if (domain_prefix) {
+		flags.insert(NCPControlInterface::PREFIX_FLAG_DOMAIN_PREFIX);
 	}
 
 	dbus_message_ref(message);

--- a/src/ncp-dummy/DummyNCPInstance.cpp
+++ b/src/ncp-dummy/DummyNCPInstance.cpp
@@ -129,7 +129,7 @@ DummyNCPInstance::remove_service_on_ncp(uint32_t enterprise_number, const Data &
 }
 
 void
-DummyNCPInstance::add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags,
+DummyNCPInstance::add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint16_t flags,
 	bool stable, CallbackWithStatus cb)
 {
 	return;

--- a/src/ncp-dummy/DummyNCPInstance.h
+++ b/src/ncp-dummy/DummyNCPInstance.h
@@ -66,7 +66,7 @@ protected:
 
 	virtual void remove_service_on_ncp(uint32_t enterprise_number, const Data &service_data, CallbackWithStatus cb);
 
-	virtual void add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags, bool stable,
+	virtual void add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint16_t flags, bool stable,
 					CallbackWithStatus cb);
 	virtual void remove_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags, bool stable,
 					CallbackWithStatus cb);

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -4812,6 +4812,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is_ON_MESH_NETS(const uint8_t *value_
 		uint8_t prefix_len = 0;
 		bool stable = false;
 		uint8_t flags = 0;
+		uint8_t flags_extended = 0;
 		bool is_local = false;
 		uint16_t rloc16 = 0;
 
@@ -4825,13 +4826,15 @@ SpinelNCPInstance::handle_ncp_spinel_value_is_ON_MESH_NETS(const uint8_t *value_
 				SPINEL_DATATYPE_UINT8_S    // flags
 				SPINEL_DATATYPE_BOOL_S     // is_local
 				SPINEL_DATATYPE_UINT16_S   // RLOC16
+				SPINEL_DATATYPE_UINT8_S    // flags extended
 			),
 			&prefix_addr,
 			&prefix_len,
 			&stable,
 			&flags,
 			&is_local,
-			&rloc16
+			&rloc16,
+			&flags_extended
 		);
 
 		if (len <= 0) {
@@ -4846,7 +4849,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is_ON_MESH_NETS(const uint8_t *value_
 			prefix_len,
 			stable ? "yes" : "no",
 			is_local ? "yes" : "no",
-			on_mesh_prefix_flags_to_string(flags).c_str(),
+			on_mesh_prefix_flags_to_string((uint16_t)((flags_extended << 8) | flags)).c_str(),
 			rloc16
 		);
 
@@ -6320,7 +6323,7 @@ SpinelNCPInstance::remove_service_on_ncp(uint32_t enterprise_number, const Data&
 }
 
 void
-SpinelNCPInstance::add_on_mesh_prefix_on_ncp(const struct in6_addr &prefix, uint8_t prefix_len, uint8_t flags,
+SpinelNCPInstance::add_on_mesh_prefix_on_ncp(const struct in6_addr &prefix, uint8_t prefix_len, uint16_t flags,
 	bool stable, CallbackWithStatus cb)
 {
 	SpinelNCPTaskSendCommand::Factory factory(this);
@@ -6336,12 +6339,18 @@ SpinelNCPInstance::add_on_mesh_prefix_on_ncp(const struct in6_addr &prefix, uint
 			SPINEL_DATATYPE_UINT8_S
 			SPINEL_DATATYPE_BOOL_S
 			SPINEL_DATATYPE_UINT8_S
+			SPINEL_DATATYPE_BOOL_S
+			SPINEL_DATATYPE_UINT16_S
+			SPINEL_DATATYPE_UINT8_S
 		),
 		SPINEL_PROP_THREAD_ON_MESH_NETS,
 		&prefix,
 		prefix_len,
 		stable,
-		flags
+		flags & 0xff,
+		false,
+		0,
+		(flags >> 8) & 0xff
 	));
 
 	start_new_task(factory.finish());

--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -170,7 +170,7 @@ protected:
 
 	virtual void remove_service_on_ncp(uint32_t enterprise_number, const Data& service_data, CallbackWithStatus cb);
 
-	virtual void add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags, bool stable,
+	virtual void add_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint16_t flags, bool stable,
 					CallbackWithStatus cb);
 	virtual void remove_on_mesh_prefix_on_ncp(const struct in6_addr &addr, uint8_t prefix_len, uint8_t flags,
 					bool stable, CallbackWithStatus cb);

--- a/src/wpanctl/tool-cmd-add-prefix.c
+++ b/src/wpanctl/tool-cmd-add-prefix.c
@@ -46,6 +46,8 @@ static const arg_list_item_t add_prefix_option_list[] = {
 	{'c', "configure", NULL, "Set the prefix flag \"configure\""},
 	{'r', "default-route", NULL, "Set the prefix flag \"default-route\""},
 	{'o', "on-mesh", NULL, "Set the prefix flag \"on-mesh\""},
+	{'n', "nd-dns", NULL, "Set the prefix flag \"nd-dns\""},
+	{'D', "domain-prefix", NULL, "Set the prefix flag \"domain-prefix\""},
 	{0}
 };
 
@@ -69,6 +71,8 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 	dbus_bool_t configure = FALSE;
 	dbus_bool_t default_route = FALSE;
 	dbus_bool_t on_mesh = FALSE;
+	dbus_bool_t nd_dns = FALSE;
+	dbus_bool_t domain_prefix = FALSE;
 	uint8_t prefix_bytes[16] = {};
 	uint8_t *addr = prefix_bytes;
 	uint32_t preferred_lifetime = 0xFFFFFFFF;
@@ -89,13 +93,15 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 			{"configure", no_argument, 0, 'c'},
 			{"default-route", no_argument, 0, 'r'},
 			{"on-mesh", no_argument, 0, 'o'},
+			{"nd-dns", no_argument, 0, 'n'},
+			{"domain-prefix", no_argument, 0, 'D'},
 			{0, 0, 0, 0}
 		};
 
 		int c;
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "ht:P:l:sfadcro", long_options, &option_index);
+		c = getopt_long(argc, argv, "ht:P:l:sfadcronD", long_options, &option_index);
 
 		if (c == -1) {
 			break;
@@ -145,6 +151,14 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 
 		case 'o':
 			on_mesh = TRUE;
+			break;
+
+		case 'n':
+			nd_dns = TRUE;
+			break;
+
+		case 'D':
+			domain_prefix = TRUE;
 			break;
 		}
 	}
@@ -229,6 +243,8 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 		DBUS_TYPE_BOOLEAN, &configure,
 		DBUS_TYPE_BOOLEAN, &stable,
 		DBUS_TYPE_UINT16, &prefix_len_in_bits,
+		DBUS_TYPE_BOOLEAN, &nd_dns,
+		DBUS_TYPE_BOOLEAN, &domain_prefix,
 		DBUS_TYPE_INVALID
 	);
 
@@ -251,7 +267,7 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 		inet_ntop(AF_INET6, (const void *)&prefix_bytes, address_string, sizeof(address_string));
 		fprintf(
 			stderr,
-			"Successfully added prefix \"%s\" len:%d stable:%c [on-mesh:%c def-route:%c config:%c dhcp:%c slaac:%c pref:%c prio:%s]\n",
+			"Successfully added prefix \"%s\" len:%d stable:%c [on-mesh:%c def-route:%c config:%c dhcp:%c slaac:%c pref:%c nd-dns:%c dp:%c prio:%s]\n",
 			address_string,
 			prefix_len_in_bits,
 			stable ? '1' : '0',
@@ -261,6 +277,8 @@ int tool_cmd_add_prefix(int argc, char* argv[])
 			dhcp ? '1' : '0',
 			slaac ? '1' : '0',
 			preferred ? '1' : '0',
+			nd_dns ? '1' : '0',
+			domain_prefix ? '1' : '0',
 			priority > 0 ? "high" : (priority < 0 ? "low" : "med")
 		);
 

--- a/src/wpantund/NCPControlInterface.h
+++ b/src/wpantund/NCPControlInterface.h
@@ -92,6 +92,8 @@ public:
 		PREFIX_FLAG_CONFIGURE,
 		PREFIX_FLAG_DEFAULT_ROUTE,
 		PREFIX_FLAG_ON_MESH,
+		PREFIX_FLAG_DOMAIN_PREFIX,
+		PREFIX_FLAG_ND_DNS,
 	};
 
 	typedef std::set<PrefixFlag> OnMeshPrefixFlags;

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -2195,7 +2195,7 @@ enum
     SPINEL_PROP_THREAD_STABLE_NETWORK_DATA_VERSION = SPINEL_PROP_THREAD__BEGIN + 9,
 
     /// On-Mesh Prefixes
-    /** Format: `A(t(6CbCbS))`
+    /** Format: `A(t(6CbCbSC))`
      *
      * Data per item is:
      *
@@ -2206,8 +2206,11 @@ enum
      *  `b`: "Is defined locally" flag. Set if this network was locally
      *       defined. Assumed to be true for set, insert and replace. Clear if
      *       the on mesh network was defined by another node.
+     *       This field is ignored for INSERT and REMOVE commands.
      *  `S`: The RLOC16 of the device that registered this on-mesh prefix entry.
      *       This value is not used and ignored when adding an on-mesh prefix.
+     *       This field is ignored for INSERT and REMOVE commands.
+     *  `C`: TLV flags extended (additional field for Thread 1.2 features).
      *
      */
     SPINEL_PROP_THREAD_ON_MESH_NETS = SPINEL_PROP_THREAD__BEGIN + 10,


### PR DESCRIPTION
This PR update the wpantund domain prefix command with new Nd Dns and Domain Prefix flag.
The SPINEL_PROP_THREAD_ON_MESH_NETS property has been extended with new TLV flags field.