### PR TITLE
[doc] update INSTALL.md to use the latest master instead of full/latest-release

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,29 +30,18 @@ Open up a terminal and perform the following commands:
 
 ### 2. Configure and build the project ###
 
-If the `configure` script is not already present in the root directory
-of your `wpantund` sources (which it should be if you got these
-sources from a tarball), you will need to either grab one of the `full/*`
-tags from the official git repository or run the bootstrap script.
+#### 2.1. Running the bootstrap script  ####
 
-#### 2.1. Grabbing a full tag from Git ####
+Make sure that your repository is at `origin/master`.
 
-The most likely thing you want to build is the latest stable release.
-In that case, all you need to do is checkout the tag `full/latest-release`:
+    git checkout origin/master 
 
-    git checkout full/latest-release
-
-And you should then be ready to build configure. Jump to section 2.3.
-
-#### 2.2. Running the bootstrap script  ####
-
-Alternatively, you can *bootstrap* the project directly by doing the
-following:
+Then *bootstrap* the project by doing the following:
 
     sudo apt-get install libtool autoconf autoconf-archive
     ./bootstrap.sh
 
-#### 2.3. Running the configure script  ####
+#### 2.2. Running the configure script  ####
 
 If the `configure` script is present, run it and then start the make
 process:


### PR DESCRIPTION
As mentioned in https://github.com/openthread/wpantund/issues/494, the INSTALL.md is outdated. For now we need to build and install `wpantund` using the latest master branch instead of `full/latest-release`, otherwise the NCP logs won't be forwarded properly.