### PR TITLE
[docs] community discussion change

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
 GitHub Issues are for bugs and feature requests. To make bugs and feature requests more easy to find and organize, we close issues that are deemed out of scope for GitHub Issues.
 
-The OpenThread GitHub Community Discussion is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://github.com/openthread/openthread/discussions
+OpenThread GitHub Community Discussion is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://github.com/openthread/openthread/discussions

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
 GitHub Issues are for bugs and feature requests. To make bugs and feature requests more easy to find and organize, we close issues that are deemed out of scope for GitHub Issues.
 
-The openthread-users Google Group is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://groups.google.com/forum/#!forum/openthread-users
+The OpenThread GitHub Community Discussion is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://github.com/openthread/openthread/discussions

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
 GitHub Issues are for bugs and feature requests. To make bugs and feature requests more easy to find and organize, we close issues that are deemed out of scope for GitHub Issues.
 
-OpenThread GitHub Community Discussion is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://github.com/openthread/openthread/discussions
+OpenThread GitHub Discussion is the recommended place for users to discuss OpenThread and interact directly with the OpenThread community. https://github.com/openthread/openthread/discussions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ avoid frustration later on.
 ### Code reviews ###
 
 All submissions, including submissions by project members, require
-review. We use Github pull requests for this purpose.
+review. We use GitHub pull requests for this purpose.
 
 ### The small print ###
 

--- a/doc/wpantund-oss-plan.md
+++ b/doc/wpantund-oss-plan.md
@@ -6,7 +6,7 @@ project.
 
 ## Online Resources ##
 
- *  Github: <https://github.com/openthread/wpantund/>
+ *  GitHub: <https://github.com/openthread/wpantund/>
      *  Public Wiki: <https://github.com/openthread/wpantund/wiki>
  *  Front-end URL: <http://wpantund.org>
      *  Will initially redirect to

--- a/third_party/openthread/README.md
+++ b/third_party/openthread/README.md
@@ -69,10 +69,8 @@ Please only use the OpenThread name and marks when accurately referencing this s
 
 # Need help?
 
-There are numerous avenues for OpenThread support:
+OpenThread support is available on GitHub:
 
-* Bugs and feature requests — [submit to the Issue Tracker](https://github.com/openthread/openthread/issues)
-* Stack Overflow — [post questions using the `openthread` tag](http://stackoverflow.com/questions/tagged/openthread)
-* Google Groups — [discussion and announcements at openthread-users](https://groups.google.com/forum/#!forum/openthread-users)
-
-The openthread-users Google Group is the recommended place for users to discuss OpenThread and interact directly with the OpenThread team.
+- wpantund bugs and feature requests — [submit to the openthread/wpantund Issue Tracker](https://github.com/openthread/wpantund/issues)
+- OpenThread bugs and feature requests — [submit to the OpenThread Issue Tracker](https://github.com/openthread/openthread/issues)
+- Community Discussion - [ask questions, share ideas, and engage with other community members](https://github.com/openthread/openthread/discussions)


### PR DESCRIPTION
Replace link to openthread-users Google Group with link to GitHub OpenThread Discussions, clarify issue reporting links, and correct capitalization of 'GitHub'.