### PR TITLE
[spinel] add interface identifier of the Thread Domain Unicast Address

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.h
+++ b/src/ncp-spinel/SpinelNCPInstance.h
@@ -303,6 +303,7 @@ private:
 	static int convert_value_channel_mask(const boost::any &value, boost::any &value_out);
 	static int convert_value_counter_reset(const boost::any &value, boost::any &value_out);
 	static int convert_value_CommissionerState(const boost::any &value, boost::any &value_out);
+	static int convert_value_dua_interface_identifier(const boost::any &value, boost::any &value_out);
 
 	void set_prop_NetworkKey(const boost::any &value, CallbackWithStatus cb);
 	void set_prop_InterfaceUp(const boost::any &value, CallbackWithStatus cb);

--- a/src/wpantund/wpan-properties.h
+++ b/src/wpantund/wpan-properties.h
@@ -139,6 +139,7 @@
 #define kWPANTUNDProperty_ThreadParent                          "Thread:Parent"
 #define kWPANTUNDProperty_ThreadParentAsValMap                  "Thread:Parent:AsValMap"
 #define kWPANTUNDProperty_ThreadDomainName                      "Thread:DomainName"
+#define kWPANTUNDProperty_ThreadDUAInterfaceIdentifier          "Thread:DUA:InterfaceIdentifier"
 
 #define kWPANTUNDProperty_DatasetActiveTimestamp                "Dataset:ActiveTimestamp"
 #define kWPANTUNDProperty_DatasetPendingTimestamp               "Dataset:PendingTimestamp"

--- a/third_party/openthread/src/ncp/spinel.c
+++ b/third_party/openthread/src/ncp/spinel.c
@@ -1831,6 +1831,10 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         ret = "THREAD_DOMAIN_NAME";
         break;
 
+    case SPINEL_PROP_THREAD_DUA_ID:
+        ret = "THREAD_DUA_ID";
+        break;
+
     case SPINEL_PROP_MESHCOP_JOINER_STATE:
         ret = "MESHCOP_JOINER_STATE";
         break;
@@ -2689,6 +2693,10 @@ const char *spinel_capability_to_cstr(spinel_capability_t capability)
 
     case SPINEL_CAP_MULTI_RADIO:
         ret = "MULTI_RADIO";
+        break;
+
+    case SPINEL_CAP_DUA:
+        ret = "DUA";
         break;
 
     case SPINEL_CAP_ERROR_RATE_TRACKING:

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -1099,6 +1099,7 @@ enum
     SPINEL_CAP_RADIO_COEX              = (SPINEL_CAP_OPENTHREAD__BEGIN + 11),
     SPINEL_CAP_MAC_RETRY_HISTOGRAM     = (SPINEL_CAP_OPENTHREAD__BEGIN + 12),
     SPINEL_CAP_MULTI_RADIO             = (SPINEL_CAP_OPENTHREAD__BEGIN + 13),
+    SPINEL_CAP_DUA                     = (SPINEL_CAP_OPENTHREAD__BEGIN + 15),
     SPINEL_CAP_OPENTHREAD__END         = 640,
 
     SPINEL_CAP_THREAD__BEGIN        = 1024,
@@ -2835,6 +2836,21 @@ enum
      *
      */
     SPINEL_PROP_THREAD_DOMAIN_NAME = SPINEL_PROP_THREAD_EXT__BEGIN + 44,
+
+    /// Interface Identifier specified for Thread Domain Unicast Address.
+    /** Format: `A(C)` - Read-write
+     *
+     *   `A(C)`: Interface Identifier (8 bytes).
+     *
+     * Required capability: SPINEL_CAP_DUA
+     *
+     * If write to this property is performed without specified parameter
+     * the Interface Identifier of the Thread Domain Unicast Address will be cleared.
+     * If the DUA Interface Identifier is cleared on the NCP device,
+     * the get spinel property command will be returned successfully without specified parameter.
+     *
+     */
+    SPINEL_PROP_THREAD_DUA_ID = SPINEL_PROP_THREAD_EXT__BEGIN + 54,
 
     SPINEL_PROP_THREAD_EXT__END = 0x1600,
 


### PR DESCRIPTION
This commit add a  new spinel property to configure Interface Identifier of the Thread Domain Unicast Address.
OT PR: https://github.com/openthread/openthread/pull/6200