### PR TITLE
[spinel] handle new spinel net role DISABLED

### DIFF
--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -5767,6 +5767,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 
 			if (ncp_state_is_joining_or_joined(get_ncp_state())
 			  && (value != SPINEL_NET_ROLE_DETACHED)
+                          && (value != SPINEL_NET_ROLE_DISABLED)
 			) {
 				change_ncp_state(ASSOCIATED);
 			}
@@ -5784,7 +5785,7 @@ SpinelNCPInstance::handle_ncp_spinel_value_is(spinel_prop_key_t key, const uint8
 			} else if (value == SPINEL_NET_ROLE_LEADER) {
 				update_node_type(LEADER);
 
-			} else if (value == SPINEL_NET_ROLE_DETACHED) {
+                        } else if (value == SPINEL_NET_ROLE_DETACHED || value == SPINEL_NET_ROLE_DISABLED) {
 				update_node_type(UNKNOWN);
 				if (ncp_state_is_associated(get_ncp_state())) {
 					change_ncp_state(ISOLATED);

--- a/third_party/openthread/src/ncp/spinel.h
+++ b/third_party/openthread/src/ncp/spinel.h
@@ -504,6 +504,7 @@ typedef enum
     SPINEL_NET_ROLE_CHILD    = 1,
     SPINEL_NET_ROLE_ROUTER   = 2,
     SPINEL_NET_ROLE_LEADER   = 3,
+    SPINEL_NET_ROLE_DISABLED = 4,
 } spinel_net_role_t;
 
 typedef enum
@@ -2090,6 +2091,7 @@ enum
      *  SPINEL_NET_ROLE_CHILD    = 1,
      *  SPINEL_NET_ROLE_ROUTER   = 2,
      *  SPINEL_NET_ROLE_LEADER   = 3,
+     *  SPINEL_NET_ROLE_DISABLED = 4,
      *
      */
     SPINEL_PROP_NET_ROLE = SPINEL_PROP_NET__BEGIN + 3,


### PR DESCRIPTION
Following https://github.com/openthread/openthread/pull/9731, this PR
adds handling of the newly added role 'SPINEL_NET_ROLE_DISABLED'.