### PR TITLE
util/netif-mgmt: only include missing strlcpy header if actually missing

### DIFF
--- a/src/util/netif-mgmt.c
+++ b/src/util/netif-mgmt.c
@@ -69,7 +69,9 @@
 #define IFEF_NOAUTOIPV6LL   0x2000  /* Interface IPv6 LinkLocal address not provided by kernel */
 #endif
 
+#ifdef MISSING_STRLCPY
 #include "missing/strlcpy/strlcpy.h"
+#endif
 
 #ifndef SIOCSIFLLADDR
 #define SIOCSIFLLADDR SIOCSIFHWADDR


### PR DESCRIPTION
In commit 4e2ef143046a0c89afe6fd66acf5b7a7f35e8356 this header was
added unconditionally. For my system (Yocto with musl) this results in
strlcpy being redefined to __missing_strlcpy in all cases. No matter if
strlcpy is available or not.

Given it is available and the nl.m4 macros detects this, the libstrlcpy.la
helper is not build which results in:

netif-mgmt.c:386: more undefined references to `___missing_strlcpy' follow

Signed-off-by: Stefan Schmidt <stefan.schmidt@huawei.com>