### PR TITLE
NCP(USB CDC ACM) hard reset support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,7 @@ NL_CHECK_BOOST_SIGNALS2([],AC_MSG_ERROR([Unable to find a usable implementation 
 NL_CHECK_BOOST_CHRONO([],AC_MSG_ERROR([Unable to find a usable implementation of boost::chrono (not even our internal copy)]))
 NL_CHECK_READLINE
 NL_CHECK_PTS
+NL_CHECK_UDEV
 
 AC_DEFINE_UNQUOTED([__STDC_LIMIT_MACROS], [1], [Needed by C++])
 AC_DEFINE_UNQUOTED([__STDC_CONSTANT_MACROS], [1], [Needed by C++])
@@ -357,6 +358,7 @@ echo "NCP plugins to build ........... ${building_ncp_plugins-none}"
 echo "Default NCP Plugin ............. ${default_ncp_plugin}"
 echo "Static link NCP plugin ......... ${enable_static_link_ncp_plugin-no}"
 echo "Fuzzing Targets ................ ${enable_fuzz_targets-no}"
+echo "Using udev.......................${with_udev-no}"
 echo ""
 
 if test "x${with_readline}" != "xyes"

--- a/m4/nl.m4
+++ b/m4/nl.m4
@@ -514,3 +514,16 @@ append-network-time-received-timestamp,
 )
 AM_CONDITIONAL([APPEND_NETWORK_TIME_RECEIVED_MONOTONIC_TIMESTAMP],[(case "${enable_append_network_time_received_timestamp}" in yes) true ;; *) false ;; esac)])
 ])
+
+AC_DEFUN([NL_CHECK_UDEV], [
+	AC_ARG_WITH([udev],
+		AS_HELP_STRING([--with-udev], [Use udev library for monitoring tty events. It's used for handling the connection after hard reset of NCP(USB CDC ACM)]))
+
+	AS_IF([test "x$with_udev" = "xyes"], [
+		AC_CHECK_LIB([udev], [udev_new])
+		AC_CHECK_HEADER([libudev.h])
+	])
+
+	AS_IF([test "x$ac_cv_lib_udev_udev_new" == "xno" || test "x$ac_cv_header_libudev_h" == "xno"],
+		[AC_MSG_ERROR([--with-udev was given, but test for udev failed])])
+])

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -33,6 +33,7 @@ install_packages_apt()
     sudo apt-get -y install bsdtar || die
     sudo apt-get -y install libtool || die
     sudo apt-get -y install libglib2.0-dev || die
+    sudo apt-get -y install libudev-dev || die
 }
 
 install_packages_opkg()

--- a/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-DataPump.cpp
@@ -538,6 +538,16 @@ SpinelNCPInstance::driver_to_ncp_pump()
 		mOutboundBufferSent += pt->byte_count;
 #endif
 
+#if HAVE_LIBUDEV
+		uint8_t header = 0;
+		unsigned int command = 0;
+		(void)spinel_datatype_unpack(mOutboundBuffer, mOutboundBufferLen, "CiD", &header,
+					     &command, NULL, 0);
+		if (command == SPINEL_CMD_RESET) {
+			hard_reset_ncp();
+		}
+#endif
+
 		mOutboundBufferLen = 0;
 
 		require(pt->last_errno == 0, on_error);

--- a/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance-Protothreads.cpp
@@ -394,7 +394,7 @@ SpinelNCPInstance::vprocess_init(int event, va_list args)
 			mDriverState = INITIALIZING_WAITING_FOR_RESET;
 
 			EH_REQUIRE_WITHIN(
-				NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT,
+				NCP_DEFAULT_RESET_RESPONSE_TIMEOUT,
 				event == EVENT_NCP_RESET,
 				on_error
 			);

--- a/src/util/SuperSocket.h
+++ b/src/util/SuperSocket.h
@@ -32,7 +32,10 @@ class SuperSocket : public UnixSocket {
 protected:
 	SuperSocket(const std::string& path);
 
-public:
+    private:
+	void waitForDevice();
+
+    public:
 	virtual ~SuperSocket();
 
 	static boost::shared_ptr<SocketWrapper> create(const std::string& path);

--- a/src/wpantund/NCPConstants.h
+++ b/src/wpantund/NCPConstants.h
@@ -37,4 +37,13 @@
 
 #define NCP_DEBUG_LINE_LENGTH_MAX               400
 
+#if HAVE_LIBUDEV
+#define NCP_RESET_TIMEOUT                       10 // seconds
+#else
+#define NCP_RESET_TIMEOUT                       0  // seconds
+#endif
+
+#define NCP_DEFAULT_RESET_RESPONSE_TIMEOUT                                                         \
+	NCP_DEFAULT_COMMAND_RESPONSE_TIMEOUT + NCP_RESET_TIMEOUT // seconds
+
 #endif


### PR DESCRIPTION
This commit handles the situation when NCP(USB CDC ACM) performs hard reset after receiving SPINEL_CMD_RESET.

When NCP is connected by USB CDC ACM and we reset it, the NCP device is reattached to the host operating system. So far for NCP(USB CDC ACM) pseudo reset has been performing meaning only specific parts of firmware were reset. It is error-prone solution for bare metal device and almost unreachable for devices working under RTOS. But what's most important it does not guarantee the clean init state of the NCP device. It's far easier and better to hard reset NCP and properly handle the USB connection on the host side.

It uses udev library to check if device enumeration has ended.

It works based on symlink to the NCP device created by udev in /dev/serial/by-id/ directory.